### PR TITLE
Create suggestion repository methods

### DIFF
--- a/app/src/main/java/com/github/se/wanderpals/model/firestoreData/FirestoreSuggestion.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/firestoreData/FirestoreSuggestion.kt
@@ -23,7 +23,7 @@ data class FirestoreSuggestion(
     val userName: String = "",
     val text: String = "",
     val createdAt: String = "", // Converted to String for Firestore compatibility
-    val stop: FirestoreStop, // Using Firestore-compatible Stop object
+    val stop: FirestoreStop = FirestoreStop(), // Using Firestore-compatible Stop object
     val comments: List<FirestoreComment> = emptyList() // Using Firestore-compatible Comment objects
 ) {
   companion object {

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/FirebaseCollections.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/FirebaseCollections.kt
@@ -4,5 +4,6 @@ enum class FirebaseCollections(val path: String) {
   TRIPS("Trips"),
   USERS_TO_TRIPS_IDS("UsersToTripIds"),
   STOPS_SUBCOLLECTION("Stops"),
-  USERS_SUBCOLLECTION("Users")
+  USERS_SUBCOLLECTION("Users"),
+  SUGGESTIONS_SUBCOLLECTION("Suggestions")
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -149,7 +149,9 @@ class TripsRepository(
           val uniqueID = UUID.randomUUID().toString()
           val firebaseSuggestion =
               FirestoreSuggestion.fromSuggestion(
-                  suggestion.copy(suggestionId = uniqueID, userId = uid)) //we already know who creates the suggestion
+                  suggestion.copy(
+                      suggestionId = uniqueID,
+                      userId = uid)) // we already know who creates the suggestion
           val suggestionDocument =
               tripsCollection
                   .document(tripId)

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -112,6 +112,7 @@ class TripsRepository(
         withContext(dispatcher) {
             try {
                 val trip = getTrip(tripId)
+
                 if (trip != null) {
                     val suggestionIds = trip.suggestions
                     suggestionIds.mapNotNull { suggestionId -> getSuggestionFromTrip(tripId, suggestionId) }
@@ -180,10 +181,10 @@ class TripsRepository(
      * @return `true` if the suggestion was successfully deleted and the trip updated, `false`
      *         otherwise. Errors during the process are logged.
      */
-    suspend fun deleteSuggestionFromTrip(tripId: String, suggestionId: String): Boolean =
+    suspend fun removeSuggestionFromTrip(tripId: String, suggestionId: String): Boolean =
         withContext(dispatcher) {
             try {
-                Log.d("TripsRepository", "deleteStopFromTrip: Deleting Suggestion $suggestionId from trip $tripId")
+                Log.d("TripsRepository", "removeSuggestionFromTrip: removing Suggestion $suggestionId from trip $tripId")
                 tripsCollection
                     .document(tripId)
                     .collection(FirebaseCollections.SUGGESTIONS_SUBCOLLECTION.path)
@@ -198,16 +199,16 @@ class TripsRepository(
                     updateTrip(updatedTrip)
                     Log.d(
                         "TripsRepository",
-                        "deleteSuggestionFromTrip: Suggestion $suggestionId deleted and trip updated successfully.")
+                        "removeSuggestionFromTrip: Suggestion $suggestionId remove and trip updated successfully.")
                     true
                 } else {
-                    Log.e("TripsRepository", "deleteSuggestionFromTrip: Trip not found with ID $tripId.")
+                    Log.e("TripsRepository", "removeSuggestionFromTrip: Trip not found with ID $tripId.")
                     false
                 }
             } catch (e: Exception) {
                 Log.e(
                     "TripsRepository",
-                    "deleteSuggestionFromTrip: Error deleting Suggestion $suggestionId from trip $tripId.",
+                    "removeSuggestionFromTrip: Error removing Suggestion $suggestionId from trip $tripId.",
                     e)
                 false
             }

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -148,7 +148,8 @@ class TripsRepository(
         try {
           val uniqueID = UUID.randomUUID().toString()
           val firebaseSuggestion =
-              FirestoreSuggestion.fromSuggestion(suggestion.copy(suggestionId = uniqueID))
+              FirestoreSuggestion.fromSuggestion(
+                  suggestion.copy(suggestionId = uniqueID, userId = uid)) //we already know who creates the suggestion
           val suggestionDocument =
               tripsCollection
                   .document(tripId)

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -63,6 +63,18 @@ class TripsRepository(
     tripsCollection = firestore.collection(FirebaseCollections.TRIPS.path)
   }
 
+    /**
+     * Retrieves a specific suggestion from a trip based on the suggestion's unique identifier.
+     * This method queries a subcollection within a trip document to retrieve a suggestion object
+     * based on the provided `suggestionId`.
+     *
+     * @param tripId The unique identifier of the trip.
+     * @param suggestionId The unique identifier of the suggestion.
+     * @return A `Suggestion` object if found, `null` otherwise. The method logs an error and returns
+     *         `null` if the suggestion is not found or if an error occurs during the Firestore query.
+     */
+
+
     suspend fun getSuggestionFromTrip(tripId: String, suggestionId: String): Suggestion? =
         withContext(dispatcher) {
             try {
@@ -89,6 +101,13 @@ class TripsRepository(
             }
         }
 
+    /**
+     * Retrieves all suggestions associated with a specific trip. It iterates over all suggestion IDs
+     * stored within a trip document and fetches their corresponding suggestion objects.
+     * @param tripId The unique identifier of the trip.
+     * @return A list of `Suggestion` objects. Returns an empty list if the trip is not found, if there
+     *         are no suggestions associated with the trip, or in case of an error during data retrieval.
+     */
     suspend fun getAllSuggestionsFromTrip(tripId: String): List<Suggestion> =
         withContext(dispatcher) {
             try {
@@ -106,6 +125,18 @@ class TripsRepository(
                 emptyList()
             }
         }
+
+    /**
+     * Adds a new suggestion to a specified trip. This involves creating a unique identifier for the
+     * suggestion, converting the suggestion to a Firestore-compatible format, and updating the
+     * trip's document to include the new suggestion.
+     * If successful, the method also updates the trip document to include the newly added suggestion's
+     * ID in the list of suggestions.
+     * @param tripId The unique identifier of the trip to which the suggestion is being added.
+     * @param suggestion The `Suggestion` object to be added to the trip.
+     * @return `true` if the suggestion was added successfully, `false` otherwise. Errors during the
+     *         process are logged.
+     */
 
     suspend fun addSuggestionToTrip(tripId: String, suggestion: Suggestion): Boolean =
         withContext(dispatcher) {
@@ -139,6 +170,16 @@ class TripsRepository(
             }
         }
 
+    /**
+     * Removes a specific suggestion from a trip. This method deletes the suggestion document from
+     * the Firestore subcollection and updates the trip document to remove the suggestion's ID from
+     * the list of associated suggestions.
+     *
+     * @param tripId The unique identifier of the trip from which the suggestion is being removed.
+     * @param suggestionId The unique identifier of the suggestion to remove.
+     * @return `true` if the suggestion was successfully deleted and the trip updated, `false`
+     *         otherwise. Errors during the process are logged.
+     */
     suspend fun deleteSuggestionFromTrip(tripId: String, suggestionId: String): Boolean =
         withContext(dispatcher) {
             try {
@@ -172,25 +213,37 @@ class TripsRepository(
             }
         }
 
-    suspend fun updateSuggestionInTrip(tripId: String, stop: Stop): Boolean =
+    /**
+     * Updates an existing suggestion within a trip. This method replaces the suggestion document in
+     * the Firestore subcollection with the updated suggestion details.
+     *
+     * It is important that the `suggestionId` within the `Suggestion` object matches the ID of the
+     * suggestion being updated to ensure the correct document is replaced.
+     *
+     * @param tripId The unique identifier of the trip containing the suggestion.
+     * @param suggestion The updated `Suggestion` object.
+     * @return `true` if the suggestion was successfully updated, `false` otherwise. Errors during
+     *         the update process are logged.
+     */
+    suspend fun updateSuggestionInTrip(tripId: String, suggestion: Suggestion): Boolean =
         withContext(dispatcher) {
             try {
-                Log.d("TripsRepository", "updateStopInTrip: Updating a stop in trip $tripId")
-                val firestoreStop = FirestoreStop.fromStop(stop)
+                Log.d("TripsRepository", "updateSuggestionInTrip: Updating a Suggestion in trip $tripId")
+                val firestoreSuggestion = FirestoreSuggestion.fromSuggestion(suggestion)
                 tripsCollection
                     .document(tripId)
-                    .collection(FirebaseCollections.STOPS_SUBCOLLECTION.path)
-                    .document(firestoreStop.stopId)
-                    .set(firestoreStop)
+                    .collection(FirebaseCollections.SUGGESTIONS_SUBCOLLECTION.path)
+                    .document(firestoreSuggestion.suggestionId)
+                    .set(firestoreSuggestion)
                     .await()
                 Log.d(
                     "TripsRepository",
-                    "updateStopInTrip: Trip's Stop updated successfully for ID $tripId.")
+                    "updateSuggestionInTrip: Trip's Suggestion updated successfully for ID $tripId.")
                 true
             } catch (e: Exception) {
                 Log.e(
                     "TripsRepository",
-                    "updateStopInTrip: Error updating stop with ID ${stop.stopId} in trip with ID $tripId",
+                    "updateSuggestionInTrip: Error updating stop with ID ${suggestion.suggestionId} in trip with ID $tripId",
                     e)
                 false
             }

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -63,192 +63,203 @@ class TripsRepository(
     tripsCollection = firestore.collection(FirebaseCollections.TRIPS.path)
   }
 
-    /**
-     * Retrieves a specific suggestion from a trip based on the suggestion's unique identifier.
-     * This method queries a subcollection within a trip document to retrieve a suggestion object
-     * based on the provided `suggestionId`.
-     *
-     * @param tripId The unique identifier of the trip.
-     * @param suggestionId The unique identifier of the suggestion.
-     * @return A `Suggestion` object if found, `null` otherwise. The method logs an error and returns
-     *         `null` if the suggestion is not found or if an error occurs during the Firestore query.
-     */
-
-
-    suspend fun getSuggestionFromTrip(tripId: String, suggestionId: String): Suggestion? =
-        withContext(dispatcher) {
-            try {
-                val documentSnapshot =
-                    tripsCollection
-                        .document(tripId)
-                        .collection(FirebaseCollections.SUGGESTIONS_SUBCOLLECTION.path)
-                        .document(suggestionId)
-                        .get()
-                        .await()
-                val firestoreSuggestion = documentSnapshot.toObject<FirestoreSuggestion>()
-                if (firestoreSuggestion != null) {
-                    firestoreSuggestion.toSuggestion()
-                } else {
-                    Log.e("TripsRepository", "getSuggestionFromTrip: Not found Suggestion $suggestionId from trip $tripId.")
-                    null
-                }
-            } catch (e: Exception) {
-                Log.e(
-                    "TripsRepository",
-                    "getSuggestionFromTrip: Error getting a Suggestion $suggestionId from trip $tripId.",
-                    e)
-                null // error
-            }
+  /**
+   * Retrieves a specific suggestion from a trip based on the suggestion's unique identifier. This
+   * method queries a subcollection within a trip document to retrieve a suggestion object based on
+   * the provided `suggestionId`.
+   *
+   * @param tripId The unique identifier of the trip.
+   * @param suggestionId The unique identifier of the suggestion.
+   * @return A `Suggestion` object if found, `null` otherwise. The method logs an error and returns
+   *   `null` if the suggestion is not found or if an error occurs during the Firestore query.
+   */
+  suspend fun getSuggestionFromTrip(tripId: String, suggestionId: String): Suggestion? =
+      withContext(dispatcher) {
+        try {
+          val documentSnapshot =
+              tripsCollection
+                  .document(tripId)
+                  .collection(FirebaseCollections.SUGGESTIONS_SUBCOLLECTION.path)
+                  .document(suggestionId)
+                  .get()
+                  .await()
+          val firestoreSuggestion = documentSnapshot.toObject<FirestoreSuggestion>()
+          if (firestoreSuggestion != null) {
+            firestoreSuggestion.toSuggestion()
+          } else {
+            Log.e(
+                "TripsRepository",
+                "getSuggestionFromTrip: Not found Suggestion $suggestionId from trip $tripId.")
+            null
+          }
+        } catch (e: Exception) {
+          Log.e(
+              "TripsRepository",
+              "getSuggestionFromTrip: Error getting a Suggestion $suggestionId from trip $tripId.",
+              e)
+          null // error
         }
+      }
 
-    /**
-     * Retrieves all suggestions associated with a specific trip. It iterates over all suggestion IDs
-     * stored within a trip document and fetches their corresponding suggestion objects.
-     * @param tripId The unique identifier of the trip.
-     * @return A list of `Suggestion` objects. Returns an empty list if the trip is not found, if there
-     *         are no suggestions associated with the trip, or in case of an error during data retrieval.
-     */
-    suspend fun getAllSuggestionsFromTrip(tripId: String): List<Suggestion> =
-        withContext(dispatcher) {
-            try {
-                val trip = getTrip(tripId)
+  /**
+   * Retrieves all suggestions associated with a specific trip. It iterates over all suggestion IDs
+   * stored within a trip document and fetches their corresponding suggestion objects.
+   *
+   * @param tripId The unique identifier of the trip.
+   * @return A list of `Suggestion` objects. Returns an empty list if the trip is not found, if
+   *   there are no suggestions associated with the trip, or in case of an error during data
+   *   retrieval.
+   */
+  suspend fun getAllSuggestionsFromTrip(tripId: String): List<Suggestion> =
+      withContext(dispatcher) {
+        try {
+          val trip = getTrip(tripId)
 
-                if (trip != null) {
-                    val suggestionIds = trip.suggestions
-                    suggestionIds.mapNotNull { suggestionId -> getSuggestionFromTrip(tripId, suggestionId) }
-                } else {
-                    Log.e("TripsRepository", "getAllSuggestionsFromTrip: Trip not found with ID $tripId.")
-                    emptyList()
-                }
-            } catch (e: Exception) {
+          if (trip != null) {
+            val suggestionIds = trip.suggestions
+            suggestionIds.mapNotNull { suggestionId -> getSuggestionFromTrip(tripId, suggestionId) }
+          } else {
+            Log.e("TripsRepository", "getAllSuggestionsFromTrip: Trip not found with ID $tripId.")
+            emptyList()
+          }
+        } catch (e: Exception) {
 
-                Log.e("TripsRepository", "getAllSuggestionsFromTrip: Error fetching Suggestion to trip $tripId.", e)
-                emptyList()
-            }
+          Log.e(
+              "TripsRepository",
+              "getAllSuggestionsFromTrip: Error fetching Suggestion to trip $tripId.",
+              e)
+          emptyList()
         }
+      }
 
-    /**
-     * Adds a new suggestion to a specified trip. This involves creating a unique identifier for the
-     * suggestion, converting the suggestion to a Firestore-compatible format, and updating the
-     * trip's document to include the new suggestion.
-     * If successful, the method also updates the trip document to include the newly added suggestion's
-     * ID in the list of suggestions.
-     * @param tripId The unique identifier of the trip to which the suggestion is being added.
-     * @param suggestion The `Suggestion` object to be added to the trip.
-     * @return `true` if the suggestion was added successfully, `false` otherwise. Errors during the
-     *         process are logged.
-     */
+  /**
+   * Adds a new suggestion to a specified trip. This involves creating a unique identifier for the
+   * suggestion, converting the suggestion to a Firestore-compatible format, and updating the trip's
+   * document to include the new suggestion. If successful, the method also updates the trip
+   * document to include the newly added suggestion's ID in the list of suggestions.
+   *
+   * @param tripId The unique identifier of the trip to which the suggestion is being added.
+   * @param suggestion The `Suggestion` object to be added to the trip.
+   * @return `true` if the suggestion was added successfully, `false` otherwise. Errors during the
+   *   process are logged.
+   */
+  suspend fun addSuggestionToTrip(tripId: String, suggestion: Suggestion): Boolean =
+      withContext(dispatcher) {
+        try {
+          val uniqueID = UUID.randomUUID().toString()
+          val firebaseSuggestion =
+              FirestoreSuggestion.fromSuggestion(suggestion.copy(suggestionId = uniqueID))
+          val suggestionDocument =
+              tripsCollection
+                  .document(tripId)
+                  .collection(FirebaseCollections.SUGGESTIONS_SUBCOLLECTION.path)
+                  .document(uniqueID)
+          suggestionDocument.set(firebaseSuggestion).await()
+          Log.d(
+              "TripsRepository",
+              "addSuggestionToTrip: Suggestion added successfully to trip $tripId.")
 
-    suspend fun addSuggestionToTrip(tripId: String, suggestion: Suggestion): Boolean =
-        withContext(dispatcher) {
-            try {
-                val uniqueID = UUID.randomUUID().toString()
-                val firebaseSuggestion = FirestoreSuggestion.fromSuggestion(suggestion.copy(suggestionId = uniqueID))
-                val suggestionDocument =
-                    tripsCollection
-                        .document(tripId)
-                        .collection(FirebaseCollections.SUGGESTIONS_SUBCOLLECTION.path)
-                        .document(uniqueID)
-                suggestionDocument.set(firebaseSuggestion).await()
-                Log.d("TripsRepository", "addSuggestionToTrip: Suggestion added successfully to trip $tripId.")
+          val trip = getTrip(tripId)
+          if (trip != null) {
+            // Add the new stopId to the trip's stops list and update the trip
+            val updatedSuggestionsList = trip.suggestions + uniqueID
+            val updatedTrip = trip.copy(suggestions = updatedSuggestionsList)
+            updateTrip(updatedTrip)
+            Log.d(
+                "TripsRepository", "addSuggestionToTrip: Suggestion ID added to trip successfully.")
+            true
+          } else {
 
-                val trip = getTrip(tripId)
-                if (trip != null) {
-                    // Add the new stopId to the trip's stops list and update the trip
-                    val updatedSuggestionsList = trip.suggestions + uniqueID
-                    val updatedTrip = trip.copy(suggestions = updatedSuggestionsList)
-                    updateTrip(updatedTrip)
-                    Log.d("TripsRepository", "addSuggestionToTrip: Suggestion ID added to trip successfully.")
-                    true
-                } else {
-
-                    Log.e("TripsRepository", "addSuggestionToTrip: Trip not found with ID $tripId.")
-                    false
-                }
-            } catch (e: Exception) {
-                Log.e("TripsRepository", "addSuggestionToTrip: Error adding Suggestion to trip $tripId.", e)
-                false
-            }
+            Log.e("TripsRepository", "addSuggestionToTrip: Trip not found with ID $tripId.")
+            false
+          }
+        } catch (e: Exception) {
+          Log.e(
+              "TripsRepository", "addSuggestionToTrip: Error adding Suggestion to trip $tripId.", e)
+          false
         }
+      }
 
-    /**
-     * Removes a specific suggestion from a trip. This method deletes the suggestion document from
-     * the Firestore subcollection and updates the trip document to remove the suggestion's ID from
-     * the list of associated suggestions.
-     *
-     * @param tripId The unique identifier of the trip from which the suggestion is being removed.
-     * @param suggestionId The unique identifier of the suggestion to remove.
-     * @return `true` if the suggestion was successfully deleted and the trip updated, `false`
-     *         otherwise. Errors during the process are logged.
-     */
-    suspend fun removeSuggestionFromTrip(tripId: String, suggestionId: String): Boolean =
-        withContext(dispatcher) {
-            try {
-                Log.d("TripsRepository", "removeSuggestionFromTrip: removing Suggestion $suggestionId from trip $tripId")
-                tripsCollection
-                    .document(tripId)
-                    .collection(FirebaseCollections.SUGGESTIONS_SUBCOLLECTION.path)
-                    .document(suggestionId)
-                    .delete()
-                    .await()
+  /**
+   * Removes a specific suggestion from a trip. This method deletes the suggestion document from the
+   * Firestore subcollection and updates the trip document to remove the suggestion's ID from the
+   * list of associated suggestions.
+   *
+   * @param tripId The unique identifier of the trip from which the suggestion is being removed.
+   * @param suggestionId The unique identifier of the suggestion to remove.
+   * @return `true` if the suggestion was successfully deleted and the trip updated, `false`
+   *   otherwise. Errors during the process are logged.
+   */
+  suspend fun removeSuggestionFromTrip(tripId: String, suggestionId: String): Boolean =
+      withContext(dispatcher) {
+        try {
+          Log.d(
+              "TripsRepository",
+              "removeSuggestionFromTrip: removing Suggestion $suggestionId from trip $tripId")
+          tripsCollection
+              .document(tripId)
+              .collection(FirebaseCollections.SUGGESTIONS_SUBCOLLECTION.path)
+              .document(suggestionId)
+              .delete()
+              .await()
 
-                val trip = getTrip(tripId)
-                if (trip != null) {
-                    val updatedSuggestionsList = trip.suggestions.filterNot { it == suggestionId }
-                    val updatedTrip = trip.copy(suggestions = updatedSuggestionsList)
-                    updateTrip(updatedTrip)
-                    Log.d(
-                        "TripsRepository",
-                        "removeSuggestionFromTrip: Suggestion $suggestionId remove and trip updated successfully.")
-                    true
-                } else {
-                    Log.e("TripsRepository", "removeSuggestionFromTrip: Trip not found with ID $tripId.")
-                    false
-                }
-            } catch (e: Exception) {
-                Log.e(
-                    "TripsRepository",
-                    "removeSuggestionFromTrip: Error removing Suggestion $suggestionId from trip $tripId.",
-                    e)
-                false
-            }
+          val trip = getTrip(tripId)
+          if (trip != null) {
+            val updatedSuggestionsList = trip.suggestions.filterNot { it == suggestionId }
+            val updatedTrip = trip.copy(suggestions = updatedSuggestionsList)
+            updateTrip(updatedTrip)
+            Log.d(
+                "TripsRepository",
+                "removeSuggestionFromTrip: Suggestion $suggestionId remove and trip updated successfully.")
+            true
+          } else {
+            Log.e("TripsRepository", "removeSuggestionFromTrip: Trip not found with ID $tripId.")
+            false
+          }
+        } catch (e: Exception) {
+          Log.e(
+              "TripsRepository",
+              "removeSuggestionFromTrip: Error removing Suggestion $suggestionId from trip $tripId.",
+              e)
+          false
         }
+      }
 
-    /**
-     * Updates an existing suggestion within a trip. This method replaces the suggestion document in
-     * the Firestore subcollection with the updated suggestion details.
-     *
-     * It is important that the `suggestionId` within the `Suggestion` object matches the ID of the
-     * suggestion being updated to ensure the correct document is replaced.
-     *
-     * @param tripId The unique identifier of the trip containing the suggestion.
-     * @param suggestion The updated `Suggestion` object.
-     * @return `true` if the suggestion was successfully updated, `false` otherwise. Errors during
-     *         the update process are logged.
-     */
-    suspend fun updateSuggestionInTrip(tripId: String, suggestion: Suggestion): Boolean =
-        withContext(dispatcher) {
-            try {
-                Log.d("TripsRepository", "updateSuggestionInTrip: Updating a Suggestion in trip $tripId")
-                val firestoreSuggestion = FirestoreSuggestion.fromSuggestion(suggestion)
-                tripsCollection
-                    .document(tripId)
-                    .collection(FirebaseCollections.SUGGESTIONS_SUBCOLLECTION.path)
-                    .document(firestoreSuggestion.suggestionId)
-                    .set(firestoreSuggestion)
-                    .await()
-                Log.d(
-                    "TripsRepository",
-                    "updateSuggestionInTrip: Trip's Suggestion updated successfully for ID $tripId.")
-                true
-            } catch (e: Exception) {
-                Log.e(
-                    "TripsRepository",
-                    "updateSuggestionInTrip: Error updating stop with ID ${suggestion.suggestionId} in trip with ID $tripId",
-                    e)
-                false
-            }
+  /**
+   * Updates an existing suggestion within a trip. This method replaces the suggestion document in
+   * the Firestore subcollection with the updated suggestion details.
+   *
+   * It is important that the `suggestionId` within the `Suggestion` object matches the ID of the
+   * suggestion being updated to ensure the correct document is replaced.
+   *
+   * @param tripId The unique identifier of the trip containing the suggestion.
+   * @param suggestion The updated `Suggestion` object.
+   * @return `true` if the suggestion was successfully updated, `false` otherwise. Errors during the
+   *   update process are logged.
+   */
+  suspend fun updateSuggestionInTrip(tripId: String, suggestion: Suggestion): Boolean =
+      withContext(dispatcher) {
+        try {
+          Log.d("TripsRepository", "updateSuggestionInTrip: Updating a Suggestion in trip $tripId")
+          val firestoreSuggestion = FirestoreSuggestion.fromSuggestion(suggestion)
+          tripsCollection
+              .document(tripId)
+              .collection(FirebaseCollections.SUGGESTIONS_SUBCOLLECTION.path)
+              .document(firestoreSuggestion.suggestionId)
+              .set(firestoreSuggestion)
+              .await()
+          Log.d(
+              "TripsRepository",
+              "updateSuggestionInTrip: Trip's Suggestion updated successfully for ID $tripId.")
+          true
+        } catch (e: Exception) {
+          Log.e(
+              "TripsRepository",
+              "updateSuggestionInTrip: Error updating stop with ID ${suggestion.suggestionId} in trip with ID $tripId",
+              e)
+          false
         }
+      }
 
   /**
    * Fetches a user's details for a specific trip. This method queries a subcollection within a trip

--- a/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
@@ -351,7 +351,7 @@ class TripsRepositoryTest {
     val suggestion1 =
         Suggestion(
             suggestionId = "",
-            userId = "user123",
+            userId = "",
             userName = "Alice",
             text =
                 "Suggesting a visit to the Colosseum, one of the greatest architectural achievements in Rome.",

--- a/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
@@ -2,15 +2,19 @@ package com.github.se.wanderpals.repository
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.github.se.wanderpals.model.data.Comment
 import com.github.se.wanderpals.model.data.GeoCords
 import com.github.se.wanderpals.model.data.Stop
+import com.github.se.wanderpals.model.data.Suggestion
 import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.data.User
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.google.firebase.FirebaseApp
+import junit.framework.TestCase.assertEquals
 import java.time.LocalDate
 import java.time.LocalTime
 import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
 import kotlin.system.measureTimeMillis
@@ -23,6 +27,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class TripsRepositoryTest {
@@ -311,8 +316,109 @@ class TripsRepositoryTest {
     println("Execution time for testTripLifecycleWithUsers: $elapsedTime ms")
   }
 
-  @After
+    @Test
+    fun testTripLifecycleWithSuggestions() = runBlocking {
+        // Initialize a trip with details for a summer vacation in Italy.
+        val trip = Trip(
+            tripId = "trip123",
+            title = "Summer Vacation",
+            startDate = LocalDate.of(2024, 5, 20),
+            endDate = LocalDate.of(2024, 6, 10),
+            totalBudget = 2000.0,
+            description = "Our summer vacation trip to Italy.",
+            imageUrl = "https://example.com/image.png",
+            stops = emptyList(),
+            users = emptyList(),
+            suggestions = emptyList()
+        )
+
+        // Initialize a stop within the suggestion for the trip.
+        val stop = Stop(
+            stopId = UUID.randomUUID().toString(),
+            title = "The Colosseum",
+            address = "Piazza del Colosseo, 1, 00184 Roma RM, Italy",
+            date = LocalDate.of(2024, 5, 21),
+            startTime = LocalTime.of(10, 0),
+            duration = 120,
+            budget = 50.0,
+            description = "Visit the iconic Roman Colosseum and learn about its history.",
+            geoCords = GeoCords(latitude = 41.8902, longitude = 12.4922),
+            website = "http://www.the-colosseum.net/",
+            imageUrl = "https://example.com/colosseum.png"
+        )
+
+        // Initialize a suggestion for the trip including the stop.
+        val suggestion1 = Suggestion(
+            suggestionId = "",
+            userId = "user123",
+            userName = "Alice",
+            text = "Suggesting a visit to the Colosseum, one of the greatest architectural achievements in Rome.",
+            createdAt = LocalDate.now(),
+            stop = stop, // Embed the Stop object directly within the suggestion.
+            comments = listOf(
+                Comment(
+                    commentId = "comment123",
+                    userId = "user456",
+                    userName = "Bob",
+                    text = "Great idea! It's a must-see.",
+                    createdAt = LocalDate.now()
+                )
+            )
+        )
+
+        val elapsedTime = measureTimeMillis {
+            try {
+                withTimeout(10000) {
+                    // Add the trip and validate the addition.
+                    assertTrue(repository.addTrip(trip))
+
+                    var fetchedTrip = repository.getTrip(repository.getTripsIds().first())!!
+                    // Add the suggestion to the trip and validate.
+                    assertTrue(repository.addSuggestionToTrip(tripId = fetchedTrip.tripId, suggestion1))
+
+                    // Validate that the suggestion was added successfully.
+                    val suggestions = repository.getAllSuggestionsFromTrip(fetchedTrip.tripId)
+
+                    assertTrue(suggestions.isNotEmpty())
+
+                    // Fetch and validate the added suggestion.
+                    fetchedTrip = repository.getTrip(repository.getTripsIds().first())!!
+
+                    val fetchedSuggestion = repository.getSuggestionFromTrip(fetchedTrip.tripId, fetchedTrip.suggestions.first())
+                    assertNotNull(fetchedSuggestion)
+                    assertEquals("Suggesting a visit to the Colosseum, one of the greatest architectural achievements in Rome.", fetchedSuggestion?.text)
+
+                    // Update the suggestion and validate the update.
+                    val updatedSuggestionText = "Updated: Visit both the Colosseum and nearby Roman Forum."
+                    assertTrue(repository.updateSuggestionInTrip(fetchedTrip.tripId, fetchedSuggestion!!.copy(text = updatedSuggestionText)))
+
+                    // Validate the update was successful.
+                    val updatedSuggestion = repository.getSuggestionFromTrip(fetchedTrip.tripId, fetchedTrip.suggestions.first())
+                    assertEquals(updatedSuggestionText, updatedSuggestion?.text)
+
+                    // Remove the suggestion from the trip and validate its removal.
+                    assertTrue(repository.removeSuggestionFromTrip(fetchedTrip.tripId, fetchedTrip.suggestions.first()))
+
+                    // Validate the suggestion list is empty after deletion.
+                    assertTrue(repository.getAllSuggestionsFromTrip(fetchedTrip.tripId).isEmpty())
+
+                    // Cleanup: Delete the trip.
+                    assertTrue(repository.deleteTrip(fetchedTrip.tripId))
+                }
+            } catch (e: TimeoutCancellationException) {
+                fail("The operation timed out after 10 seconds")
+            }
+        }
+        println("Execution time for testTripLifecycleWithSuggestions: $elapsedTime ms")
+    }
+
+
+    @After
   fun tearDown() = runBlocking {
+        //for debugging
+        // true false
+        val debug = false
+
     // Attempt to retrieve all trip IDs that might have been added during tests
     val tripIds =
         try {
@@ -325,15 +431,18 @@ class TripsRepositoryTest {
     tripIds.forEach { tripId ->
       try {
         val trip = repository.getTrip(tripId)
-        if (trip != null) {
-          val stopIds = trip.stops
 
+        if (trip != null && !debug) {
+          val stopIds = trip.stops
           stopIds.forEach { stopId ->
             repository.removeStopFromTrip(tripId, stopId)
           } // delete all stops
 
           val userIds = trip.users
           userIds.forEach { userId -> repository.removeUserFromTrip(tripId, userId) }
+
+            val suggestionIds = trip.suggestions
+            suggestionIds.forEach { suggestionId -> repository.removeSuggestionFromTrip(tripId, suggestionId) }
           repository.deleteTrip(tripId)
           repository.removeTripId(tripId)
         }

--- a/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
@@ -10,9 +10,10 @@ import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.data.User
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.google.firebase.FirebaseApp
-import junit.framework.TestCase.assertEquals
 import java.time.LocalDate
 import java.time.LocalTime
+import java.util.UUID
+import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertTrue
@@ -27,7 +28,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class TripsRepositoryTest {
@@ -316,10 +316,11 @@ class TripsRepositoryTest {
     println("Execution time for testTripLifecycleWithUsers: $elapsedTime ms")
   }
 
-    @Test
-    fun testTripLifecycleWithSuggestions() = runBlocking {
-        // Initialize a trip with details for a summer vacation in Italy.
-        val trip = Trip(
+  @Test
+  fun testTripLifecycleWithSuggestions() = runBlocking {
+    // Initialize a trip with details for a summer vacation in Italy.
+    val trip =
+        Trip(
             tripId = "trip123",
             title = "Summer Vacation",
             startDate = LocalDate.of(2024, 5, 20),
@@ -329,11 +330,11 @@ class TripsRepositoryTest {
             imageUrl = "https://example.com/image.png",
             stops = emptyList(),
             users = emptyList(),
-            suggestions = emptyList()
-        )
+            suggestions = emptyList())
 
-        // Initialize a stop within the suggestion for the trip.
-        val stop = Stop(
+    // Initialize a stop within the suggestion for the trip.
+    val stop =
+        Stop(
             stopId = UUID.randomUUID().toString(),
             title = "The Colosseum",
             address = "Piazza del Colosseo, 1, 00184 Roma RM, Italy",
@@ -344,80 +345,86 @@ class TripsRepositoryTest {
             description = "Visit the iconic Roman Colosseum and learn about its history.",
             geoCords = GeoCords(latitude = 41.8902, longitude = 12.4922),
             website = "http://www.the-colosseum.net/",
-            imageUrl = "https://example.com/colosseum.png"
-        )
+            imageUrl = "https://example.com/colosseum.png")
 
-        // Initialize a suggestion for the trip including the stop.
-        val suggestion1 = Suggestion(
+    // Initialize a suggestion for the trip including the stop.
+    val suggestion1 =
+        Suggestion(
             suggestionId = "",
             userId = "user123",
             userName = "Alice",
-            text = "Suggesting a visit to the Colosseum, one of the greatest architectural achievements in Rome.",
+            text =
+                "Suggesting a visit to the Colosseum, one of the greatest architectural achievements in Rome.",
             createdAt = LocalDate.now(),
             stop = stop, // Embed the Stop object directly within the suggestion.
-            comments = listOf(
-                Comment(
-                    commentId = "comment123",
-                    userId = "user456",
-                    userName = "Bob",
-                    text = "Great idea! It's a must-see.",
-                    createdAt = LocalDate.now()
-                )
-            )
-        )
+            comments =
+                listOf(
+                    Comment(
+                        commentId = "comment123",
+                        userId = "user456",
+                        userName = "Bob",
+                        text = "Great idea! It's a must-see.",
+                        createdAt = LocalDate.now())))
 
-        val elapsedTime = measureTimeMillis {
-            try {
-                withTimeout(10000) {
-                    // Add the trip and validate the addition.
-                    assertTrue(repository.addTrip(trip))
+    val elapsedTime = measureTimeMillis {
+      try {
+        withTimeout(10000) {
+          // Add the trip and validate the addition.
+          assertTrue(repository.addTrip(trip))
 
-                    var fetchedTrip = repository.getTrip(repository.getTripsIds().first())!!
-                    // Add the suggestion to the trip and validate.
-                    assertTrue(repository.addSuggestionToTrip(tripId = fetchedTrip.tripId, suggestion1))
+          var fetchedTrip = repository.getTrip(repository.getTripsIds().first())!!
+          // Add the suggestion to the trip and validate.
+          assertTrue(repository.addSuggestionToTrip(tripId = fetchedTrip.tripId, suggestion1))
 
-                    // Validate that the suggestion was added successfully.
-                    val suggestions = repository.getAllSuggestionsFromTrip(fetchedTrip.tripId)
+          // Validate that the suggestion was added successfully.
+          val suggestions = repository.getAllSuggestionsFromTrip(fetchedTrip.tripId)
 
-                    assertTrue(suggestions.isNotEmpty())
+          assertTrue(suggestions.isNotEmpty())
 
-                    // Fetch and validate the added suggestion.
-                    fetchedTrip = repository.getTrip(repository.getTripsIds().first())!!
+          // Fetch and validate the added suggestion.
+          fetchedTrip = repository.getTrip(repository.getTripsIds().first())!!
 
-                    val fetchedSuggestion = repository.getSuggestionFromTrip(fetchedTrip.tripId, fetchedTrip.suggestions.first())
-                    assertNotNull(fetchedSuggestion)
-                    assertEquals("Suggesting a visit to the Colosseum, one of the greatest architectural achievements in Rome.", fetchedSuggestion?.text)
+          val fetchedSuggestion =
+              repository.getSuggestionFromTrip(fetchedTrip.tripId, fetchedTrip.suggestions.first())
+          assertNotNull(fetchedSuggestion)
+          assertEquals(
+              "Suggesting a visit to the Colosseum, one of the greatest architectural achievements in Rome.",
+              fetchedSuggestion?.text)
 
-                    // Update the suggestion and validate the update.
-                    val updatedSuggestionText = "Updated: Visit both the Colosseum and nearby Roman Forum."
-                    assertTrue(repository.updateSuggestionInTrip(fetchedTrip.tripId, fetchedSuggestion!!.copy(text = updatedSuggestionText)))
+          // Update the suggestion and validate the update.
+          val updatedSuggestionText = "Updated: Visit both the Colosseum and nearby Roman Forum."
+          assertTrue(
+              repository.updateSuggestionInTrip(
+                  fetchedTrip.tripId, fetchedSuggestion!!.copy(text = updatedSuggestionText)))
 
-                    // Validate the update was successful.
-                    val updatedSuggestion = repository.getSuggestionFromTrip(fetchedTrip.tripId, fetchedTrip.suggestions.first())
-                    assertEquals(updatedSuggestionText, updatedSuggestion?.text)
+          // Validate the update was successful.
+          val updatedSuggestion =
+              repository.getSuggestionFromTrip(fetchedTrip.tripId, fetchedTrip.suggestions.first())
+          assertEquals(updatedSuggestionText, updatedSuggestion?.text)
 
-                    // Remove the suggestion from the trip and validate its removal.
-                    assertTrue(repository.removeSuggestionFromTrip(fetchedTrip.tripId, fetchedTrip.suggestions.first()))
+          // Remove the suggestion from the trip and validate its removal.
+          assertTrue(
+              repository.removeSuggestionFromTrip(
+                  fetchedTrip.tripId, fetchedTrip.suggestions.first()))
 
-                    // Validate the suggestion list is empty after deletion.
-                    assertTrue(repository.getAllSuggestionsFromTrip(fetchedTrip.tripId).isEmpty())
+          // Validate the suggestion list is empty after deletion.
+          assertTrue(repository.getAllSuggestionsFromTrip(fetchedTrip.tripId).isEmpty())
 
-                    // Cleanup: Delete the trip.
-                    assertTrue(repository.deleteTrip(fetchedTrip.tripId))
-                }
-            } catch (e: TimeoutCancellationException) {
-                fail("The operation timed out after 10 seconds")
-            }
+          // Cleanup: Delete the trip.
+          assertTrue(repository.deleteTrip(fetchedTrip.tripId))
         }
-        println("Execution time for testTripLifecycleWithSuggestions: $elapsedTime ms")
+      } catch (e: TimeoutCancellationException) {
+        fail("The operation timed out after 10 seconds")
+      }
     }
+    println("Execution time for testTripLifecycleWithSuggestions: $elapsedTime ms")
+  }
 
-
-    @After
+  @After
   fun tearDown() = runBlocking {
-        //for debugging
-        // true false
-        val debug = false
+    // for debugging
+    // true false
+    val debug = false
 
     // Attempt to retrieve all trip IDs that might have been added during tests
     val tripIds =
@@ -441,8 +448,10 @@ class TripsRepositoryTest {
           val userIds = trip.users
           userIds.forEach { userId -> repository.removeUserFromTrip(tripId, userId) }
 
-            val suggestionIds = trip.suggestions
-            suggestionIds.forEach { suggestionId -> repository.removeSuggestionFromTrip(tripId, suggestionId) }
+          val suggestionIds = trip.suggestions
+          suggestionIds.forEach { suggestionId ->
+            repository.removeSuggestionFromTrip(tripId, suggestionId)
+          }
           repository.deleteTrip(tripId)
           repository.removeTripId(tripId)
         }


### PR DESCRIPTION
This pull request adds essential methods for managing suggestions within trips and introduces tests that cover basic scenarios for each method. The core functionalities implemented are:

addSuggestionToTrip: Facilitates the addition of new suggestions to a trip.
updateSuggestionInTrip: Enables updating details of an existing suggestion.
removeSuggestionFromTrip: Allows for the removal of a suggestion from a trip.
getSuggestionFromTrip and getAllSuggestionsFromTrip: Provides mechanisms to fetch suggestions, either a specific one or all associated with a trip.
The accompanying tests ensure these methods perform correctly under straightforward conditions, laying the groundwork for future, more complex test scenarios.