### PR TITLE
Creating trip creation screen with inputs

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/CreateTripTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/CreateTripTest.kt
@@ -1,0 +1,167 @@
+package com.github.se.wanderpals
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.wanderpals.model.data.Trip
+import com.github.se.wanderpals.model.repository.TripsRepository
+import com.github.se.wanderpals.model.viewmodel.CreateTripViewModel
+import com.github.se.wanderpals.screens.CreateTripoScreen
+import com.github.se.wanderpals.ui.navigation.NavigationActions
+import com.github.se.wanderpals.ui.navigation.Route
+import com.github.se.wanderpals.ui.screens.CreateTrip
+import com.kaspersky.components.composesupport.config.withComposeSupport
+import com.kaspersky.kaspresso.kaspresso.Kaspresso
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.Called
+import io.mockk.confirmVerified
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit4.MockKRule
+import io.mockk.verify
+import java.time.LocalDate
+import kotlinx.coroutines.Dispatchers
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private val testTrip =
+    Trip(
+        "",
+        "My trip",
+        LocalDate.of(2024, 3, 5),
+        LocalDate.of(2024, 3, 10),
+        500.0,
+        "My description",
+        "",
+        emptyList(),
+        emptyList(),
+        emptyList())
+
+open class CreateTripViewModelTest(tripsRepository: TripsRepository) :
+    CreateTripViewModel(tripsRepository) {
+  override fun createTrip(trip: Trip) {
+    assert(trip == testTrip)
+  }
+}
+
+@RunWith(AndroidJUnit4::class)
+class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @get:Rule val mockkRule = MockKRule(this)
+
+  @RelaxedMockK lateinit var mockNavActions: NavigationActions
+
+  @Before
+  fun testSetup() {
+    val vm = CreateTripViewModelTest(TripsRepository("testUser123", Dispatchers.IO))
+    composeTestRule.setContent { CreateTrip(vm, mockNavActions) }
+  }
+
+  @Test
+  fun goBackButtonTriggersBackNavigation() = run {
+    ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
+      goBackButton {
+        assertIsDisplayed()
+        assertIsEnabled()
+        performClick()
+      }
+    }
+
+    verify { mockNavActions.navigateTo(Route.OVERVIEW) }
+    confirmVerified(mockNavActions)
+  }
+
+  @Test
+  fun saveTripDoesNotWorkWithEmptyTitle() = run {
+    ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
+      step("Open trip screen") {
+        inputTitle {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Title")
+          assertTextContains("Name the trip")
+
+          performTextClearance()
+        }
+
+        saveButton {
+          assertIsDisplayed()
+          performClick()
+        }
+
+        verify { mockNavActions wasNot Called }
+        confirmVerified(mockNavActions)
+      }
+    }
+  }
+
+  @Test
+  fun saveTripWorks() = run {
+    ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
+      step("Open trip screen") {
+        inputTitle {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Title")
+          assertTextContains("Name the trip")
+
+          performTextClearance()
+          performTextInput("My trip")
+        }
+
+        inputBudget {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Budget")
+          assertTextContains("Enter the total budget")
+
+          performTextClearance()
+          performTextInput("500")
+        }
+
+        inputDescription {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Describe")
+          assertTextContains("Describe the trip")
+
+          performTextClearance()
+          performTextInput("My description")
+        }
+
+        inputStartDate {
+          assertIsDisplayed()
+
+          assertTextContains("dd/mm/yyyy")
+          performTextClearance()
+
+          performTextInput("05/03/2024")
+        }
+
+        inputEndDate {
+          assertIsDisplayed()
+
+          assertTextContains("dd/mm/yyyy")
+          performTextClearance()
+
+          performTextInput("10/03/2024")
+        }
+
+        saveButton {
+          assertIsDisplayed()
+          performClick()
+        }
+
+        verify { mockNavActions.navigateTo(Route.OVERVIEW) }
+        confirmVerified(mockNavActions)
+      }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/se/wanderpals/CreateTripTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/CreateTripTest.kt
@@ -88,6 +88,300 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
           performTextClearance()
         }
 
+        inputBudget {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Budget")
+
+          performTextClearance()
+          performTextInput("500")
+        }
+
+        inputDescription {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Describe")
+          assertTextContains("Describe the trip")
+
+          performTextClearance()
+          performTextInput("My description")
+        }
+
+        inputStartDate {
+          assertIsDisplayed()
+
+          assertTextContains("dd/mm/yyyy")
+
+          performTextClearance()
+          performTextInput("05/03/2024")
+        }
+
+        inputEndDate {
+          assertIsDisplayed()
+
+          assertTextContains("dd/mm/yyyy")
+
+          performTextClearance()
+          performTextInput("10/03/2024")
+        }
+
+        saveButton {
+          assertIsDisplayed()
+          performClick()
+        }
+
+        verify { mockNavActions wasNot Called }
+        confirmVerified(mockNavActions)
+      }
+    }
+  }
+
+  @Test
+  fun saveTripDoesNotWorkWithEmptyDescription() = run {
+    ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
+      step("Open trip screen") {
+        inputTitle {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Title")
+          assertTextContains("Name the trip")
+
+          performTextClearance()
+          performTextInput("My trip")
+        }
+
+        inputBudget {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Budget")
+
+          performTextClearance()
+          performTextInput("500")
+        }
+
+        inputDescription {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Describe")
+          assertTextContains("Describe the trip")
+
+          performTextClearance()
+        }
+
+        inputStartDate {
+          assertIsDisplayed()
+
+          assertTextContains("dd/mm/yyyy")
+
+          performTextClearance()
+          performTextInput("05/03/2024")
+        }
+
+        inputEndDate {
+          assertIsDisplayed()
+
+          assertTextContains("dd/mm/yyyy")
+
+          performTextClearance()
+          performTextInput("10/03/2024")
+        }
+
+        saveButton {
+          assertIsDisplayed()
+          performClick()
+        }
+
+        verify { mockNavActions wasNot Called }
+        confirmVerified(mockNavActions)
+      }
+    }
+  }
+
+  fun saveTripDoesNotWorkWithEmptyDates() = run {
+    ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
+      step("Open trip screen") {
+        inputTitle {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Title")
+          assertTextContains("Name the trip")
+
+          performTextClearance()
+          performTextInput("My trip")
+        }
+
+        inputBudget {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Budget")
+
+          performTextClearance()
+          performTextInput("500")
+        }
+
+        inputDescription {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Describe")
+          assertTextContains("Describe the trip")
+
+          performTextClearance()
+          performTextInput("My description")
+        }
+
+        inputStartDate {
+          assertIsDisplayed()
+
+          assertTextContains("dd/mm/yyyy")
+
+          performTextClearance()
+        }
+
+        inputEndDate {
+          assertIsDisplayed()
+
+          assertTextContains("dd/mm/yyyy")
+
+          performTextClearance()
+        }
+
+        saveButton {
+          assertIsDisplayed()
+          performClick()
+        }
+
+        verify { mockNavActions wasNot Called }
+        confirmVerified(mockNavActions)
+      }
+    }
+  }
+
+  fun saveTripDoesNotWorkWithNotLogicalDates() = run {
+    ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
+      step("Open trip screen") {
+        inputTitle {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Title")
+          assertTextContains("Name the trip")
+
+          performTextClearance()
+          performTextInput("My trip")
+        }
+
+        inputBudget {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Budget")
+
+          performTextClearance()
+          performTextInput("500")
+        }
+
+        inputDescription {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Describe")
+          assertTextContains("Describe the trip")
+
+          performTextClearance()
+          performTextInput("My description")
+        }
+
+        inputStartDate {
+          assertIsDisplayed()
+
+          assertTextContains("dd/mm/yyyy")
+
+          performTextClearance()
+          performTextInput("10/03/2024")
+        }
+
+        inputEndDate {
+          assertIsDisplayed()
+
+          assertTextContains("dd/mm/yyyy")
+
+          performTextClearance()
+          performTextInput("05/03/2024")
+        }
+
+        saveButton {
+          assertIsDisplayed()
+          performClick()
+        }
+
+        verify { mockNavActions wasNot Called }
+        confirmVerified(mockNavActions)
+      }
+    }
+  }
+
+  @Test
+  fun saveDoesNotWorkWithNegativeBudget() = run {
+    ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
+      step("Open trip screen") {
+        inputTitle {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Title")
+          assertTextContains("Name the trip")
+
+          performTextClearance()
+          performTextInput("My trip")
+        }
+
+        inputBudget {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Budget")
+
+          performTextClearance()
+          performTextInput("-500")
+        }
+
+        inputDescription {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Describe")
+          assertTextContains("Describe the trip")
+
+          performTextClearance()
+          performTextInput("My description")
+        }
+
+        inputStartDate {
+          assertIsDisplayed()
+
+          assertTextContains("dd/mm/yyyy")
+
+          performTextClearance()
+          performTextInput("05/03/2024")
+        }
+
+        inputEndDate {
+          assertIsDisplayed()
+
+          assertTextContains("dd/mm/yyyy")
+
+          performTextClearance()
+          performTextInput("10/03/2024")
+        }
+
         saveButton {
           assertIsDisplayed()
           performClick()
@@ -119,7 +413,6 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
           performClick()
 
           assertTextContains("Budget")
-          assertTextContains("Enter the total budget")
 
           performTextClearance()
           performTextInput("500")

--- a/app/src/androidTest/java/com/github/se/wanderpals/screens/CreateTripScreen.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/screens/CreateTripScreen.kt
@@ -1,0 +1,22 @@
+package com.github.se.wanderpals.screens
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+class CreateTripoScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<CreateTripoScreen>(
+        semanticsProvider = semanticsProvider,
+        viewBuilderAction = { hasTestTag("createTripScreen") }) {
+
+  val screenTitle: KNode = onNode { hasTestTag("createTripTitle") }
+
+  val goBackButton: KNode = onNode { hasTestTag("goBackButton") }
+  val saveButton: KNode = onNode { hasTestTag("tripSave") }
+
+  val inputTitle: KNode = onNode { hasTestTag("inputTripTitle") }
+  val inputBudget: KNode = onNode { hasTestTag("inputTripBudget") }
+  val inputStartDate: KNode = onNode { hasTestTag("inputTripStartDate") }
+  val inputEndDate: KNode = onNode { hasTestTag("inputTripEndDate") }
+  val inputDescription: KNode = onNode { hasTestTag("inputTripDescription") }
+}

--- a/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
+++ b/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
@@ -13,28 +13,40 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.github.se.wanderpals.model.repository.TripsRepository
+import com.github.se.wanderpals.model.viewmodel.CreateTripViewModel
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
+import com.github.se.wanderpals.ui.screens.CreateTrip
 import com.github.se.wanderpals.ui.screens.Greeting
 import com.github.se.wanderpals.ui.screens.SignIn
 import com.github.se.wanderpals.ui.screens.trip.Trip
 import com.github.se.wanderpals.ui.theme.WanderPalsTheme
 import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import kotlinx.coroutines.Dispatchers
 
 class MainActivity : ComponentActivity() {
   private lateinit var signInClient: GoogleSignInClient
+
+  private lateinit var account: GoogleSignInAccount
 
   private lateinit var navController: NavHostController
 
   private lateinit var navigationActions: NavigationActions
 
+  private lateinit var tripsRepository: TripsRepository
+
   private val launcher =
       registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
-        val account = task.result
-        Log.d("SignIn", "Login result " + account?.displayName)
+        account = task.result
+        val uid = account.id ?: ""
+        tripsRepository = TripsRepository(uid, Dispatchers.IO)
+        tripsRepository.initFirestore()
+        Log.d("SignIn", "Login result " + account.displayName)
         navigationActions.navigateTo(Route.OVERVIEW)
         signInClient.signOut()
       }
@@ -63,6 +75,9 @@ class MainActivity : ComponentActivity() {
             }
             composable(Route.OVERVIEW) { Greeting("Android") }
             composable(Route.TRIP) { Trip(navigationActions) }
+            composable(Route.CREATE_TRIP) {
+              CreateTrip(CreateTripViewModel(tripsRepository), navigationActions)
+            }
           }
         }
       }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/CreateTripViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/CreateTripViewModel.kt
@@ -1,0 +1,16 @@
+package com.github.se.wanderpals.model.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.se.wanderpals.model.data.Trip
+import com.github.se.wanderpals.model.repository.TripsRepository
+import kotlinx.coroutines.launch
+
+open class CreateTripViewModel(tripsRepository: TripsRepository) : ViewModel() {
+
+  private val _tripsRepository = tripsRepository
+
+  open fun createTrip(trip: Trip) {
+    viewModelScope.launch { _tripsRepository.addTrip(trip) }
+  }
+}

--- a/app/src/main/java/com/github/se/wanderpals/ui/navigation/Route.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/navigation/Route.kt
@@ -2,6 +2,7 @@ package com.github.se.wanderpals.ui.navigation
 
 /** Object defining the routes in the app. */
 object Route {
+  const val CREATE_TRIP = "create_trip"
   const val NOTIFICATION = "notif"
   const val DASHBOARD = "dashboard"
   const val AGENDA = "agenda"

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/CreateTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/CreateTrip.kt
@@ -1,0 +1,278 @@
+package com.github.se.wanderpals.ui.screens
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.github.se.wanderpals.model.data.Trip
+import com.github.se.wanderpals.model.viewmodel.CreateTripViewModel
+import com.github.se.wanderpals.ui.navigation.NavigationActions
+import com.github.se.wanderpals.ui.navigation.Route
+import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.util.Date
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+/**
+ * Custom interaction source for date picker.
+ *
+ * Needed because the OutlinedTextField does not have a click functionality that works
+ * while being enabled (so testable)
+ *
+ * @param onClick action to be executed when the date picker is clicked
+ */
+class DateInteractionSource(val onClick: () -> Unit) : MutableInteractionSource {
+
+  override val interactions =
+      MutableSharedFlow<Interaction>(
+          extraBufferCapacity = 16,
+          onBufferOverflow = BufferOverflow.DROP_OLDEST,
+      )
+
+  override suspend fun emit(interaction: Interaction) {
+    if (interaction is PressInteraction.Release) {
+      onClick()
+    }
+
+    interactions.emit(interaction)
+  }
+
+  override fun tryEmit(interaction: Interaction): Boolean {
+    return interactions.tryEmit(interaction)
+  }
+}
+
+/**
+ * Screen for creating a new trip.
+ *
+ * The user can input the title, budget, description, start date, and end date of the trip.
+ * The dates are selected using a date picker dialog present in another function
+ *
+ * @param tripViewModel view model for creating a trip
+ * @param nav navigation actions
+ */
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun CreateTrip(tripViewModel: CreateTripViewModel, nav: NavigationActions) {
+  var name by remember { mutableStateOf("") }
+  var budget by remember { mutableStateOf("") }
+  var startDate by remember { mutableStateOf("") }
+  var endDate by remember { mutableStateOf("") }
+  var description by remember { mutableStateOf("") }
+
+  var errorText by remember { mutableStateOf("") }
+  var showDatePickerStart by remember { mutableStateOf(false) }
+  var showDatePickerEnd by remember { mutableStateOf(false) }
+
+  Scaffold(
+      modifier = Modifier.testTag("createTripScreen"),
+      topBar = {
+        Row {
+          OutlinedButton(
+              modifier = Modifier.testTag("goBackButton").padding(16.dp),
+              onClick = { nav.navigateTo(Route.OVERVIEW) }) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                    contentDescription = "Back",
+                )
+              }
+
+          Text(
+              text = "Create a new Trip",
+              modifier = Modifier.testTag("createTripTitle").padding(28.dp))
+        }
+      },
+      content = {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              OutlinedTextField(
+                  value = name,
+                  onValueChange = { name = it },
+                  label = { Text("Title") },
+                  modifier =
+                      Modifier.testTag("inputTripTitle").fillMaxWidth().padding(bottom = 16.dp),
+                  isError = errorText.isNotEmpty(),
+                  singleLine = true,
+                  placeholder = { Text("Name the trip") })
+              OutlinedTextField(
+                  value = budget,
+                  onValueChange = { budget = it },
+                  keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                  label = { Text("Budget") },
+                  modifier =
+                      Modifier.testTag("inputTripBudget").fillMaxWidth().padding(bottom = 16.dp),
+                  isError = errorText.isNotEmpty(),
+                  singleLine = true,
+                  placeholder = { Text("Enter the total budget") })
+              OutlinedTextField(
+                  value = description,
+                  onValueChange = { description = it },
+                  label = { Text("Describe") },
+                  modifier =
+                      Modifier.testTag("inputTripDescription")
+                          .fillMaxWidth()
+                          .height(200.dp)
+                          .padding(bottom = 16.dp),
+                  isError = errorText.isNotEmpty(),
+                  singleLine = true,
+                  placeholder = { Text("Describe the trip") })
+
+              Row(horizontalArrangement = Arrangement.SpaceEvenly) {
+                OutlinedTextField(
+                    value = startDate,
+                    onValueChange = { startDate = it },
+                    placeholder = { Text("dd/mm/yyyy") },
+                    modifier =
+                        Modifier.size(150.dp, 50.dp)
+                            .padding(end = 16.dp)
+                            .testTag("inputTripStartDate")
+                            .clickable { showDatePickerStart = true },
+                    isError = errorText.isNotEmpty(),
+                    singleLine = true,
+                    interactionSource = DateInteractionSource { showDatePickerStart = true })
+                OutlinedTextField(
+                    value = endDate,
+                    onValueChange = { endDate = it },
+                    placeholder = { Text("dd/mm/yyyy") },
+                    modifier = Modifier.size(150.dp, 50.dp).testTag("inputTripEndDate"),
+                    isError = errorText.isNotEmpty(),
+                    singleLine = true,
+                    interactionSource = DateInteractionSource { showDatePickerEnd = true })
+              }
+              if (showDatePickerStart) {
+                MyDatePickerDialog(
+                    onDateSelected = { startDate = it },
+                    onDismiss = { showDatePickerStart = false })
+              }
+
+              if (showDatePickerEnd) {
+                MyDatePickerDialog(
+                    onDateSelected = { endDate = it }, onDismiss = { showDatePickerEnd = false })
+              }
+
+              Text(
+                  text = errorText,
+                  color = Color.Red,
+              )
+
+              Button(
+                  modifier = Modifier.testTag("tripSave").fillMaxWidth().padding(16.dp),
+                  onClick = {
+                    val boolVar =
+                        name.isBlank() ||
+                            description.isBlank() ||
+                            startDate.isBlank() ||
+                            endDate.isBlank()
+                    errorText =
+                        if (boolVar) {
+                          "Input field cannot be empty!"
+                        } else {
+                          ""
+                        }
+                    if (!boolVar) {
+                      val trip =
+                          Trip(
+                              tripId = "",
+                              title = name,
+                              startDate =
+                                  LocalDate.of(
+                                      startDate.split("/")[2].toInt(),
+                                      startDate.split("/")[1].toInt(),
+                                      startDate.split("/")[0].toInt()),
+                              endDate =
+                                  LocalDate.of(
+                                      endDate.split("/")[2].toInt(),
+                                      endDate.split("/")[1].toInt(),
+                                      endDate.split("/")[0].toInt()),
+                              totalBudget = budget.toDouble(),
+                              description = description,
+                              imageUrl = "",
+                              stops = emptyList(),
+                              users = emptyList(),
+                              suggestions = emptyList())
+                      tripViewModel.createTrip(trip)
+                      nav.navigateTo(Route.OVERVIEW)
+                    }
+                  },
+              ) {
+                Text("Save")
+              }
+            }
+      })
+}
+
+/**
+ * Date picker dialog for selecting a date.
+ *
+ * @param onDateSelected action to be executed when a date is selected
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MyDatePickerDialog(onDateSelected: (String) -> Unit, onDismiss: () -> Unit) {
+  val datePickerState = rememberDatePickerState()
+
+  val selectedDate = datePickerState.selectedDateMillis?.let { convertMillisToDate(it) } ?: ""
+
+  DatePickerDialog(
+      onDismissRequest = { onDismiss() },
+      confirmButton = {
+        Button(
+            onClick = {
+              onDateSelected(selectedDate)
+              onDismiss()
+            }) {
+              Text(text = "OK")
+            }
+      },
+      dismissButton = { Button(onClick = { onDismiss() }) { Text(text = "Cancel") } }) {
+        DatePicker(state = datePickerState, modifier = Modifier.testTag("datePicker"))
+      }
+}
+
+/**
+ * Converts milliseconds to a date string.
+ *
+ * @param millis milliseconds to convert
+ * @return date string in the format "dd/MM/yyyy"
+ */
+@SuppressLint("SimpleDateFormat")
+private fun convertMillisToDate(millis: Long): String {
+  val formatter = SimpleDateFormat("dd/MM/yyyy")
+  return formatter.format(Date(millis))
+}

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/CreateTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/CreateTrip.kt
@@ -50,8 +50,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 /**
  * Custom interaction source for date picker.
  *
- * Needed because the OutlinedTextField does not have a click functionality that works
- * while being enabled (so testable)
+ * Needed because the OutlinedTextField does not have a click functionality that works while being
+ * enabled (so testable)
  *
  * @param onClick action to be executed when the date picker is clicked
  */
@@ -79,8 +79,8 @@ class DateInteractionSource(val onClick: () -> Unit) : MutableInteractionSource 
 /**
  * Screen for creating a new trip.
  *
- * The user can input the title, budget, description, start date, and end date of the trip.
- * The dates are selected using a date picker dialog present in another function
+ * The user can input the title, budget, description, start date, and end date of the trip. The
+ * dates are selected using a date picker dialog present in another function
  *
  * @param tripViewModel view model for creating a trip
  * @param nav navigation actions


### PR DESCRIPTION
I've created a simple Trip Creation Screen with the associated view model linked to the TripRepository for firebase access. 

It's missing the functionality of inviting friends because there is some challenges with the fact that the databases stores for now only ids that are hard to get for other users when you are a user. Inviting users by giving them the trip id to enter in the overview is one possible solution that is being discussed but if the team decides that the functionality of inviting should be present in this screen, I will add it in a futur release