### PR TITLE
Adding more Logging inside of MainActivity and making the CI Action APK run more often

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     types:
       - closed
+      - synchronize
+      - reopened
 
 jobs:
   build:

--- a/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
+++ b/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
@@ -48,19 +48,22 @@ class MainActivity : ComponentActivity() {
         task.addOnSuccessListener { account ->
           val googleTokenId = account.idToken ?: ""
           val credential = GoogleAuthProvider.getCredential(googleTokenId, null)
-          FirebaseAuth.getInstance().signInWithCredential(credential).addOnCompleteListener {
-            if (it.isSuccessful) {
-
-              val uid = it.result?.user?.uid ?: ""
-              tripsRepository = TripsRepository(uid, Dispatchers.IO)
-              tripsRepository.initFirestore()
-              Log.d("SignIn", "Login result " + account.displayName)
-              navigationActions.navigateTo(Route.OVERVIEW)
-              // previously sign out
-            } else {
-              Log.d("MainActivity", "SignIn: Firebase Login Failed")
-            }
-          }
+          FirebaseAuth.getInstance()
+              .signInWithCredential(credential)
+              .addOnCompleteListener {
+                if (it.isSuccessful) {
+                  Log.d("MainActivity", "SignIn: Firebase Login Completed Successfully")
+                  val uid = it.result?.user?.uid ?: ""
+                  tripsRepository = TripsRepository(uid, Dispatchers.IO)
+                  tripsRepository.initFirestore()
+                  Log.d("SignIn", "Login result " + account.displayName)
+                  navigationActions.navigateTo(Route.OVERVIEW)
+                } else {
+                  Log.d("MainActivity", "SignIn: Firebase Login Completed Unsuccessfully")
+                }
+              }
+              .addOnFailureListener { Log.d("MainActivity", "SignIn: Firebase Login Failed") }
+              .addOnCanceledListener { Log.d("MainActivity", "SignIn: Firebase Login Canceled") }
         }
       }
 


### PR DESCRIPTION
Adding a lot more Logging to see why the APK generated by the CI Action can't go further than the SignIn Screen and made the CI Action of building the APK constantly run on new commits inside of this PR

APK generated locally with the same commands produces an APK that works perfectly fine