### PR TITLE
Trip repository stops methods

### DIFF
--- a/app/src/main/java/com/github/se/wanderpals/model/firestoreData/FirestoreStop.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/firestoreData/FirestoreStop.kt
@@ -32,7 +32,7 @@ data class FirestoreStop(
     val duration: Int = 0, // Duration in minutes
     val budget: Double = 0.0,
     val description: String = "",
-    val geoCords: GeoCords, // Assuming GeoCords is Firestore compatible
+    val geoCords: GeoCords = GeoCords(0.0, 0.0), // Assuming GeoCords is Firestore compatible
     val website: String = "",
     val imageUrl: String = ""
 ) {

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/FirebaseCollections.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/FirebaseCollections.kt
@@ -2,5 +2,6 @@ package com.github.se.wanderpals.model.repository
 
 enum class FirebaseCollections(val path: String) {
   TRIPS("Trips"),
-  USERS_TO_TRIPS_IDS("UsersToTripIds")
+  USERS_TO_TRIPS_IDS("UsersToTripIds"),
+  STOPS_SUBCOLLECTION("Stops"),
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -70,7 +70,13 @@ class TripsRepository(
                   .document(stopId)
                   .get()
                   .await()
-          documentSnapshot.toObject<FirestoreStop>()?.toStop()
+          val firestoreStop = documentSnapshot.toObject<FirestoreStop>()
+          if (firestoreStop != null) {
+            firestoreStop.toStop()
+          } else {
+            Log.e("TripsRepository", "getStopFromTrip: Not found stop $stopId from trip $tripId.")
+            null
+          }
         } catch (e: Exception) {
           Log.e(
               "TripsRepository",

--- a/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
@@ -2,6 +2,8 @@ package com.github.se.wanderpals.repository
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.github.se.wanderpals.model.data.GeoCords
+import com.github.se.wanderpals.model.data.Stop
 import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.google.firebase.FirebaseApp
@@ -18,6 +20,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.time.LocalTime
 
 @RunWith(RobolectricTestRunner::class)
 class TripsRepositoryTest {
@@ -146,6 +149,61 @@ class TripsRepositoryTest {
     }
     println("testAddAndGetAndRemoveAndModifyAndGetAllTrip execution time: $elapsedTime ms")
   }
+
+    @Test
+    fun testAddModifyDeleteGetGetAllStopsInTrips() = runBlocking {
+        val trip =
+            Trip(
+                tripId = "trip123",
+                title = "Summer Vacation",
+                startDate = LocalDate.of(2024, 5, 20), // Assuming format is YYYY, MM, DD
+                endDate = LocalDate.of(2024, 6, 10),
+                totalBudget = 2000.0,
+                description = "Our summer vacation trip to Italy.",
+                imageUrl = "https://example.com/image.png",
+                stops = emptyList(),
+                users = emptyList(),
+                suggestions = emptyList())
+
+        val stop = Stop(
+            stopId = "", // Will be set by addStopToTrip method
+            title = "Colosseum",
+            address = "Piazza del Colosseo, 1, 00184 Roma RM, Italy",
+            date = LocalDate.of(2024, 5, 21),
+            startTime = LocalTime.of(10, 0),
+            duration = 120, // Example: 2 hours in minutes
+            budget = 0.0, // Assume free entry for simplicity
+            description = "Visit the ancient Roman gladiatorial arena.",
+            geoCords = GeoCords(41.8902, 12.4922), // Placeholder coordinates
+            website = "https://example.com/colosseum",
+            imageUrl = "https://example.com/colosseum.png")
+
+        val elapsedTime = measureTimeMillis {
+            try {
+                withTimeout(10000) {
+                    // Add the trip (assuming addTrip method exists and works correctly)
+                    //assertTrue(repository.addTrip(trip))
+
+                    // Add a stop to the trip
+
+                    assertTrue(repository.addStopToTrip("6446f69b-5610-4338-9643-e873d87dadaa", stop))
+                }
+
+                withTimeout(10000) {
+
+                }
+
+                withTimeout(10000) {
+
+                }
+            } catch (e: TimeoutCancellationException) {
+                // If a timeout occurs, fail the test
+                fail("The operation timed out after 10 seconds")
+            }
+        }
+        println("testAddAndGetAndRemoveAndModifyAndGetAllTrip execution time: $elapsedTime ms")
+    }
+
 
   @After
   fun tearDown() = runBlocking {

--- a/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
@@ -194,18 +194,22 @@ class TripsRepositoryTest {
           assertTrue(repository.addStopToTrip(tripId, colosseumStop))
 
           val fetchedTrip = repository.getTrip(tripId)
+          assertTrue(fetchedTrip != null)
           if (fetchedTrip != null) {
             val stopId = fetchedTrip.stops[0]
 
             // Fetch and validate the stop's details.
             val fetchedStop = repository.getStopFromTrip(fetchedTrip.tripId, stopId)
+            assertTrue(fetchedStop != null)
             if (fetchedStop != null) {
+
               assertTrue(fetchedStop.description == colosseumStop.description)
 
               // Update the stop's description, validate the update.
               repository.updateStopInTrip(
                   fetchedTrip.tripId, fetchedStop.copy(description = "NEW DESCRIPTION"))
               val updatedStop = repository.getStopFromTrip(fetchedTrip.tripId, stopId)
+              assertTrue(updatedStop != null)
               if (updatedStop != null) {
                 assertTrue(updatedStop.description == "NEW DESCRIPTION")
               }
@@ -218,6 +222,8 @@ class TripsRepositoryTest {
             // Ensure the stop list is empty after deletion.
             val finalStopList = repository.getAllStopsFromTrip(tripId)
             assertTrue("Stop list should be empty after deletion.", finalStopList.isEmpty())
+
+            assertTrue(repository.deleteTrip(tripId))
           }
         }
       } catch (e: TimeoutCancellationException) {

--- a/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
@@ -8,6 +8,7 @@ import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.google.firebase.FirebaseApp
 import java.time.LocalDate
+import java.time.LocalTime
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
 import kotlin.system.measureTimeMillis
@@ -20,7 +21,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.time.LocalTime
 
 @RunWith(RobolectricTestRunner::class)
 class TripsRepositoryTest {
@@ -150,60 +150,83 @@ class TripsRepositoryTest {
     println("testAddAndGetAndRemoveAndModifyAndGetAllTrip execution time: $elapsedTime ms")
   }
 
-    @Test
-    fun testAddModifyDeleteGetGetAllStopsInTrips() = runBlocking {
-        val trip =
-            Trip(
-                tripId = "trip123",
-                title = "Summer Vacation",
-                startDate = LocalDate.of(2024, 5, 20), // Assuming format is YYYY, MM, DD
-                endDate = LocalDate.of(2024, 6, 10),
-                totalBudget = 2000.0,
-                description = "Our summer vacation trip to Italy.",
-                imageUrl = "https://example.com/image.png",
-                stops = emptyList(),
-                users = emptyList(),
-                suggestions = emptyList())
+  @Test
+  fun testTripLifecycleWithStops() = runBlocking {
+    // Initialize a trip with details for a summer vacation in Italy.
+    val trip =
+        Trip(
+            tripId = "trip123",
+            title = "Summer Vacation",
+            startDate = LocalDate.of(2024, 5, 20),
+            endDate = LocalDate.of(2024, 6, 10),
+            totalBudget = 2000.0,
+            description = "Our summer vacation trip to Italy.",
+            imageUrl = "https://example.com/image.png",
+            stops = emptyList(),
+            users = emptyList(),
+            suggestions = emptyList())
 
-        val stop = Stop(
-            stopId = "", // Will be set by addStopToTrip method
+    // Initialize a stop at the Colosseum with detailed information.
+    val colosseumStop =
+        Stop(
+            stopId = "", // ID to be assigned by addStopToTrip method
             title = "Colosseum",
             address = "Piazza del Colosseo, 1, 00184 Roma RM, Italy",
             date = LocalDate.of(2024, 5, 21),
             startTime = LocalTime.of(10, 0),
-            duration = 120, // Example: 2 hours in minutes
-            budget = 0.0, // Assume free entry for simplicity
+            duration = 120,
+            budget = 0.0,
             description = "Visit the ancient Roman gladiatorial arena.",
-            geoCords = GeoCords(41.8902, 12.4922), // Placeholder coordinates
+            geoCords = GeoCords(41.8902, 12.4922),
             website = "https://example.com/colosseum",
             imageUrl = "https://example.com/colosseum.png")
 
-        val elapsedTime = measureTimeMillis {
-            try {
-                withTimeout(10000) {
-                    // Add the trip (assuming addTrip method exists and works correctly)
-                    //assertTrue(repository.addTrip(trip))
+    val elapsedTime = measureTimeMillis {
+      try {
+        withTimeout(10000) {
+          // Add the trip and validate the addition.
+          assertTrue(repository.addTrip(trip))
 
-                    // Add a stop to the trip
+          // Retrieve the trip ID, assuming this is the first and only trip.
+          val tripId = repository.getTripsIds()[0]
 
-                    assertTrue(repository.addStopToTrip("6446f69b-5610-4338-9643-e873d87dadaa", stop))
-                }
+          // Add the Colosseum stop to the trip and validate.
+          assertTrue(repository.addStopToTrip(tripId, colosseumStop))
 
-                withTimeout(10000) {
+          val fetchedTrip = repository.getTrip(tripId)
+          if (fetchedTrip != null) {
+            val stopId = fetchedTrip.stops[0]
 
-                }
+            // Fetch and validate the stop's details.
+            val fetchedStop = repository.getStopFromTrip(fetchedTrip.tripId, stopId)
+            if (fetchedStop != null) {
+              assertTrue(fetchedStop.description == colosseumStop.description)
 
-                withTimeout(10000) {
-
-                }
-            } catch (e: TimeoutCancellationException) {
-                // If a timeout occurs, fail the test
-                fail("The operation timed out after 10 seconds")
+              // Update the stop's description, validate the update.
+              repository.updateStopInTrip(
+                  fetchedTrip.tripId, fetchedStop.copy(description = "NEW DESCRIPTION"))
+              val updatedStop = repository.getStopFromTrip(fetchedTrip.tripId, stopId)
+              if (updatedStop != null) {
+                assertTrue(updatedStop.description == "NEW DESCRIPTION")
+              }
             }
-        }
-        println("testAddAndGetAndRemoveAndModifyAndGetAllTrip execution time: $elapsedTime ms")
-    }
 
+            // Remove the stop from the trip and validate its removal.
+            assertTrue(
+                "Failed to delete stop from trip.", repository.removeStopFromTrip(tripId, stopId))
+
+            // Ensure the stop list is empty after deletion.
+            val finalStopList = repository.getAllStopsFromTrip(tripId)
+            assertTrue("Stop list should be empty after deletion.", finalStopList.isEmpty())
+          }
+        }
+      } catch (e: TimeoutCancellationException) {
+        // Handle operation timeout.
+        fail("The operation timed out after 10 seconds")
+      }
+    }
+    println("Execution time for testTripLifecycleWithStops: $elapsedTime ms")
+  }
 
   @After
   fun tearDown() = runBlocking {
@@ -218,8 +241,16 @@ class TripsRepositoryTest {
     // Loop through each trip ID and attempt to remove it for cleanup
     tripIds.forEach { tripId ->
       try {
-        repository.deleteTrip(tripId)
-        repository.removeTripId(tripId)
+        val trip = repository.getTrip(tripId)
+        if (trip != null) {
+          val stopIds = trip.stops
+
+          stopIds.forEach { stopId ->
+            repository.removeStopFromTrip(tripId, stopId)
+          } // delete all stops
+          repository.deleteTrip(tripId)
+          repository.removeTripId(tripId)
+        }
       } catch (e: Exception) {
         println("Error cleaning up trip ID: $tripId")
       }


### PR DESCRIPTION
Implemented methods in the TripsRepository class to manage stop-related operations, including adding, removing, modifying, retrieving, and listing all stops for a specified trip ID. Additionally, minor corrections were made in the getAllTrips and addTrip methods. A basic test suite has been developed to validate the functionality of these new and corrected methods.