### PR TITLE
Removed testDebugUnitTest from grable of apk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
       # Run Build Project
       - name: Build gradle project
-        run: ./gradlew build
+        run: ./gradlew build -x app:testDebugUnitTest
 
       # Upload Artifact Build
       - name: Upload APK Debug


### PR DESCRIPTION
I've found a fix for the APK Generation that should work every time now with an added exclusion of testDebugUnitTest that I didn't know was possible before.

Sorry for the 3 related PRs and commits that where done to achieve this