### PR TITLE
stopped tracking local properties

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Sun Mar 31 17:06:16 CEST 2024
-MAPS_API_KEY=DEFAULT_API_KEY


### PR DESCRIPTION
Removed tracking of local.properties, because people starting pushing it, and so we remove it, and if someone didn't get it, we will just have them add it locally