### PR TITLE
Enhance Repository Initialization in MainActivity with Lifecycle-Aware ViewModel

### DIFF
--- a/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
+++ b/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
@@ -8,6 +8,7 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -19,6 +20,7 @@ import androidx.navigation.compose.rememberNavController
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.AdminViewModel
 import com.github.se.wanderpals.model.viewmodel.CreateSuggestionViewModel
+import com.github.se.wanderpals.model.viewmodel.MainViewModel
 import com.github.se.wanderpals.model.viewmodel.OverviewViewModel
 import com.github.se.wanderpals.service.MapManager
 import com.github.se.wanderpals.service.SessionManager
@@ -51,11 +53,19 @@ class MainActivity : ComponentActivity() {
 
   private lateinit var mapManager: MapManager
 
-  private lateinit var tripsRepository: TripsRepository
+  //private lateinit var tripsRepository: TripsRepository
 
   private lateinit var context: Context
 
-  private val launcher =
+
+  private val viewModel: MainViewModel by viewModels {
+      MainViewModel.MainViewModelFactory(
+          application
+      )
+  }
+
+
+    private val launcher =
       registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
         task
@@ -69,8 +79,7 @@ class MainActivity : ComponentActivity() {
                       Log.d("MainActivity", "SignIn: Firebase Login Completed Successfully")
                       val uid = it.result?.user?.uid ?: ""
                       Log.d("MainActivity", "Firebase UID: $uid")
-                      tripsRepository = TripsRepository(uid, Dispatchers.IO)
-                      tripsRepository.initFirestore()
+                        viewModel.initRepository(uid)
                       Log.d("MainActivity", "Firebase Initialized")
                       Log.d("SignIn", "Login result " + account.displayName)
 
@@ -164,8 +173,9 @@ class MainActivity : ComponentActivity() {
                             .signInAnonymously()
                             .addOnSuccessListener { result ->
                               val uid = result.user?.uid ?: ""
-                              tripsRepository = TripsRepository(uid, Dispatchers.IO)
-                              tripsRepository.initFirestore()
+                              //tripsRepository = TripsRepository(uid, Dispatchers.IO)
+                              //tripsRepository.initFirestore()
+                              viewModel.initRepository(uid)
                               SessionManager.setUserSession(
                                   userId = uid, name = "Anonymous User", email = "")
                               navigationActions.navigateTo(Route.OVERVIEW)
@@ -177,8 +187,7 @@ class MainActivity : ComponentActivity() {
                       onClick3 = { email, password ->
                         val onSucess = { result: AuthResult ->
                           val uid = result.user?.uid ?: ""
-                          tripsRepository = TripsRepository(uid, Dispatchers.IO)
-                          tripsRepository.initFirestore()
+                            viewModel.initRepository(uid)
                           SessionManager.setUserSession(
                               userId = uid,
                               name = result.user?.displayName ?: "",
@@ -201,7 +210,7 @@ class MainActivity : ComponentActivity() {
                 composable(Route.OVERVIEW) {
                   val overviewViewModel: OverviewViewModel =
                       viewModel(
-                          factory = OverviewViewModel.OverviewViewModelFactory(tripsRepository),
+                          factory = OverviewViewModel.OverviewViewModelFactory(viewModel.getTripsRepository()),
                           key = "Overview")
                   Overview(
                       overviewViewModel = overviewViewModel, navigationActions = navigationActions)
@@ -210,12 +219,12 @@ class MainActivity : ComponentActivity() {
                   navigationActions.tripNavigation.setNavController(rememberNavController())
                   val tripId = navigationActions.variables.currentTrip
                   navigationActions.tripNavigation.setNavController(rememberNavController())
-                  Trip(navigationActions, tripId, tripsRepository, mapManager)
+                  Trip(navigationActions, tripId, viewModel.getTripsRepository(), mapManager)
                 }
                 composable(Route.CREATE_TRIP) {
                   val overviewViewModel: OverviewViewModel =
                       viewModel(
-                          factory = OverviewViewModel.OverviewViewModelFactory(tripsRepository),
+                          factory = OverviewViewModel.OverviewViewModelFactory(viewModel.getTripsRepository()),
                           key = "Overview")
                   CreateTrip(overviewViewModel, navigationActions)
                 }
@@ -230,7 +239,7 @@ class MainActivity : ComponentActivity() {
                       viewModel(
                           factory =
                               CreateSuggestionViewModel.CreateSuggestionViewModelFactory(
-                                  tripsRepository),
+                                  viewModel.getTripsRepository()),
                           key = "CreateSuggestion")
                   CreateSuggestion(
                       tripId = navigationActions.variables.currentTrip,
@@ -245,7 +254,7 @@ class MainActivity : ComponentActivity() {
                           viewModel(
                               factory =
                                   AdminViewModel.AdminViewModelFactory(
-                                      navigationActions.variables.currentTrip, tripsRepository),
+                                      navigationActions.variables.currentTrip, viewModel.getTripsRepository()),
                               key = "AdminPage"))
                 }
               }

--- a/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
+++ b/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
@@ -17,7 +17,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.AdminViewModel
 import com.github.se.wanderpals.model.viewmodel.CreateSuggestionViewModel
 import com.github.se.wanderpals.model.viewmodel.MainViewModel
@@ -41,7 +40,6 @@ import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
-import kotlinx.coroutines.Dispatchers
 
 const val EMPTY_CODE = ""
 
@@ -53,19 +51,13 @@ class MainActivity : ComponentActivity() {
 
   private lateinit var mapManager: MapManager
 
-  //private lateinit var tripsRepository: TripsRepository
-
   private lateinit var context: Context
 
-
   private val viewModel: MainViewModel by viewModels {
-      MainViewModel.MainViewModelFactory(
-          application
-      )
+    MainViewModel.MainViewModelFactory(application)
   }
 
-
-    private val launcher =
+  private val launcher =
       registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
         task
@@ -79,7 +71,7 @@ class MainActivity : ComponentActivity() {
                       Log.d("MainActivity", "SignIn: Firebase Login Completed Successfully")
                       val uid = it.result?.user?.uid ?: ""
                       Log.d("MainActivity", "Firebase UID: $uid")
-                        viewModel.initRepository(uid)
+                      viewModel.initRepository(uid)
                       Log.d("MainActivity", "Firebase Initialized")
                       Log.d("SignIn", "Login result " + account.displayName)
 
@@ -173,8 +165,6 @@ class MainActivity : ComponentActivity() {
                             .signInAnonymously()
                             .addOnSuccessListener { result ->
                               val uid = result.user?.uid ?: ""
-                              //tripsRepository = TripsRepository(uid, Dispatchers.IO)
-                              //tripsRepository.initFirestore()
                               viewModel.initRepository(uid)
                               SessionManager.setUserSession(
                                   userId = uid, name = "Anonymous User", email = "")
@@ -187,7 +177,7 @@ class MainActivity : ComponentActivity() {
                       onClick3 = { email, password ->
                         val onSucess = { result: AuthResult ->
                           val uid = result.user?.uid ?: ""
-                            viewModel.initRepository(uid)
+                          viewModel.initRepository(uid)
                           SessionManager.setUserSession(
                               userId = uid,
                               name = result.user?.displayName ?: "",
@@ -210,7 +200,9 @@ class MainActivity : ComponentActivity() {
                 composable(Route.OVERVIEW) {
                   val overviewViewModel: OverviewViewModel =
                       viewModel(
-                          factory = OverviewViewModel.OverviewViewModelFactory(viewModel.getTripsRepository()),
+                          factory =
+                              OverviewViewModel.OverviewViewModelFactory(
+                                  viewModel.getTripsRepository()),
                           key = "Overview")
                   Overview(
                       overviewViewModel = overviewViewModel, navigationActions = navigationActions)
@@ -224,7 +216,9 @@ class MainActivity : ComponentActivity() {
                 composable(Route.CREATE_TRIP) {
                   val overviewViewModel: OverviewViewModel =
                       viewModel(
-                          factory = OverviewViewModel.OverviewViewModelFactory(viewModel.getTripsRepository()),
+                          factory =
+                              OverviewViewModel.OverviewViewModelFactory(
+                                  viewModel.getTripsRepository()),
                           key = "Overview")
                   CreateTrip(overviewViewModel, navigationActions)
                 }
@@ -254,7 +248,8 @@ class MainActivity : ComponentActivity() {
                           viewModel(
                               factory =
                                   AdminViewModel.AdminViewModelFactory(
-                                      navigationActions.variables.currentTrip, viewModel.getTripsRepository()),
+                                      navigationActions.variables.currentTrip,
+                                      viewModel.getTripsRepository()),
                               key = "AdminPage"))
                 }
               }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MainViewModel.kt
@@ -1,0 +1,33 @@
+package com.github.se.wanderpals.model.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.github.se.wanderpals.model.repository.TripsRepository
+import kotlinx.coroutines.Dispatchers
+
+
+class MainViewModel(application: Application): AndroidViewModel(application) {
+
+    private lateinit var tripsRepository: TripsRepository
+
+    fun initRepository(userId: String) {
+        tripsRepository = TripsRepository(userId, Dispatchers.IO)
+        tripsRepository.initFirestore()
+    }
+
+    fun getTripsRepository(): TripsRepository {
+        return tripsRepository
+    }
+
+    class MainViewModelFactory(private val application: Application) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return MainViewModel(application) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
+}

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MainViewModel.kt
@@ -7,27 +7,48 @@ import androidx.lifecycle.ViewModelProvider
 import com.github.se.wanderpals.model.repository.TripsRepository
 import kotlinx.coroutines.Dispatchers
 
+/**
+ * ViewModel to manage data for the main user interface components. It handles the initialization
+ * and provision of the TripsRepository.
+ *
+ * @param application The context of the application passed to AndroidViewModel for use with
+ *   application-wide tasks.
+ */
+class MainViewModel(application: Application) : AndroidViewModel(application) {
 
-class MainViewModel(application: Application): AndroidViewModel(application) {
+  private lateinit var tripsRepository: TripsRepository
 
-    private lateinit var tripsRepository: TripsRepository
+  /**
+   * Initializes the TripsRepository with a specific user ID. This method must be called immediately
+   * after a user successfully signs in.
+   *
+   * @param userId The unique identifier for the user, used to initialize the repository.
+   */
+  fun initRepository(userId: String) {
+    tripsRepository = TripsRepository(userId, Dispatchers.IO)
+    tripsRepository.initFirestore()
+  }
 
-    fun initRepository(userId: String) {
-        tripsRepository = TripsRepository(userId, Dispatchers.IO)
-        tripsRepository.initFirestore()
+  /**
+   * Retrieves the instance of TripsRepository initialized with a user's ID. This repository handles
+   * all data operations related to trips.
+   *
+   * @return The instance of TripsRepository.
+   */
+  fun getTripsRepository(): TripsRepository {
+    return tripsRepository
+  }
+
+  /**
+   * Factory for creating instances of the MainViewModel. Ensures the ViewModel is constructed with
+   * the necessary application context.
+   */
+  class MainViewModelFactory(private val application: Application) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST") return MainViewModel(application) as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
     }
-
-    fun getTripsRepository(): TripsRepository {
-        return tripsRepository
-    }
-
-    class MainViewModelFactory(private val application: Application) : ViewModelProvider.Factory {
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
-                @Suppress("UNCHECKED_CAST")
-                return MainViewModel(application) as T
-            }
-            throw IllegalArgumentException("Unknown ViewModel class")
-        }
-    }
+  }
 }


### PR DESCRIPTION
In this PR, I've introduced a fix for the repository initialization in MainActivity. Previously, the repository was instantiated directly within the activity, which made it non-lifecycle-aware. This approach led to issues during configuration changes, such as screen rotations, where the repository would not be reinitialized, causing the application to crash.

To address this issue, I have implemented a ViewModel that serves as a container for the repository, making it lifecycle-aware. This change ensures that the repository is maintained across configuration changes, preventing crashes and enhancing the stability of our application.