### PR TITLE
Fixed Bug with navigation

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
@@ -39,7 +39,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-class OverviewViewModelTest() :
+class OverviewViewModelTest :
     OverviewViewModel(TripsRepository("-1", dispatcher = Dispatchers.IO)) {
   private val trip1 =
       Trip(
@@ -336,7 +336,10 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
         assertIsDisplayed()
         performClick()
       }
-      verify { mockNavActions.navigateTo(Route.TRIP + "/1") }
+      verify {
+        mockNavActions.currentTrip = "1"
+        mockNavActions.navigateTo(Route.TRIP)
+      }
       confirmVerified(mockNavActions)
     }
   }

--- a/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
+++ b/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
@@ -97,10 +97,9 @@ class MainActivity : ComponentActivity() {
                   overviewViewModel = OverviewViewModel(tripsRepository),
                   navigationActions = navigationActions)
             }
-            composable(Route.TRIP + "/{tripId}") { navBackStackEntry ->
+            composable(Route.TRIP) { navBackStackEntry ->
               BackHandler(true) {}
-              val tripId = navBackStackEntry.arguments?.getString("tripId") ?: ""
-              Trip(navigationActions, tripId, tripsRepository, placesClient)
+              Trip(navigationActions, navigationActions.currentTrip, tripsRepository, placesClient)
             }
             composable(Route.CREATE_TRIP) {
               BackHandler(true) {}

--- a/app/src/main/java/com/github/se/wanderpals/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/navigation/NavigationActions.kt
@@ -13,6 +13,9 @@ import androidx.navigation.compose.currentBackStackEntryAsState
  * @param navController The navigation controller.
  */
 class NavigationActions(private val navController: NavHostController) {
+
+  var currentTrip = ""
+
   /**
    * Navigate to a specific route.
    *

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -90,7 +90,10 @@ fun OverviewTrip(trip: Trip, navigationActions: NavigationActions) {
   Box(modifier = Modifier.fillMaxWidth()) {
     // Button representing the trip overview
     Button(
-        onClick = { navigationActions.navigateTo(Route.TRIP + "/${trip.tripId}") },
+        onClick = {
+          navigationActions.currentTrip = trip.tripId
+          navigationActions.navigateTo(Route.TRIP)
+        },
         modifier =
             Modifier.align(Alignment.TopCenter)
                 .width(360.dp)


### PR DESCRIPTION
We have detected an issue when going to a Trip 1, going back to the list of Trips in Overview, and then to going Trip 2. The navigation brings you inside of the Trip 1 and not the Trip 2.

After multiple tries, the simplest solution was to store the tripId inside of the NavAction directly

@AgeX21 originally found the bug