### PR TITLE
Make stop interactable with Map in Agenda

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/agenda/DailyActivitiesTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/agenda/DailyActivitiesTest.kt
@@ -70,8 +70,7 @@ class DailyActivitiesTest {
               0,
               0.0,
               "Description 4",
-              GeoCords(0.0, 0.0))
-      )
+              GeoCords(0.0, 0.0)))
   private val testViewModel = FakeAgendaViewModel(YearMonth.now(), testActivities)
   private val emptyTestViewModel = FakeAgendaViewModel(YearMonth.now(), emptyList())
 
@@ -93,7 +92,6 @@ class DailyActivitiesTest {
     composeTestRule.onNodeWithTag(testActivities[1].stopId).assertIsDisplayed()
 
     composeTestRule.onNodeWithTag(testActivities[2].stopId).assertIsDisplayed()
-
 
     composeTestRule.onNodeWithTag(testActivities[3].stopId).assertIsDisplayed()
   }
@@ -127,15 +125,15 @@ class DailyActivitiesTest {
 
       val hasLocation = testStop.geoCords.latitude != 0.0 || testStop.geoCords.longitude != 0.0
       // Assert that the address is displayed correctly
-      if(hasLocation){
-          composeTestRule
-              .onNodeWithTag("ActivityAddress${testStop.stopId}", useUnmergedTree = true)
-              .assertIsDisplayed()
-              .assertTextEquals(testStop.address)
-      }else{
-          composeTestRule
-              .onNodeWithTag("ActivityAddress${testStop.stopId}", useUnmergedTree = true)
-              .assertIsNotDisplayed()
+      if (hasLocation) {
+        composeTestRule
+            .onNodeWithTag("ActivityAddress${testStop.stopId}", useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertTextEquals(testStop.address)
+      } else {
+        composeTestRule
+            .onNodeWithTag("ActivityAddress${testStop.stopId}", useUnmergedTree = true)
+            .assertIsNotDisplayed()
       }
     }
   }
@@ -191,25 +189,21 @@ class DailyActivitiesTest {
       composeTestRule.onNodeWithTag("activitySchedule").assertIsDisplayed()
       composeTestRule.onNodeWithTag("titleAddress").assertIsDisplayed()
       composeTestRule.onNodeWithTag("activityAddress").assertIsDisplayed()
-      if(testStop.address.isNotEmpty()){
-          composeTestRule
-              .onNodeWithTag("activityAddress")
-              .assertTextEquals("Location " + testStop.stopId)
-          composeTestRule.onNodeWithTag("navigationToMapButton"+testStop.stopId)
-              .assertIsDisplayed()
-
-      }else{
-          composeTestRule
-              .onNodeWithTag("activityAddress")
-              .assertTextEquals("No address provided")
-          composeTestRule.onNodeWithTag("navigationToMapButton"+testStop.stopId)
-              .assertIsDisplayed()
-              .assertIsNotEnabled()
+      if (testStop.address.isNotEmpty()) {
+        composeTestRule
+            .onNodeWithTag("activityAddress")
+            .assertTextEquals("Location " + testStop.stopId)
+        composeTestRule.onNodeWithTag("navigationToMapButton" + testStop.stopId).assertIsDisplayed()
+      } else {
+        composeTestRule.onNodeWithTag("activityAddress").assertTextEquals("No address provided")
+        composeTestRule
+            .onNodeWithTag("navigationToMapButton" + testStop.stopId)
+            .assertIsDisplayed()
+            .assertIsNotEnabled()
       }
       composeTestRule.onNodeWithTag("titleBudget").assertIsDisplayed()
       composeTestRule.onNodeWithTag("activityBudget").assertIsDisplayed()
       composeTestRule.onNodeWithTag("activityBudget").assertTextEquals("0.0")
-
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/agenda/DailyActivitiesTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/agenda/DailyActivitiesTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -38,7 +40,7 @@ class DailyActivitiesTest {
               0,
               0.0,
               "Description 1",
-              GeoCords(0.0, 0.0)),
+              GeoCords(1.0, 0.0)),
           Stop(
               "2",
               "Title 2",
@@ -48,7 +50,7 @@ class DailyActivitiesTest {
               0,
               0.0,
               "Description 2",
-              GeoCords(0.0, 0.0)),
+              GeoCords(0.0, 1.0)),
           Stop(
               "3",
               "Title 3",
@@ -58,7 +60,18 @@ class DailyActivitiesTest {
               0,
               0.0,
               "Description 3",
-              GeoCords(0.0, 0.0)))
+              GeoCords(1.0, 1.0)),
+          Stop(
+              "4",
+              "Title 4",
+              "",
+              LocalDate.now(),
+              LocalTime.now(),
+              0,
+              0.0,
+              "Description 4",
+              GeoCords(0.0, 0.0))
+      )
   private val testViewModel = FakeAgendaViewModel(YearMonth.now(), testActivities)
   private val emptyTestViewModel = FakeAgendaViewModel(YearMonth.now(), emptyList())
 
@@ -80,6 +93,9 @@ class DailyActivitiesTest {
     composeTestRule.onNodeWithTag(testActivities[1].stopId).assertIsDisplayed()
 
     composeTestRule.onNodeWithTag(testActivities[2].stopId).assertIsDisplayed()
+
+
+    composeTestRule.onNodeWithTag(testActivities[3].stopId).assertIsDisplayed()
   }
 
   // Check that the content of the activity items is displayed correctly
@@ -109,11 +125,18 @@ class DailyActivitiesTest {
           .assertIsDisplayed()
           .assertTextEquals(expectedTime)
 
+      val hasLocation = testStop.geoCords.latitude != 0.0 || testStop.geoCords.longitude != 0.0
       // Assert that the address is displayed correctly
-      composeTestRule
-          .onNodeWithTag("ActivityAddress${testStop.stopId}", useUnmergedTree = true)
-          .assertIsDisplayed()
-          .assertTextEquals(testStop.address)
+      if(hasLocation){
+          composeTestRule
+              .onNodeWithTag("ActivityAddress${testStop.stopId}", useUnmergedTree = true)
+              .assertIsDisplayed()
+              .assertTextEquals(testStop.address)
+      }else{
+          composeTestRule
+              .onNodeWithTag("ActivityAddress${testStop.stopId}", useUnmergedTree = true)
+              .assertIsNotDisplayed()
+      }
     }
   }
 
@@ -168,12 +191,25 @@ class DailyActivitiesTest {
       composeTestRule.onNodeWithTag("activitySchedule").assertIsDisplayed()
       composeTestRule.onNodeWithTag("titleAddress").assertIsDisplayed()
       composeTestRule.onNodeWithTag("activityAddress").assertIsDisplayed()
-      composeTestRule
-          .onNodeWithTag("activityAddress")
-          .assertTextEquals("Location " + testStop.stopId)
+      if(testStop.address.isNotEmpty()){
+          composeTestRule
+              .onNodeWithTag("activityAddress")
+              .assertTextEquals("Location " + testStop.stopId)
+          composeTestRule.onNodeWithTag("navigationToMapButton"+testStop.stopId)
+              .assertIsDisplayed()
+
+      }else{
+          composeTestRule
+              .onNodeWithTag("activityAddress")
+              .assertTextEquals("No address provided")
+          composeTestRule.onNodeWithTag("navigationToMapButton"+testStop.stopId)
+              .assertIsDisplayed()
+              .assertIsNotEnabled()
+      }
       composeTestRule.onNodeWithTag("titleBudget").assertIsDisplayed()
       composeTestRule.onNodeWithTag("activityBudget").assertIsDisplayed()
       composeTestRule.onNodeWithTag("activityBudget").assertTextEquals("0.0")
+
     }
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -884,7 +884,7 @@ class TripsRepository(
   suspend fun addStopToTrip(tripId: String, stop: Stop): Boolean =
       withContext(dispatcher) {
         try {
-          val uniqueID = UUID.randomUUID().toString() + "/" + stop.stopId
+          val uniqueID = UUID.randomUUID().toString() + "," + stop.stopId
           val firebaseStop = FirestoreStop.fromStop(stop.copy(stopId = uniqueID))
           val stopDocument =
               tripsCollection

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
@@ -148,9 +148,8 @@ fun ActivityItem(stop: Stop, onActivityClick: (String) -> Unit) {
                 },
                 modifier =
                     Modifier.size(24.dp) // Adjust the size of the IconButton as needed
-                        .align(
-                            Alignment
-                                .CenterVertically), // Center the IconButton vertically within the
+                            .align(Alignment.CenterVertically)
+                            .testTag("navigationToMapButton"+stop.stopId), // Center the IconButton vertically within the
                 enabled = stopHasLocation
                 // Row
                 ) {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.unit.dp
 import com.github.se.wanderpals.model.data.Stop
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.AgendaViewModel
+import com.github.se.wanderpals.navigationActions
+import com.github.se.wanderpals.ui.navigation.Route
 import com.github.se.wanderpals.ui.theme.WanderPalsTheme
 import kotlinx.coroutines.Dispatchers
 
@@ -132,7 +134,13 @@ fun ActivityItem(stop: Stop, onActivityClick: (String) -> Unit) {
 
             // Icon Button at the far right, centered vertically
             IconButton(
-                onClick = { /*TODO : implement this in the future*/},
+                onClick = {
+                          navigationActions.setVariablesLocation(
+                              stop.geoCords,
+                              stop.address
+                          )
+                          navigationActions.navigateTo(Route.MAP)
+                },
                 modifier =
                     Modifier.size(24.dp) // Adjust the size of the IconButton as needed
                         .align(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
@@ -124,13 +124,15 @@ fun ActivityItem(stop: Stop, onActivityClick: (String) -> Unit) {
                       modifier =
                           Modifier.wrapContentWidth(Alignment.Start)
                               .testTag("ActivityTime" + stop.stopId))
-                  Text(
-                      text = stop.address,
-                      style = MaterialTheme.typography.bodyLarge,
-                      color = Color.Black,
-                      modifier =
-                          Modifier.wrapContentWidth(Alignment.Start)
-                              .testTag("ActivityAddress" + stop.stopId))
+                if(stopHasLocation){
+                    Text(
+                        text = stop.address,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = Color.Black,
+                        modifier =
+                        Modifier.wrapContentWidth(Alignment.Start)
+                            .testTag("ActivityAddress" + stop.stopId))
+                }
                 }
 
             // Icon Button at the far right, centered vertically

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
@@ -92,6 +92,7 @@ fun DailyActivities(agendaViewModel: AgendaViewModel, onActivityItemClick: (Stri
  */
 @Composable
 fun ActivityItem(stop: Stop, onActivityClick: (String) -> Unit) {
+  val stopHasLocation = stop.geoCords.latitude != 0.0 || stop.geoCords.longitude != 0.0
   Box(modifier = Modifier.testTag(stop.stopId).fillMaxWidth()) {
     Button(
         onClick = { onActivityClick(stop.stopId) },
@@ -135,25 +136,29 @@ fun ActivityItem(stop: Stop, onActivityClick: (String) -> Unit) {
             // Icon Button at the far right, centered vertically
             IconButton(
                 onClick = {
-                          navigationActions.setVariablesLocation(
-                              stop.geoCords,
-                              stop.address
-                          )
-                          navigationActions.navigateTo(Route.MAP)
+                         if(stopHasLocation){
+                             navigationActions.setVariablesLocation(
+                                 stop.geoCords,
+                                 stop.address
+                             )
+                             navigationActions.navigateTo(Route.MAP)
+                         }
                 },
                 modifier =
                     Modifier.size(24.dp) // Adjust the size of the IconButton as needed
                         .align(
                             Alignment
-                                .CenterVertically) // Center the IconButton vertically within the
+                                .CenterVertically), // Center the IconButton vertically within the
+                enabled = stopHasLocation
                 // Row
                 ) {
                   Icon(
                       imageVector = Icons.Default.LocationOn,
-                      tint = MaterialTheme.colorScheme.primary,
+                      tint = if (stopHasLocation) MaterialTheme.colorScheme.primary else Color.LightGray,
                       contentDescription = null // Provide an appropriate content description
                       )
                 }
+
           }
         }
   }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
@@ -124,42 +124,42 @@ fun ActivityItem(stop: Stop, onActivityClick: (String) -> Unit) {
                       modifier =
                           Modifier.wrapContentWidth(Alignment.Start)
                               .testTag("ActivityTime" + stop.stopId))
-                if(stopHasLocation){
+                  if (stopHasLocation) {
                     Text(
                         text = stop.address,
                         style = MaterialTheme.typography.bodyLarge,
                         color = Color.Black,
                         modifier =
-                        Modifier.wrapContentWidth(Alignment.Start)
-                            .testTag("ActivityAddress" + stop.stopId))
-                }
+                            Modifier.wrapContentWidth(Alignment.Start)
+                                .testTag("ActivityAddress" + stop.stopId))
+                  }
                 }
 
             // Icon Button at the far right, centered vertically
             IconButton(
                 onClick = {
-                         if(stopHasLocation){
-                             navigationActions.setVariablesLocation(
-                                 stop.geoCords,
-                                 stop.address
-                             )
-                             navigationActions.navigateTo(Route.MAP)
-                         }
+                  if (stopHasLocation) {
+                    navigationActions.setVariablesLocation(stop.geoCords, stop.address)
+                    navigationActions.navigateTo(Route.MAP)
+                  }
                 },
                 modifier =
                     Modifier.size(24.dp) // Adjust the size of the IconButton as needed
-                            .align(Alignment.CenterVertically)
-                            .testTag("navigationToMapButton"+stop.stopId), // Center the IconButton vertically within the
+                        .align(Alignment.CenterVertically)
+                        .testTag(
+                            "navigationToMapButton" +
+                                stop.stopId), // Center the IconButton vertically within the
                 enabled = stopHasLocation
                 // Row
                 ) {
                   Icon(
                       imageVector = Icons.Default.LocationOn,
-                      tint = if (stopHasLocation) MaterialTheme.colorScheme.primary else Color.LightGray,
+                      tint =
+                          if (stopHasLocation) MaterialTheme.colorScheme.primary
+                          else Color.LightGray,
                       contentDescription = null // Provide an appropriate content description
                       )
                 }
-
           }
         }
   }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/StopInfoDialog.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/StopInfoDialog.kt
@@ -101,7 +101,7 @@ fun StopInfoDialog(stop: Stop, closeDialogueAction: () -> Unit) {
                     modifier = Modifier.testTag("titleAddress"))
 
                 Text(
-                    text = stop.address,
+                    text = stop.address.ifEmpty { "No address provided" },
                     style = TextStyle(fontSize = 16.sp),
                     textAlign = TextAlign.Center,
                     modifier =

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/map/Map.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/map/Map.kt
@@ -311,8 +311,8 @@ fun Map(
                 icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE),
                 onInfoWindowClick = {
                   // check if stop.stopId contains a "/" and if it does, split it and get the first
-                  if (stop.stopId.last() != '/' && stop.stopId.contains('/')) {
-                    val placeId = stop.stopId.split("/")[1]
+                  if (stop.stopId.last() != ',' && stop.stopId.contains(',')) {
+                    val placeId = stop.stopId.split(",")[1]
                     mapManager.fetchPlace(placeId).addOnSuccessListener { response ->
                       val place = response.place
                       placeData = placeData.setPlaceData(place, placeId)

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/map/Map.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/map/Map.kt
@@ -310,7 +310,7 @@ fun Map(
                 snippet = stop.description,
                 icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE),
                 onInfoWindowClick = {
-                  // check if stop.stopId contains a "/" and if it does, split it and get the first
+                  // check if stop.stopId contains a "," and if it does, split it and get the first
                   if (stop.stopId.last() != ',' && stop.stopId.contains(',')) {
                     val placeId = stop.stopId.split(",")[1]
                     mapManager.fetchPlace(placeId).addOnSuccessListener { response ->


### PR DESCRIPTION
This PR aims to make stop items interactable and upgrade the stops in agenda view.
- in the agenda view when selecting a specific day containing stops, we can now click on the map icon that will make us navigate to the specific stop. If the stop has nos address, the button will not be enabled and displayed in grey
- The fact that stops doesn't necessary have an address is now handled in the UI of the agenda.