### PR TITLE
Fixing flickering and ViewModel problems

### DIFF
--- a/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
+++ b/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
@@ -171,10 +171,12 @@ class MainActivity : ComponentActivity() {
                       })
                 }
                 composable(Route.OVERVIEW) {
-                    val overviewViewModel:OverviewViewModel = viewModel(factory = OverviewViewModel.OverviewViewModelFactory(tripsRepository), key = "Overview")
+                  val overviewViewModel: OverviewViewModel =
+                      viewModel(
+                          factory = OverviewViewModel.OverviewViewModelFactory(tripsRepository),
+                          key = "Overview")
                   Overview(
-                      overviewViewModel = overviewViewModel,
-                      navigationActions = navigationActions)
+                      overviewViewModel = overviewViewModel, navigationActions = navigationActions)
                 }
                 composable(Route.TRIP) {
                   navigationActions.tripNavigation.setNavController(rememberNavController())
@@ -183,7 +185,10 @@ class MainActivity : ComponentActivity() {
                   Trip(navigationActions, tripId, tripsRepository, placesClient)
                 }
                 composable(Route.CREATE_TRIP) {
-                    val overviewViewModel:OverviewViewModel = viewModel(factory = OverviewViewModel.OverviewViewModelFactory(tripsRepository), key = "Overview")
+                  val overviewViewModel: OverviewViewModel =
+                      viewModel(
+                          factory = OverviewViewModel.OverviewViewModelFactory(tripsRepository),
+                          key = "Overview")
                   CreateTrip(overviewViewModel, navigationActions)
                 }
 
@@ -194,7 +199,12 @@ class MainActivity : ComponentActivity() {
                   Log.d("CREATE_SUGGESTION", "GeoCords: $cord")
                   val onAction: () -> Unit = { navigationActions.goBack() }
 
-                    val createSuggestionViewModel:CreateSuggestionViewModel = viewModel(factory = CreateSuggestionViewModel.CreateSuggestionViewModelFactory(tripsRepository), key = "CreateSuggestion")
+                  val createSuggestionViewModel: CreateSuggestionViewModel =
+                      viewModel(
+                          factory =
+                              CreateSuggestionViewModel.CreateSuggestionViewModelFactory(
+                                  tripsRepository),
+                          key = "CreateSuggestion")
                   CreateSuggestion(
                       tripId = navigationActions.variables.currentTrip,
                       viewModel = createSuggestionViewModel,

--- a/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
+++ b/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -170,8 +171,9 @@ class MainActivity : ComponentActivity() {
                       })
                 }
                 composable(Route.OVERVIEW) {
+                    val overviewViewModel:OverviewViewModel = viewModel(factory = OverviewViewModel.OverviewViewModelFactory(tripsRepository), key = "Overview")
                   Overview(
-                      overviewViewModel = OverviewViewModel(tripsRepository),
+                      overviewViewModel = overviewViewModel,
                       navigationActions = navigationActions)
                 }
                 composable(Route.TRIP) {
@@ -181,7 +183,8 @@ class MainActivity : ComponentActivity() {
                   Trip(navigationActions, tripId, tripsRepository, placesClient)
                 }
                 composable(Route.CREATE_TRIP) {
-                  CreateTrip(OverviewViewModel(tripsRepository), navigationActions)
+                    val overviewViewModel:OverviewViewModel = viewModel(factory = OverviewViewModel.OverviewViewModelFactory(tripsRepository), key = "Overview")
+                  CreateTrip(overviewViewModel, navigationActions)
                 }
 
                 composable(Route.CREATE_SUGGESTION) {
@@ -190,9 +193,11 @@ class MainActivity : ComponentActivity() {
                   Log.d("CREATE_SUGGESTION", "Location: $loc")
                   Log.d("CREATE_SUGGESTION", "GeoCords: $cord")
                   val onAction: () -> Unit = { navigationActions.goBack() }
+
+                    val createSuggestionViewModel:CreateSuggestionViewModel = viewModel(factory = CreateSuggestionViewModel.CreateSuggestionViewModelFactory(tripsRepository), key = "CreateSuggestion")
                   CreateSuggestion(
                       tripId = navigationActions.variables.currentTrip,
-                      viewModel = CreateSuggestionViewModel(tripsRepository),
+                      viewModel = createSuggestionViewModel,
                       addr = loc,
                       geoCords = cord,
                       onSuccess = onAction,

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
@@ -137,9 +137,10 @@ open class AgendaViewModel(
       _dailyActivities.value = getDailyActivities(selectedDate)?.toList() ?: emptyList()
     }
   }
+
   class AgendaViewModelFactory(
-    private val tripId: String,
-    private val tripsRepository: TripsRepository
+      private val tripId: String,
+      private val tripsRepository: TripsRepository
   ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.se.wanderpals.model.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.github.se.wanderpals.model.data.Stop
 import com.github.se.wanderpals.model.repository.TripsRepository
@@ -134,6 +135,18 @@ open class AgendaViewModel(
   fun fetchDailyActivities(selectedDate: LocalDate) {
     viewModelScope.launch {
       _dailyActivities.value = getDailyActivities(selectedDate)?.toList() ?: emptyList()
+    }
+  }
+  class AgendaViewModelFactory(
+    private val tripId: String,
+    private val tripsRepository: TripsRepository
+  ) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(AgendaViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST") return AgendaViewModel(tripId, tripsRepository) as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
     }
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AnnouncementViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AnnouncementViewModel.kt
@@ -22,4 +22,19 @@ class AnnouncementViewModel(private val tripsRepository: TripsRepository) {
       false
     }
   }
+
+
+  // TO add once the view model extends the viewModel class and become sa proper view model
+  /*
+  class AnnouncementViewModelFactory(private val tripsRepository: TripsRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(AnnouncementViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST")
+        return AnnouncementViewModel(tripsRepository) as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
+    }
+  }
+
+   */
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AnnouncementViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AnnouncementViewModel.kt
@@ -23,7 +23,6 @@ class AnnouncementViewModel(private val tripsRepository: TripsRepository) {
     }
   }
 
-
   // TO add once the view model extends the viewModel class and become sa proper view model
   /*
   class AnnouncementViewModelFactory(private val tripsRepository: TripsRepository) : ViewModelProvider.Factory {

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/CreateAnnouncementViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/CreateAnnouncementViewModel.kt
@@ -29,17 +29,14 @@ open class CreateAnnouncementViewModel(tripsRepository: TripsRepository) : ViewM
     return a
   }
 
-  class CreateAnnouncementViewModelFactory(
-    private val tripsRepository: TripsRepository
-  ) : ViewModelProvider.Factory {
+  class CreateAnnouncementViewModelFactory(private val tripsRepository: TripsRepository) :
+      ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
       if (modelClass.isAssignableFrom(CreateAnnouncementViewModel::class.java)) {
-        @Suppress("UNCHECKED_CAST")
-        return CreateAnnouncementViewModel(tripsRepository) as T
+        @Suppress("UNCHECKED_CAST") return CreateAnnouncementViewModel(tripsRepository) as T
       }
       throw IllegalArgumentException("Unknown ViewModel class")
     }
   }
-
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/CreateAnnouncementViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/CreateAnnouncementViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.se.wanderpals.model.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.github.se.wanderpals.model.data.Announcement
 import com.github.se.wanderpals.model.repository.TripsRepository
@@ -27,4 +28,18 @@ open class CreateAnnouncementViewModel(tripsRepository: TripsRepository) : ViewM
     }
     return a
   }
+
+  class CreateAnnouncementViewModelFactory(
+    private val tripsRepository: TripsRepository
+  ) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(CreateAnnouncementViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST")
+        return CreateAnnouncementViewModel(tripsRepository) as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
+    }
+  }
+
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/CreateSuggestionViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/CreateSuggestionViewModel.kt
@@ -19,14 +19,12 @@ open class CreateSuggestionViewModel(tripsRepository: TripsRepository) : ViewMod
     return a
   }
 
-  class CreateSuggestionViewModelFactory(
-    private val tripsRepository: TripsRepository
-  ) : ViewModelProvider.Factory {
+  class CreateSuggestionViewModelFactory(private val tripsRepository: TripsRepository) :
+      ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
       if (modelClass.isAssignableFrom(CreateSuggestionViewModel::class.java)) {
-        @Suppress("UNCHECKED_CAST")
-        return CreateSuggestionViewModel(tripsRepository) as T
+        @Suppress("UNCHECKED_CAST") return CreateSuggestionViewModel(tripsRepository) as T
       }
       throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/CreateSuggestionViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/CreateSuggestionViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.se.wanderpals.model.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.github.se.wanderpals.model.data.Suggestion
 import com.github.se.wanderpals.model.repository.TripsRepository
@@ -16,5 +17,18 @@ open class CreateSuggestionViewModel(tripsRepository: TripsRepository) : ViewMod
       _tripsRepository.addSuggestionToTrip(tripId, suggestion).also { a = it }
     }
     return a
+  }
+
+  class CreateSuggestionViewModelFactory(
+    private val tripsRepository: TripsRepository
+  ) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(CreateSuggestionViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST")
+        return CreateSuggestionViewModel(tripsRepository) as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
+    }
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/DashboardViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/DashboardViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.se.wanderpals.model.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.github.se.wanderpals.model.data.Suggestion
 import com.github.se.wanderpals.model.repository.TripsRepository
@@ -30,6 +31,20 @@ open class DashboardViewModel(private val tripsRepository: TripsRepository, trip
       // Fetch all trips from the repository
       _state.value = tripsRepository.getAllSuggestionsFromTrip(tripId)
       _isLoading.value = false
+    }
+  }
+
+  class DashboardViewModelFactory(
+    private val tripsRepository: TripsRepository,
+    private val tripId: String
+  ) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(DashboardViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST")
+        return DashboardViewModel(tripsRepository, tripId) as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
     }
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/DashboardViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/DashboardViewModel.kt
@@ -35,14 +35,13 @@ open class DashboardViewModel(private val tripsRepository: TripsRepository, trip
   }
 
   class DashboardViewModelFactory(
-    private val tripsRepository: TripsRepository,
-    private val tripId: String
+      private val tripsRepository: TripsRepository,
+      private val tripId: String
   ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
       if (modelClass.isAssignableFrom(DashboardViewModel::class.java)) {
-        @Suppress("UNCHECKED_CAST")
-        return DashboardViewModel(tripsRepository, tripId) as T
+        @Suppress("UNCHECKED_CAST") return DashboardViewModel(tripsRepository, tripId) as T
       }
       throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MapViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.se.wanderpals.model.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.github.se.wanderpals.model.data.Stop
 import com.github.se.wanderpals.model.repository.TripsRepository
@@ -39,6 +40,21 @@ open class MapViewModel(tripsRepository: TripsRepository, private val tripId: St
       val allStopsFromSubscribedTrips =
           _tripsRepository.getAllSuggestionsFromTrip(tripId).map { it.stop }
       stops.value = allStops.toMutableList().apply { addAll(allStopsFromSubscribedTrips) }
+    }
+  }
+
+
+  class MapViewModelFactory(
+    private val tripsRepository: TripsRepository,
+    private val tripId: String
+  ) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(MapViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST")
+        return MapViewModel(tripsRepository, tripId) as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
     }
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MapViewModel.kt
@@ -43,16 +43,14 @@ open class MapViewModel(tripsRepository: TripsRepository, private val tripId: St
     }
   }
 
-
   class MapViewModelFactory(
-    private val tripsRepository: TripsRepository,
-    private val tripId: String
+      private val tripsRepository: TripsRepository,
+      private val tripId: String
   ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
       if (modelClass.isAssignableFrom(MapViewModel::class.java)) {
-        @Suppress("UNCHECKED_CAST")
-        return MapViewModel(tripsRepository, tripId) as T
+        @Suppress("UNCHECKED_CAST") return MapViewModel(tripsRepository, tripId) as T
       }
       throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/OverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/OverviewViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.se.wanderpals.model.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.repository.TripsRepository
@@ -71,5 +72,18 @@ open class OverviewViewModel(private val tripsRepository: TripsRepository) : Vie
       }
     }
     return success
+  }
+
+  class OverviewViewModelFactory(
+    private val tripsRepository: TripsRepository
+  ) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(OverviewViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST")
+        return OverviewViewModel(tripsRepository) as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
+    }
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/OverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/OverviewViewModel.kt
@@ -27,11 +27,6 @@ open class OverviewViewModel(private val tripsRepository: TripsRepository) : Vie
   private val _isLoading = MutableStateFlow(true)
   open val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
-  init {
-    // Fetch all trips when the ViewModel is initialized
-    getAllTrips()
-  }
-
   /** Fetches all trips from the repository and updates the state flow accordingly. */
   open fun getAllTrips() {
     viewModelScope.launch {
@@ -74,14 +69,12 @@ open class OverviewViewModel(private val tripsRepository: TripsRepository) : Vie
     return success
   }
 
-  class OverviewViewModelFactory(
-    private val tripsRepository: TripsRepository
-  ) : ViewModelProvider.Factory {
+  class OverviewViewModelFactory(private val tripsRepository: TripsRepository) :
+      ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
       if (modelClass.isAssignableFrom(OverviewViewModel::class.java)) {
-        @Suppress("UNCHECKED_CAST")
-        return OverviewViewModel(tripsRepository) as T
+        @Suppress("UNCHECKED_CAST") return OverviewViewModel(tripsRepository) as T
       }
       throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SessionViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SessionViewModel.kt
@@ -2,6 +2,7 @@ package com.github.se.wanderpals.model.viewmodel
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.service.SessionManager
@@ -24,6 +25,18 @@ class SessionViewModel(private val tripsRepository: TripsRepository) : ViewModel
           Log.e("SessionViewModel", "Failed to update user role", e)
         }
       }
+    }
+  }
+  class SessionViewModelFactory(
+    private val tripsRepository: TripsRepository
+  ) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(SessionViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST")
+        return SessionViewModel(tripsRepository) as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
     }
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SessionViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SessionViewModel.kt
@@ -27,14 +27,13 @@ class SessionViewModel(private val tripsRepository: TripsRepository) : ViewModel
       }
     }
   }
-  class SessionViewModelFactory(
-    private val tripsRepository: TripsRepository
-  ) : ViewModelProvider.Factory {
+
+  class SessionViewModelFactory(private val tripsRepository: TripsRepository) :
+      ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
       if (modelClass.isAssignableFrom(SessionViewModel::class.java)) {
-        @Suppress("UNCHECKED_CAST")
-        return SessionViewModel(tripsRepository) as T
+        @Suppress("UNCHECKED_CAST") return SessionViewModel(tripsRepository) as T
       }
       throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SuggestionsViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SuggestionsViewModel.kt
@@ -184,17 +184,16 @@ open class SuggestionsViewModel(
     hideBottomSheet()
   }
 
+  class SuggestionsViewModelFactory(
+      private val tripsRepository: TripsRepository,
+      private val tripId: String
+  ) : ViewModelProvider.Factory {
 
-    class SuggestionsViewModelFactory(
-        private val tripsRepository: TripsRepository,
-        private val tripId: String
-    ) : ViewModelProvider.Factory {
-
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            if (modelClass.isAssignableFrom(SuggestionsViewModel::class.java)) {
-                @Suppress("UNCHECKED_CAST") return SuggestionsViewModel(tripsRepository, tripId) as T
-            }
-            throw IllegalArgumentException("Unknown ViewModel class")
-        }
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(SuggestionsViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST") return SuggestionsViewModel(tripsRepository, tripId) as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
     }
+  }
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SuggestionsViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SuggestionsViewModel.kt
@@ -2,6 +2,7 @@ package com.github.se.wanderpals.model.viewmodel
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.github.se.wanderpals.model.data.Comment
 import com.github.se.wanderpals.model.data.Suggestion
@@ -182,4 +183,18 @@ open class SuggestionsViewModel(
     hideDeleteDialog()
     hideBottomSheet()
   }
+
+
+    class SuggestionsViewModelFactory(
+        private val tripsRepository: TripsRepository,
+        private val tripId: String
+    ) : ViewModelProvider.Factory {
+
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(SuggestionsViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST") return SuggestionsViewModel(tripsRepository, tripId) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/Overview.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/Overview.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -45,7 +46,10 @@ import com.github.se.wanderpals.ui.navigation.Route
  */
 @Composable
 fun Overview(overviewViewModel: OverviewViewModel, navigationActions: NavigationActions) {
-
+  LaunchedEffect(
+      Unit) { // This ensures getAllTrips is called once per composition, not on every recomposition
+        overviewViewModel.getAllTrips()
+      }
   // Collecting trips list and loading state from view model
   val tripsList by overviewViewModel.state.collectAsState()
   val isLoading by overviewViewModel.isLoading.collectAsState()

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
@@ -60,7 +60,9 @@ fun Trip(
 ) {
 
   // update the SessionManagers Users Role, from the User In the Trip Object
-    val sessionViewModel:SessionViewModel = viewModel(factory = SessionViewModel.SessionViewModelFactory(tripsRepository), key = "Session")
+  val sessionViewModel: SessionViewModel =
+      viewModel(
+          factory = SessionViewModel.SessionViewModelFactory(tripsRepository), key = "Session")
   LaunchedEffect(key1 = tripId) { sessionViewModel.updateRoleForCurrentUser(tripId) }
 
   Scaffold(
@@ -77,26 +79,29 @@ fun Trip(
                   startDestination = oldNavActions.tripNavigation.getStartDestination(),
                   route = Route.TRIP) {
                     composable(Route.DASHBOARD) {
-                        val dashboardViewModel: DashboardViewModel = viewModel(
-                            factory = DashboardViewModel.DashboardViewModelFactory(
-                                tripsRepository,
-                                tripId
-                            ), key = "Dashboard"
-                        )
+                      val dashboardViewModel: DashboardViewModel =
+                          viewModel(
+                              factory =
+                                  DashboardViewModel.DashboardViewModelFactory(
+                                      tripsRepository, tripId),
+                              key = "Dashboard")
                       Dashboard(tripId, dashboardViewModel, oldNavActions)
                     }
                     composable(Route.AGENDA) {
-                        val agendaViewModel: AgendaViewModel = viewModel (factory = AgendaViewModel.AgendaViewModelFactory(tripId,tripsRepository), key = "Agenda")
-                        Agenda(agendaViewModel)
+                      val agendaViewModel: AgendaViewModel =
+                          viewModel(
+                              factory =
+                                  AgendaViewModel.AgendaViewModelFactory(tripId, tripsRepository),
+                              key = "Agenda")
+                      Agenda(agendaViewModel)
                     }
                     composable(Route.SUGGESTION) {
-
-                        val suggestionsViewModel: SuggestionsViewModel =
-                            viewModel(
-                                factory =
-                                SuggestionsViewModel.SuggestionsViewModelFactory(
-                                    tripsRepository, tripId),
-                                key = "SuggestionsViewModel")
+                      val suggestionsViewModel: SuggestionsViewModel =
+                          viewModel(
+                              factory =
+                                  SuggestionsViewModel.SuggestionsViewModelFactory(
+                                      tripsRepository, tripId),
+                              key = "SuggestionsViewModel")
                       Suggestion(
                           oldNavActions,
                           tripId,
@@ -107,7 +112,9 @@ fun Trip(
                           })
                     }
                     composable(Route.MAP) {
-                        val mapViewModel:MapViewModel = viewModel(factory = MapViewModel.MapViewModelFactory(tripsRepository,tripId))
+                      val mapViewModel: MapViewModel =
+                          viewModel(
+                              factory = MapViewModel.MapViewModelFactory(tripsRepository, tripId))
                       if (client != null) {
                         if (oldNavActions.variables.currentAddress == "") {
                           Log.d("NAVIGATION", "Navigating to map with empty address")
@@ -132,16 +139,15 @@ fun Trip(
                           "SuggestionDetail",
                           "SuggestionDetail: ${oldNavActions.variables.suggestionId}")
 
-                        val suggestionsViewModel: SuggestionsViewModel =
-                            viewModel(
-                                factory =
-                                SuggestionsViewModel.SuggestionsViewModelFactory(
-                                    tripsRepository, oldNavActions.variables.currentTrip),
-                                key = "SuggestionsViewModel")
+                      val suggestionsViewModel: SuggestionsViewModel =
+                          viewModel(
+                              factory =
+                                  SuggestionsViewModel.SuggestionsViewModelFactory(
+                                      tripsRepository, oldNavActions.variables.currentTrip),
+                              key = "SuggestionsViewModel")
                       SuggestionDetail(
                           suggestionId = oldNavActions.variables.suggestionId,
-                          viewModel =
-                          suggestionsViewModel,
+                          viewModel = suggestionsViewModel,
                           navActions = oldNavActions)
                     }
                   }
@@ -157,9 +163,7 @@ fun Trip(
 @Composable
 fun BottomBar(navActions: NavigationActions) {
   NavigationBar(
-      modifier = Modifier
-          .testTag("bottomNav")
-          .height(56.dp),
+      modifier = Modifier.testTag("bottomNav").height(56.dp),
       containerColor = NavigationBarDefaults.containerColor,
       contentColor = MaterialTheme.colorScheme.contentColorFor(containerColor),
       tonalElevation = NavigationBarDefaults.Elevation,
@@ -169,9 +173,7 @@ fun BottomBar(navActions: NavigationActions) {
 
     TRIP_BOTTOM_BAR.forEach { destination ->
       NavigationBarItem(
-          modifier = Modifier
-              .testTag(destination.text)
-              .size(56.dp),
+          modifier = Modifier.testTag(destination.text).size(56.dp),
           selected = currentRoute == destination.route,
           onClick = {
             currentRoute = destination.route


### PR DESCRIPTION
This PR introduces inner factory classes within our ViewModel classes. The primary aim of this architectural adjustment is to enhance the creation and management of ViewModel instances across different screens, especially in cases where multiple ViewModels of the same type are needed but with minimal lifecycle dependency and reduced redundancy in data fetches.
Also fixed Overview, to load the trips when entering the UI (called only once)