### PR TITLE
Create trip notification repository methods

### DIFF
--- a/app/src/main/java/com/github/se/wanderpals/model/repository/FirebaseCollections.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/FirebaseCollections.kt
@@ -5,5 +5,6 @@ enum class FirebaseCollections(val path: String) {
   USERS_TO_TRIPS_IDS("UsersToTripIds"),
   STOPS_SUBCOLLECTION("Stops"),
   USERS_SUBCOLLECTION("Users"),
-  SUGGESTIONS_SUBCOLLECTION("Suggestions")
+  SUGGESTIONS_SUBCOLLECTION("Suggestions"),
+  TRIPS_NOTIFICATION_SUBCOLLECTION("TripsNotifications")
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -66,206 +66,226 @@ class TripsRepository(
     tripsCollection = firestore.collection(FirebaseCollections.TRIPS.path)
   }
 
-
-    /**
-     * Retrieves a specific trip notification from a trip based on the notification's unique identifier.
-     * This method queries the Firestore subcollection for trip notifications within a specific trip document.
-     *
-     * @param tripId The unique identifier of the trip.
-     * @param tripNotificationId The unique identifier of the trip notification to be retrieved.
-     * @return A `TripNotification` object if found, or `null` if the notification is not found or if an error occurs.
-     * The method logs an error and returns `null` in case of failure.
-     */
-    suspend fun getTripNotificationFromTrip(tripId: String, tripNotificationId: String): TripNotification? =
-        withContext(dispatcher) {
-            try {
-                val documentSnapshot =
-                    tripsCollection
-                        .document(tripId)
-                        .collection(FirebaseCollections.TRIPS_NOTIFICATION_SUBCOLLECTION.path)
-                        .document(tripNotificationId)
-                        .get()
-                        .await()
-                val firestoreTripNotification = documentSnapshot.toObject<FirestoreTripNotification>()
-                if (firestoreTripNotification != null) {
-                    firestoreTripNotification.toTripNotification()
-                } else {
-                    Log.e(
-                        "TripsRepository",
-                        "getTripNotificationFromTrip: Not found TripNotification $tripNotificationId from trip $tripId.")
-                    null
-                }
-            } catch (e: Exception) {
-                Log.e(
-                    "TripsRepository",
-                    "getTripNotificationFromTrip: Error getting a TripNotification $tripNotificationId from trip $tripId.",
-                    e)
-                null // error
-            }
+  /**
+   * Retrieves a specific trip notification from a trip based on the notification's unique
+   * identifier. This method queries the Firestore subcollection for trip notifications within a
+   * specific trip document.
+   *
+   * @param tripId The unique identifier of the trip.
+   * @param tripNotificationId The unique identifier of the trip notification to be retrieved.
+   * @return A `TripNotification` object if found, or `null` if the notification is not found or if
+   *   an error occurs. The method logs an error and returns `null` in case of failure.
+   */
+  suspend fun getTripNotificationFromTrip(
+      tripId: String,
+      tripNotificationId: String
+  ): TripNotification? =
+      withContext(dispatcher) {
+        try {
+          val documentSnapshot =
+              tripsCollection
+                  .document(tripId)
+                  .collection(FirebaseCollections.TRIPS_NOTIFICATION_SUBCOLLECTION.path)
+                  .document(tripNotificationId)
+                  .get()
+                  .await()
+          val firestoreTripNotification = documentSnapshot.toObject<FirestoreTripNotification>()
+          if (firestoreTripNotification != null) {
+            firestoreTripNotification.toTripNotification()
+          } else {
+            Log.e(
+                "TripsRepository",
+                "getTripNotificationFromTrip: Not found TripNotification $tripNotificationId from trip $tripId.")
+            null
+          }
+        } catch (e: Exception) {
+          Log.e(
+              "TripsRepository",
+              "getTripNotificationFromTrip: Error getting a TripNotification $tripNotificationId from trip $tripId.",
+              e)
+          null // error
         }
+      }
 
+  /**
+   * Retrieves all trip notifications associated with a specific trip. It iterates over all
+   * notification IDs stored within the trip document and fetches their corresponding trip
+   * notification objects.
+   *
+   * @param tripId The unique identifier of the trip.
+   * @return A list of `TripNotification` objects. Returns an empty list if the trip is not found,
+   *   if there are no notifications associated with the trip, or in case of an error during data
+   *   retrieval.
+   */
+  suspend fun getAllTripNotificationsFromTrip(tripId: String): List<TripNotification> =
+      withContext(dispatcher) {
+        try {
+          val trip = getTrip(tripId)
 
-    /**
-     * Retrieves all trip notifications associated with a specific trip. It iterates over all notification IDs
-     * stored within the trip document and fetches their corresponding trip notification objects.
-     *
-     * @param tripId The unique identifier of the trip.
-     * @return A list of `TripNotification` objects. Returns an empty list if the trip is not found, if
-     * there are no notifications associated with the trip, or in case of an error during data retrieval.
-     */
-    suspend fun getAllTripNotificationsFromTrip(tripId: String): List<TripNotification> =
-        withContext(dispatcher) {
-            try {
-                val trip = getTrip(tripId)
-
-                if (trip != null) {
-                    val tripNotificationIds = trip.tripNotifications
-                    tripNotificationIds.mapNotNull { tripNotificationId -> getTripNotificationFromTrip(tripId, tripNotificationId) }
-                } else {
-                    Log.e("TripsRepository", "getAllTripNotificationsFromTrip: Trip not found with ID $tripId.")
-                    emptyList()
-                }
-            } catch (e: Exception) {
-
-                Log.e(
-                    "TripsRepository",
-                    "getAllTripNotificationsFromTrip: Error fetching TripNotification to trip $tripId.",
-                    e)
-                emptyList()
+          if (trip != null) {
+            val tripNotificationIds = trip.tripNotifications
+            tripNotificationIds.mapNotNull { tripNotificationId ->
+              getTripNotificationFromTrip(tripId, tripNotificationId)
             }
+          } else {
+            Log.e(
+                "TripsRepository",
+                "getAllTripNotificationsFromTrip: Trip not found with ID $tripId.")
+            emptyList()
+          }
+        } catch (e: Exception) {
+
+          Log.e(
+              "TripsRepository",
+              "getAllTripNotificationsFromTrip: Error fetching TripNotification to trip $tripId.",
+              e)
+          emptyList()
         }
+      }
 
+  /**
+   * Adds a notification to a specific trip in the Firestore database. This method generates a
+   * unique ID for the new notification, creates a corresponding FirestoreTripNotification object,
+   * and commits it to the trip's notification subcollection.
+   *
+   * It also updates the trip's document to include this new notification ID in its list.
+   *
+   * @param tripId The unique identifier of the trip where the notification will be added.
+   * @param tripNotification The TripNotification object to add.
+   * @return Boolean indicating the success (true) or failure (false) of the operation.
+   */
+  suspend fun addTripNotificationToTrip(
+      tripId: String,
+      tripNotification: TripNotification
+  ): Boolean =
+      withContext(dispatcher) {
+        try {
+          val uniqueID = UUID.randomUUID().toString()
+          val firebaseTripNotification =
+              FirestoreTripNotification.fromTripNotification(
+                  tripNotification.copy(
+                      notificationId = uniqueID,
+                      userId = uid)) // we already know who creates the TripNotification
+          val tripNotificationDocument =
+              tripsCollection
+                  .document(tripId)
+                  .collection(FirebaseCollections.TRIPS_NOTIFICATION_SUBCOLLECTION.path)
+                  .document(uniqueID)
+          tripNotificationDocument.set(firebaseTripNotification).await()
+          Log.d(
+              "TripsRepository",
+              "addTripNotificationToTrip: TripNotification added successfully to trip $tripId.")
 
-    /**
-     * Adds a notification to a specific trip in the Firestore database. This method generates a unique ID for the new
-     * notification, creates a corresponding FirestoreTripNotification object, and commits it to the trip's
-     * notification subcollection.
-     *
-     * It also updates the trip's document to include this new notification ID in its list.
-     *
-     * @param tripId The unique identifier of the trip where the notification will be added.
-     * @param tripNotification The TripNotification object to add.
-     * @return Boolean indicating the success (true) or failure (false) of the operation.
-     */
-    suspend fun addTripNotificationToTrip(tripId: String, tripNotification: TripNotification): Boolean =
-        withContext(dispatcher) {
-            try {
-                val uniqueID = UUID.randomUUID().toString()
-                val firebaseTripNotification =
-                    FirestoreTripNotification.fromTripNotification(
-                        tripNotification.copy(
-                            notificationId = uniqueID,
-                            userId = uid)) // we already know who creates the TripNotification
-                val tripNotificationDocument =
-                    tripsCollection
-                        .document(tripId)
-                        .collection(FirebaseCollections.TRIPS_NOTIFICATION_SUBCOLLECTION.path)
-                        .document(uniqueID)
-                tripNotificationDocument.set(firebaseTripNotification).await()
-                Log.d(
-                    "TripsRepository",
-                    "addTripNotificationToTrip: TripNotification added successfully to trip $tripId.")
+          val trip = getTrip(tripId)
+          if (trip != null) {
+            // Add the new tripNotificationId to the trip's tripsNotifications list and update the
+            // trip
+            val updatedTripNotificationsList = trip.tripNotifications + uniqueID
+            val updatedTrip = trip.copy(tripNotifications = updatedTripNotificationsList)
+            updateTrip(updatedTrip)
+            Log.d(
+                "TripsRepository",
+                "addTripNotificationToTrip: TripNotification ID added to trip successfully.")
+            true
+          } else {
 
-                val trip = getTrip(tripId)
-                if (trip != null) {
-                    // Add the new tripNotificationId to the trip's tripsNotifications list and update the trip
-                    val updatedTripNotificationsList = trip.tripNotifications + uniqueID
-                    val updatedTrip = trip.copy(tripNotifications = updatedTripNotificationsList)
-                    updateTrip(updatedTrip)
-                    Log.d(
-                        "TripsRepository", "addTripNotificationToTrip: TripNotification ID added to trip successfully.")
-                    true
-                } else {
-
-                    Log.e("TripsRepository", "addTripNotificationToTrip: Trip not found with ID $tripId.")
-                    false
-                }
-            } catch (e: Exception) {
-                Log.e(
-                    "TripsRepository", "addTripNotificationToTrip: Error adding TripNotification to trip $tripId.", e)
-                false
-            }
+            Log.e("TripsRepository", "addTripNotificationToTrip: Trip not found with ID $tripId.")
+            false
+          }
+        } catch (e: Exception) {
+          Log.e(
+              "TripsRepository",
+              "addTripNotificationToTrip: Error adding TripNotification to trip $tripId.",
+              e)
+          false
         }
+      }
 
+  /**
+   * Removes a specific notification from a trip's notification list and the Firestore database.
+   * This method first deletes the notification document from the trip's notification subcollection.
+   *
+   * It also updates the trip's document to remove the notification ID from its list.
+   *
+   * @param tripId The unique identifier of the trip.
+   * @param tripNotificationId The unique identifier of the notification to be removed.
+   * @return Boolean indicating the success (true) or failure (false) of the operation.
+   */
+  suspend fun removeTripNotificationFromTrip(tripId: String, tripNotificationId: String): Boolean =
+      withContext(dispatcher) {
+        try {
+          Log.d(
+              "TripsRepository",
+              "removeSuggestionFromTrip: removing TripNotification $tripNotificationId from trip $tripId")
+          tripsCollection
+              .document(tripId)
+              .collection(FirebaseCollections.TRIPS_NOTIFICATION_SUBCOLLECTION.path)
+              .document(tripNotificationId)
+              .delete()
+              .await()
 
-    /**
-     * Removes a specific notification from a trip's notification list and the Firestore database.
-     * This method first deletes the notification document from the trip's notification subcollection.
-     *
-     * It also updates the trip's document to remove the notification ID from its list.
-     *
-     * @param tripId The unique identifier of the trip.
-     * @param tripNotificationId The unique identifier of the notification to be removed.
-     * @return Boolean indicating the success (true) or failure (false) of the operation.
-     */
-    suspend fun removeTripNotificationFromTrip(tripId: String, tripNotificationId: String): Boolean =
-        withContext(dispatcher) {
-            try {
-                Log.d(
-                    "TripsRepository",
-                    "removeSuggestionFromTrip: removing TripNotification $tripNotificationId from trip $tripId")
-                tripsCollection
-                    .document(tripId)
-                    .collection(FirebaseCollections.TRIPS_NOTIFICATION_SUBCOLLECTION.path)
-                    .document(tripNotificationId)
-                    .delete()
-                    .await()
-
-                val trip = getTrip(tripId)
-                if (trip != null) {
-                    val updatedTripNotificationsList = trip.tripNotifications.filterNot { it == tripNotificationId }
-                    val updatedTrip = trip.copy(suggestions = updatedTripNotificationsList)
-                    updateTrip(updatedTrip)
-                    Log.d(
-                        "TripsRepository",
-                        "removeSuggestionFromTrip: TripNotification $tripNotificationId remove and trip updated successfully.")
-                    true
-                } else {
-                    Log.e("TripsRepository", "removeSuggestionFromTrip: Trip not found with ID $tripId.")
-                    false
-                }
-            } catch (e: Exception) {
-                Log.e(
-                    "TripsRepository",
-                    "removeSuggestionFromTrip: Error removing TripNotification $tripNotificationId from trip $tripId.",
-                    e)
-                false
-            }
+          val trip = getTrip(tripId)
+          if (trip != null) {
+            val updatedTripNotificationsList =
+                trip.tripNotifications.filterNot { it == tripNotificationId }
+            val updatedTrip = trip.copy(suggestions = updatedTripNotificationsList)
+            updateTrip(updatedTrip)
+            Log.d(
+                "TripsRepository",
+                "removeSuggestionFromTrip: TripNotification $tripNotificationId remove and trip updated successfully.")
+            true
+          } else {
+            Log.e("TripsRepository", "removeSuggestionFromTrip: Trip not found with ID $tripId.")
+            false
+          }
+        } catch (e: Exception) {
+          Log.e(
+              "TripsRepository",
+              "removeSuggestionFromTrip: Error removing TripNotification $tripNotificationId from trip $tripId.",
+              e)
+          false
         }
+      }
 
-
-    /**
-     * Updates a specific notification in a trip's notification subcollection in the Firestore database.
-     * This method creates a FirestoreTripNotification object from the provided TripNotification object
-     * and sets it to the corresponding document identified by the notification ID.
-     *
-     * @param tripId The unique identifier of the trip.
-     * @param tripNotification The TripNotification object that contains updated data.
-     * @return Boolean indicating the success (true) or failure (false) of the operation.
-     */
-    suspend fun updateTripNotificationInTrip(tripId: String, tripNotification: TripNotification): Boolean =
-        withContext(dispatcher) {
-            try {
-                Log.d("TripsRepository", "updateTripNotificationInTrip: Updating a TripNotification in trip $tripId")
-                val firestoreTripNotification = FirestoreTripNotification.fromTripNotification(tripNotification)
-                tripsCollection
-                    .document(tripId)
-                    .collection(FirebaseCollections.TRIPS_NOTIFICATION_SUBCOLLECTION.path)
-                    .document(firestoreTripNotification.notificationId)
-                    .set(firestoreTripNotification)
-                    .await()
-                Log.d(
-                    "TripsRepository",
-                    "updateTripNotificationInTrip: Trip's TripNotification updated successfully for ID $tripId.")
-                true
-            } catch (e: Exception) {
-                Log.e(
-                    "TripsRepository",
-                    "updateTripNotificationInTrip: Error updating tripNotification with ID ${tripNotification.notificationId} in trip with ID $tripId",
-                    e)
-                false
-            }
+  /**
+   * Updates a specific notification in a trip's notification subcollection in the Firestore
+   * database. This method creates a FirestoreTripNotification object from the provided
+   * TripNotification object and sets it to the corresponding document identified by the
+   * notification ID.
+   *
+   * @param tripId The unique identifier of the trip.
+   * @param tripNotification The TripNotification object that contains updated data.
+   * @return Boolean indicating the success (true) or failure (false) of the operation.
+   */
+  suspend fun updateTripNotificationInTrip(
+      tripId: String,
+      tripNotification: TripNotification
+  ): Boolean =
+      withContext(dispatcher) {
+        try {
+          Log.d(
+              "TripsRepository",
+              "updateTripNotificationInTrip: Updating a TripNotification in trip $tripId")
+          val firestoreTripNotification =
+              FirestoreTripNotification.fromTripNotification(tripNotification)
+          tripsCollection
+              .document(tripId)
+              .collection(FirebaseCollections.TRIPS_NOTIFICATION_SUBCOLLECTION.path)
+              .document(firestoreTripNotification.notificationId)
+              .set(firestoreTripNotification)
+              .await()
+          Log.d(
+              "TripsRepository",
+              "updateTripNotificationInTrip: Trip's TripNotification updated successfully for ID $tripId.")
+          true
+        } catch (e: Exception) {
+          Log.e(
+              "TripsRepository",
+              "updateTripNotificationInTrip: Error updating tripNotification with ID ${tripNotification.notificationId} in trip with ID $tripId",
+              e)
+          false
         }
+      }
 
   /**
    * Retrieves a specific suggestion from a trip based on the suggestion's unique identifier. This

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -250,7 +250,7 @@ class TripsRepository(
                 val firestoreTripNotification = FirestoreTripNotification.fromTripNotification(tripNotification)
                 tripsCollection
                     .document(tripId)
-                    .collection(FirebaseCollections.SUGGESTIONS_SUBCOLLECTION.path)
+                    .collection(FirebaseCollections.TRIPS_NOTIFICATION_SUBCOLLECTION.path)
                     .document(firestoreTripNotification.notificationId)
                     .set(firestoreTripNotification)
                     .await()

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -67,6 +67,15 @@ class TripsRepository(
   }
 
 
+    /**
+     * Retrieves a specific trip notification from a trip based on the notification's unique identifier.
+     * This method queries the Firestore subcollection for trip notifications within a specific trip document.
+     *
+     * @param tripId The unique identifier of the trip.
+     * @param tripNotificationId The unique identifier of the trip notification to be retrieved.
+     * @return A `TripNotification` object if found, or `null` if the notification is not found or if an error occurs.
+     * The method logs an error and returns `null` in case of failure.
+     */
     suspend fun getTripNotificationFromTrip(tripId: String, tripNotificationId: String): TripNotification? =
         withContext(dispatcher) {
             try {
@@ -96,6 +105,14 @@ class TripsRepository(
         }
 
 
+    /**
+     * Retrieves all trip notifications associated with a specific trip. It iterates over all notification IDs
+     * stored within the trip document and fetches their corresponding trip notification objects.
+     *
+     * @param tripId The unique identifier of the trip.
+     * @return A list of `TripNotification` objects. Returns an empty list if the trip is not found, if
+     * there are no notifications associated with the trip, or in case of an error during data retrieval.
+     */
     suspend fun getAllTripNotificationsFromTrip(tripId: String): List<TripNotification> =
         withContext(dispatcher) {
             try {
@@ -119,6 +136,17 @@ class TripsRepository(
         }
 
 
+    /**
+     * Adds a notification to a specific trip in the Firestore database. This method generates a unique ID for the new
+     * notification, creates a corresponding FirestoreTripNotification object, and commits it to the trip's
+     * notification subcollection.
+     *
+     * It also updates the trip's document to include this new notification ID in its list.
+     *
+     * @param tripId The unique identifier of the trip where the notification will be added.
+     * @param tripNotification The TripNotification object to add.
+     * @return Boolean indicating the success (true) or failure (false) of the operation.
+     */
     suspend fun addTripNotificationToTrip(tripId: String, tripNotification: TripNotification): Boolean =
         withContext(dispatcher) {
             try {
@@ -160,6 +188,16 @@ class TripsRepository(
         }
 
 
+    /**
+     * Removes a specific notification from a trip's notification list and the Firestore database.
+     * This method first deletes the notification document from the trip's notification subcollection.
+     *
+     * It also updates the trip's document to remove the notification ID from its list.
+     *
+     * @param tripId The unique identifier of the trip.
+     * @param tripNotificationId The unique identifier of the notification to be removed.
+     * @return Boolean indicating the success (true) or failure (false) of the operation.
+     */
     suspend fun removeTripNotificationFromTrip(tripId: String, tripNotificationId: String): Boolean =
         withContext(dispatcher) {
             try {
@@ -196,6 +234,15 @@ class TripsRepository(
         }
 
 
+    /**
+     * Updates a specific notification in a trip's notification subcollection in the Firestore database.
+     * This method creates a FirestoreTripNotification object from the provided TripNotification object
+     * and sets it to the corresponding document identified by the notification ID.
+     *
+     * @param tripId The unique identifier of the trip.
+     * @param tripNotification The TripNotification object that contains updated data.
+     * @return Boolean indicating the success (true) or failure (false) of the operation.
+     */
     suspend fun updateTripNotificationInTrip(tripId: String, tripNotification: TripNotification): Boolean =
         withContext(dispatcher) {
             try {

--- a/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/repository/TripsRepositoryTest.kt
@@ -8,6 +8,7 @@ import com.github.se.wanderpals.model.data.Role
 import com.github.se.wanderpals.model.data.Stop
 import com.github.se.wanderpals.model.data.Suggestion
 import com.github.se.wanderpals.model.data.Trip
+import com.github.se.wanderpals.model.data.TripNotification
 import com.github.se.wanderpals.model.data.User
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.google.firebase.FirebaseApp
@@ -29,6 +30,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.time.LocalDateTime
 
 @RunWith(RobolectricTestRunner::class)
 class TripsRepositoryTest {
@@ -432,6 +434,98 @@ class TripsRepositoryTest {
     println("Execution time for testTripLifecycleWithSuggestions: $elapsedTime ms")
   }
 
+    @Test
+    fun testTripLifecycleWithTripNotifications() = runBlocking {
+        // Initialize a trip with details for a summer vacation in Italy.
+        val trip =
+            Trip(
+                tripId = "trip123",
+                title = "Summer Vacation",
+                startDate = LocalDate.of(2024, 5, 20),
+                endDate = LocalDate.of(2024, 6, 10),
+                totalBudget = 2000.0,
+                description = "Our summer vacation trip to Italy.",
+                imageUrl = "https://example.com/image.png",
+                stops = emptyList(),
+                users = emptyList(),
+                suggestions = emptyList(),
+                tripNotifications = emptyList())
+
+        // Define a trip notification object.
+        val tripNotification = TripNotification(
+            notificationId = "",
+            userId = "user123",
+            title = "Flight Booking Reminder",
+            userName = "System",
+            description = "Reminder to book your flight to Italy",
+            timestamp = LocalDateTime.now()
+        )
+
+        val elapsedTime = measureTimeMillis {
+            try {
+                withTimeout(10000) {
+                    // Add the trip and validate the addition.
+                    assertTrue(repository.addTrip(trip))
+
+                    var fetchedTrip = repository.getTrip(repository.getTripsIds().first())!!
+                    // Add a trip notification to the trip and validate.
+                    assertTrue(repository.addTripNotificationToTrip(tripId = fetchedTrip.tripId, tripNotification))
+
+                    // Fetch and validate the added trip notification.
+                    val notifications = repository.getAllTripNotificationsFromTrip(fetchedTrip.tripId)
+                    assertTrue(notifications.isNotEmpty())
+
+                    val fetchedNotification = notifications.first()
+                    assertNotNull(fetchedNotification)
+                    assertEquals("Reminder to book your flight to Italy", fetchedNotification.description)
+
+
+                    // Fetch and validate the added suggestion.
+                    fetchedTrip = repository.getTrip(repository.getTripsIds().first())!!
+
+
+
+
+                    val fetchedTripNotification =
+                        repository.getTripNotificationFromTrip(fetchedTrip.tripId, fetchedTrip.tripNotifications.first())
+                    assertNotNull(fetchedTripNotification)
+                    assertEquals(
+                        "Reminder to book your flight to Italy",
+                        fetchedTripNotification?.description)
+
+
+
+
+
+                    // Update the trip notification and validate the update.
+                    val updatedNotification = fetchedNotification.copy(description = "Updated: Confirm your hotel booking as well.")
+                    assertTrue(repository.updateTripNotificationInTrip(fetchedTrip.tripId, updatedNotification))
+
+                    // Validate the update was successful.
+                    val updatedFetchedNotification = repository.getTripNotificationFromTrip(fetchedTrip.tripId, updatedNotification.notificationId)
+                    assertNotNull(updatedFetchedNotification)
+                    assertEquals("Updated: Confirm your hotel booking as well.", updatedFetchedNotification?.description)
+
+
+
+                    // Remove the suggestion from the trip and validate its removal.
+                    assertTrue(
+                        repository.removeTripNotificationFromTrip(
+                            fetchedTrip.tripId, fetchedTrip.tripNotifications.first()))
+
+                    // Validate the suggestion list is empty after deletion.
+                    assertTrue(repository.getAllTripNotificationsFromTrip(fetchedTrip.tripId).isEmpty())
+
+                    // Cleanup: Delete the trip.
+                    assertTrue(repository.deleteTrip(fetchedTrip.tripId))
+                }
+            } catch (e: TimeoutCancellationException) {
+                fail("The operation timed out after 10 seconds")
+            }
+        }
+        println("Execution time for testTripLifecycleWithSuggestions: $elapsedTime ms")
+    }
+
   @After
   fun tearDown() = runBlocking {
     // for debugging
@@ -464,6 +558,9 @@ class TripsRepositoryTest {
           suggestionIds.forEach { suggestionId ->
             repository.removeSuggestionFromTrip(tripId, suggestionId)
           }
+
+            val tripNotificationIds = trip.tripNotifications
+            tripNotificationIds.forEach { tripNotificationId -> repository.removeTripNotificationFromTrip(tripId, tripNotificationId) }
           repository.deleteTrip(tripId)
           repository.removeTripId(tripId)
         }


### PR DESCRIPTION
This pull request introduces a series of updates to the TripsRepository class to manage trip notifications within our application. Specifically, it adds methods for adding, retrieving, updating, and removing trip notifications from a Firestore database. Each method ensures robust error handling and logs appropriate messages for debugging purposes. The tests in testTripLifecycleWithTripNotifications validate the basic behaviors of these methods, ensuring that trip notifications can be added, retrieved, updated, and removed correctly, and that changes persist in the database as expected. These tests help guarantee the reliability and functionality of our trip notification management system within the application.