### PR TITLE
Create users repository methods

### DIFF
--- a/app/src/main/java/com/github/se/wanderpals/model/data/User.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/data/User.kt
@@ -2,6 +2,7 @@ package com.github.se.wanderpals.model.data
 
 /**
  * Defines user details within the application, including their roles and permissions.
+ * (Currently all field have a default value for serialization for firebase/ in refactor will most likely add a DTO for this object)
  *
  * @param userId Unique identifier for the user.
  * @param name User's full name for display and identification.
@@ -11,9 +12,9 @@ package com.github.se.wanderpals.model.data
  *   detailed access control.
  */
 data class User(
-    val userId: String,
-    val name: String,
-    val email: String,
-    val role: String,
+    val userId: String = "",
+    val name: String = "",
+    val email: String = "",
+    val role: String = "",
     val permissions: List<String> = emptyList()
 )

--- a/app/src/main/java/com/github/se/wanderpals/model/data/User.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/data/User.kt
@@ -1,8 +1,9 @@
 package com.github.se.wanderpals.model.data
 
 /**
- * Defines user details within the application, including their roles and permissions.
- * (Currently all field have a default value for serialization for firebase/ in refactor will most likely add a DTO for this object)
+ * Defines user details within the application, including their roles and permissions. (Currently
+ * all field have a default value for serialization for firebase/ in refactor will most likely add a
+ * DTO for this object)
  *
  * @param userId Unique identifier for the user.
  * @param name User's full name for display and identification.

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/FirebaseCollections.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/FirebaseCollections.kt
@@ -4,4 +4,5 @@ enum class FirebaseCollections(val path: String) {
   TRIPS("Trips"),
   USERS_TO_TRIPS_IDS("UsersToTripIds"),
   STOPS_SUBCOLLECTION("Stops"),
+  USERS_SUBCOLLECTION("Users")
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -99,13 +99,12 @@ class TripsRepository(
    * Retrieves all users associated with a specific trip. It iterates over all user IDs stored
    * within a trip document and fetches their corresponding user objects.
    *
-   * @param tripId The unique identifier of the trip.
-   * @param userId The unique identifier of the user making the request. (Note: This parameter
-   *   appears unused and may be a mistake in the method signature.)
+   * @param tripId The unique identifier of the trip. appears unused and may be a mistake in the
+   *   method signature.)
    * @return A list of `User` objects. Returns an empty list if the trip is not found or in case of
    *   an error.
    */
-  suspend fun getAllUsersFromTrip(tripId: String, userId: String): List<User> =
+  suspend fun getAllUsersFromTrip(tripId: String): List<User> =
       withContext(dispatcher) {
         try {
           val trip = getTrip(tripId)

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -4,6 +4,7 @@ import FirestoreTrip
 import android.util.Log
 import com.github.se.wanderpals.model.data.Stop
 import com.github.se.wanderpals.model.data.Trip
+import com.github.se.wanderpals.model.data.User
 import com.github.se.wanderpals.model.firestoreData.FirestoreStop
 import com.google.firebase.FirebaseApp
 import com.google.firebase.firestore.CollectionReference
@@ -60,6 +61,69 @@ class TripsRepository(
     tripsCollection = firestore.collection(FirebaseCollections.TRIPS.path)
   }
 
+    suspend fun getUserFromTrip(tripId: String,userId:String):User? = withContext(dispatcher){
+        try {
+            val documentSnapshot =
+                tripsCollection
+                    .document(tripId)
+                    .collection(FirebaseCollections.STOPS_SUBCOLLECTION.path)
+                    .document(userId)
+                    .get()
+                    .await()
+            val stop = documentSnapshot.toObject<User>()
+            if(stop != null){
+                stop
+            }else{
+                Log.e("TripsRepository", "getUserFromTrip: Not found user $userId from trip $tripId.")
+                null
+            }
+        }catch (e:Exception){
+            Log.e(
+                "TripsRepository",
+                "getUserFromTrip: Error getting an user $userId from trip $tripId.",
+                e)
+            null // error
+        }
+    }
+    suspend fun getAllUsersFromTrip(tripId: String,userId: String): List<User> = withContext(dispatcher){
+        try {
+            val trip = getTrip(tripId)
+            if (trip != null) {
+                val stopIds = trip.users
+                stopIds.mapNotNull { userId -> getUserFromTrip(tripId, userId) }
+            } else {
+                Log.e("TripsRepository", "getAllUsersFromTrip: Trip not found with ID $tripId.")
+                emptyList()
+            }
+        } catch (e: Exception) {
+            Log.e("TripsRepository", "getAllUsersFromTrip: Error fetching trip to trip $tripId.", e)
+            emptyList()
+        }
+    }
+
+    suspend fun addUserToTrip(tripId: String, user: User):Boolean = withContext(dispatcher){
+        try {
+
+        }catch (e:Exception){
+
+        }
+    }
+
+    suspend fun updateUserInTrip(tripId: String, user: User):Boolean = withContext(dispatcher){
+        try {
+
+        }catch (e:Exception){
+
+        }
+    }
+
+    suspend fun removeUserFromTrip(tripId: String,userId: String):Boolean = withContext(dispatcher){
+        try {
+
+        }catch (e:Exception){
+
+        }
+    }
   suspend fun getStopFromTrip(tripId: String, stopId: String): Stop? =
       withContext(dispatcher) {
         try {

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -61,164 +61,179 @@ class TripsRepository(
     tripsCollection = firestore.collection(FirebaseCollections.TRIPS.path)
   }
 
-    /**
-     * Fetches a user's details for a specific trip. This method queries a subcollection within a trip document to retrieve a user object based on the provided `userId`.
-     *
-     * @param tripId The unique identifier of the trip.
-     * @param userId The unique identifier of the user.
-     * @return A `User` object if found, `null` otherwise.
-     */
-    suspend fun getUserFromTrip(tripId: String,userId:String):User? = withContext(dispatcher){
+  /**
+   * Fetches a user's details for a specific trip. This method queries a subcollection within a trip
+   * document to retrieve a user object based on the provided `userId`.
+   *
+   * @param tripId The unique identifier of the trip.
+   * @param userId The unique identifier of the user.
+   * @return A `User` object if found, `null` otherwise.
+   */
+  suspend fun getUserFromTrip(tripId: String, userId: String): User? =
+      withContext(dispatcher) {
         try {
-            val documentSnapshot =
-                tripsCollection
-                    .document(tripId)
-                    .collection(FirebaseCollections.STOPS_SUBCOLLECTION.path)
-                    .document(userId)
-                    .get()
-                    .await()
-            val stop = documentSnapshot.toObject<User>()
-            if(stop != null){
-                stop
-            }else{
-                Log.e("TripsRepository", "getUserFromTrip: Not found user $userId from trip $tripId.")
-                null
-            }
-        }catch (e:Exception){
-            Log.e(
-                "TripsRepository",
-                "getUserFromTrip: Error getting an user $userId from trip $tripId.",
-                e)
-            null // error
-        }
-    }
-
-    /**
-     * Retrieves all users associated with a specific trip. It iterates over all user IDs stored within a trip document and fetches their corresponding user objects.
-     *
-     * @param tripId The unique identifier of the trip.
-     * @param userId The unique identifier of the user making the request. (Note: This parameter appears unused and may be a mistake in the method signature.)
-     * @return A list of `User` objects. Returns an empty list if the trip is not found or in case of an error.
-     */
-    suspend fun getAllUsersFromTrip(tripId: String,userId: String): List<User> = withContext(dispatcher){
-        try {
-            val trip = getTrip(tripId)
-            if (trip != null) {
-                val stopIds = trip.users
-                stopIds.mapNotNull { userId -> getUserFromTrip(tripId, userId) }
-            } else {
-                Log.e("TripsRepository", "getAllUsersFromTrip: Trip not found with ID $tripId.")
-                emptyList()
-            }
+          val documentSnapshot =
+              tripsCollection
+                  .document(tripId)
+                  .collection(FirebaseCollections.USERS_SUBCOLLECTION.path)
+                  .document(userId)
+                  .get()
+                  .await()
+          val user = documentSnapshot.toObject<User>()
+          if (user != null) {
+            user
+          } else {
+            Log.e("TripsRepository", "getUserFromTrip: Not found user $userId from trip $tripId.")
+            null
+          }
         } catch (e: Exception) {
-            Log.e("TripsRepository", "getAllUsersFromTrip: Error fetching trip to trip $tripId.", e)
+          Log.e(
+              "TripsRepository",
+              "getUserFromTrip: Error getting an user $userId from trip $tripId.",
+              e)
+          null // error
+        }
+      }
+
+  /**
+   * Retrieves all users associated with a specific trip. It iterates over all user IDs stored
+   * within a trip document and fetches their corresponding user objects.
+   *
+   * @param tripId The unique identifier of the trip.
+   * @param userId The unique identifier of the user making the request. (Note: This parameter
+   *   appears unused and may be a mistake in the method signature.)
+   * @return A list of `User` objects. Returns an empty list if the trip is not found or in case of
+   *   an error.
+   */
+  suspend fun getAllUsersFromTrip(tripId: String, userId: String): List<User> =
+      withContext(dispatcher) {
+        try {
+          val trip = getTrip(tripId)
+          if (trip != null) {
+            val stopIds = trip.users
+            stopIds.mapNotNull { userId -> getUserFromTrip(tripId, userId) }
+          } else {
+            Log.e("TripsRepository", "getAllUsersFromTrip: Trip not found with ID $tripId.")
             emptyList()
+          }
+        } catch (e: Exception) {
+          Log.e("TripsRepository", "getAllUsersFromTrip: Error fetching trip to trip $tripId.", e)
+          emptyList()
         }
-    }
+      }
 
-    /**
-     * Adds a user to a specified trip. This method creates or updates a document in the Users subcollection within a trip, storing the user's details.
-     *
-     * @param tripId The unique identifier of the trip.
-     * @param user The `User` object containing the user's details.
-     * @return `true` if the operation is successful, `false` otherwise.
-     */
-    suspend fun addUserToTrip(tripId: String, user: User):Boolean = withContext(dispatcher){
+  /**
+   * Adds a user to a specified trip. This method creates or updates a document in the Users
+   * subcollection within a trip, storing the user's details.
+   *
+   * @param tripId The unique identifier of the trip.
+   * @param user The `User` object containing the user's details.
+   * @return `true` if the operation is successful, `false` otherwise.
+   */
+  suspend fun addUserToTrip(tripId: String, user: User): Boolean =
+      withContext(dispatcher) {
         try {
-            //for users, there IDs are google ids currently no need to gen a new one
+          // for users, there IDs are google ids currently no need to gen a new one
 
-            val userDocument = tripsCollection.document(tripId).collection(FirebaseCollections.USERS_SUBCOLLECTION.path).document(user.userId)
-            userDocument.set(user).await()
-            Log.d("TripsRepository", "addUserToTrip: User added successfully to trip $tripId.")
-            val trip = getTrip(tripId)
-            if (trip != null) {
-                // Add the new userID to the trip's user list and update the trip
-                val updatedStopsList = trip.users + user.userId
-                val updatedTrip = trip.copy(users = updatedStopsList)
-                updateTrip(updatedTrip)
-                Log.d("TripsRepository", "addUserToTrip: Stop ID added to trip successfully.")
-                true
-            } else {
+          val userDocument =
+              tripsCollection
+                  .document(tripId)
+                  .collection(FirebaseCollections.USERS_SUBCOLLECTION.path)
+                  .document(user.userId)
+          userDocument.set(user).await()
+          Log.d("TripsRepository", "addUserToTrip: User added successfully to trip $tripId.")
+          val trip = getTrip(tripId)
+          if (trip != null) {
+            // Add the new userID to the trip's user list and update the trip
+            val updatedStopsList = trip.users + user.userId
+            val updatedTrip = trip.copy(users = updatedStopsList)
+            updateTrip(updatedTrip)
+            Log.d("TripsRepository", "addUserToTrip: Stop ID added to trip successfully.")
+            true
+          } else {
 
-                Log.e("TripsRepository", "addUserToTrip: Trip not found with ID $tripId.")
-                false
-            }
-
-        }catch (e:Exception){
-            Log.e("TripsRepository", "addUserToTrip: Error adding user to trip $tripId.", e)
+            Log.e("TripsRepository", "addUserToTrip: Trip not found with ID $tripId.")
             false
+          }
+        } catch (e: Exception) {
+          Log.e("TripsRepository", "addUserToTrip: Error adding user to trip $tripId.", e)
+          false
         }
-    }
+      }
 
-    /**
-     * Updates details of a user in a specified trip. Similar to `addUserToTrip`, but specifically intended for updating existing user documents.
-     *
-     * @param tripId The unique identifier of the trip.
-     * @param user The `User` object to be updated.
-     * @return `true` if the operation is successful, `false` otherwise.
-     */
-    suspend fun updateUserInTrip(tripId: String, user: User):Boolean = withContext(dispatcher){
+  /**
+   * Updates details of a user in a specified trip. Similar to `addUserToTrip`, but specifically
+   * intended for updating existing user documents.
+   *
+   * @param tripId The unique identifier of the trip.
+   * @param user The `User` object to be updated.
+   * @return `true` if the operation is successful, `false` otherwise.
+   */
+  suspend fun updateUserInTrip(tripId: String, user: User): Boolean =
+      withContext(dispatcher) {
         try {
-            Log.d("TripsRepository", "updateUserInTrip: Updating a user in trip $tripId")
+          Log.d("TripsRepository", "updateUserInTrip: Updating a user in trip $tripId")
 
-            tripsCollection
-                .document(tripId)
-                .collection(FirebaseCollections.USERS_SUBCOLLECTION.path)
-                .document(user.userId)
-                .set(user)
-                .await()
+          tripsCollection
+              .document(tripId)
+              .collection(FirebaseCollections.USERS_SUBCOLLECTION.path)
+              .document(user.userId)
+              .set(user)
+              .await()
+          Log.d(
+              "TripsRepository",
+              "updateUserInTrip: Trip's user updated successfully for ID $tripId.")
+          true
+        } catch (e: Exception) {
+          Log.e(
+              "TripsRepository",
+              "updateUserInTrip: Error updating user with ID ${user.userId} in trip with ID $tripId",
+              e)
+          false
+        }
+      }
+
+  /**
+   * Removes a user from a trip. This method deletes a user's document from the Users subcollection
+   * within a trip.
+   *
+   * @param tripId The unique identifier of the trip.
+   * @param userId The unique identifier of the user to be removed.
+   * @return `true` if the operation is successful, `false` otherwise.
+   */
+  suspend fun removeUserFromTrip(tripId: String, userId: String): Boolean =
+      withContext(dispatcher) {
+        try {
+          Log.d("TripsRepository", "removeUserFromTrip: Deleting user $userId from trip $tripId")
+          tripsCollection
+              .document(tripId)
+              .collection(FirebaseCollections.USERS_SUBCOLLECTION.path)
+              .document(userId)
+              .delete()
+              .await()
+
+          val trip = getTrip(tripId)
+          if (trip != null) {
+            val updatedUsersList = trip.users.filterNot { it == userId }
+            val updatedTrip = trip.copy(users = updatedUsersList)
+            updateTrip(updatedTrip)
             Log.d(
                 "TripsRepository",
-                "updateUserInTrip: Trip's user updated successfully for ID $tripId.")
+                "removeUserFromTrip: User $userId deleted and trip updated successfully.")
             true
+          } else {
+            Log.e("TripsRepository", "removeUserFromTrip: Trip not found with ID $tripId.")
+            false
+          }
         } catch (e: Exception) {
-            Log.e(
-                "TripsRepository",
-                "updateUserInTrip: Error updating user with ID ${user.userId} in trip with ID $tripId",
-                e)
-            false
+          Log.e(
+              "TripsRepository",
+              "removeUserFromTrip: Error deleting user $userId from trip $tripId.",
+              e)
+          false
         }
-    }
+      }
 
-    /**
-     * Removes a user from a trip. This method deletes a user's document from the Users subcollection within a trip.
-     *
-     * @param tripId The unique identifier of the trip.
-     * @param userId The unique identifier of the user to be removed.
-     * @return `true` if the operation is successful, `false` otherwise.
-     */
-    suspend fun removeUserFromTrip(tripId: String,userId: String):Boolean = withContext(dispatcher){
-        try {
-            Log.d("TripsRepository", "removeUserFromTrip: Deleting user $userId from trip $tripId")
-            tripsCollection
-                .document(tripId)
-                .collection(FirebaseCollections.USERS_SUBCOLLECTION.path)
-                .document(userId)
-                .delete()
-                .await()
-
-            val trip = getTrip(tripId)
-            if (trip != null) {
-                val updatedUsersList = trip.users.filterNot { it == userId }
-                val updatedTrip = trip.copy(users = updatedUsersList)
-                updateTrip(updatedTrip)
-                Log.d(
-                    "TripsRepository",
-                    "removeUserFromTrip: User $userId deleted and trip updated successfully.")
-                true
-            } else {
-                Log.e("TripsRepository", "removeUserFromTrip: Trip not found with ID $tripId.")
-                false
-            }
-
-        }catch (e:Exception){
-            Log.e(
-                "TripsRepository",
-                "removeUserFromTrip: Error deleting user $userId from trip $tripId.",
-                e)
-            false
-        }
-    }
   suspend fun getStopFromTrip(tripId: String, stopId: String): Stop? =
       withContext(dispatcher) {
         try {

--- a/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
@@ -280,6 +280,9 @@ class TripsRepositoryTest {
 
             // Fetch and validate the stop's details.
             val fetchedUser = repository.getUserFromTrip(fetchedTrip.tripId, userId)
+
+            val fetchedUsers = repository.getAllUsersFromTrip(fetchedTrip.tripId)
+            assertTrue(fetchedUsers.isNotEmpty())
             assertTrue(fetchedUser != null)
             if (fetchedUser != null) {
 


### PR DESCRIPTION
In this pull request, we introduce new functionality and comprehensive testing for managing users within trips in our TripsRepository. The changes include methods for fetching individual users and all users associated with a trip, adding and updating users in a trip, and removing users from a trip. Each method is designed to interact seamlessly with Firestore, ensuring efficient data retrieval and manipulation. We've also included a test case, testTripLifecycleWithUsers, to rigorously test these functionalities through a simulated trip lifecycle. This includes adding a trip, adding a user to the trip, verifying user details, updating user information, and finally removing the user and deleting the trip. This test ensures our repository handles user data accurately and efficiently, supporting robust user management within trips.
Also added default values to the users data class, for serialization for my base (will refactor to make it cleaner ina  separate issue)