### PR TITLE
Save draft markers on map

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/map/MapScreenTests.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/map/MapScreenTests.kt
@@ -13,8 +13,7 @@ import com.github.se.wanderpals.screens.MapScreen
 import com.github.se.wanderpals.service.MapManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.screens.trip.map.Map
-import com.google.android.gms.maps.model.LatLng
-import com.google.maps.android.compose.MarkerState
+import com.github.se.wanderpals.ui.screens.trip.map.PlaceData
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
@@ -62,7 +61,7 @@ object FakeMapViewModel : MapViewModel(TripsRepository("-1", dispatcher = Dispat
 
   override var stops = MutableStateFlow(listOf(stop1, stop2))
 
-  override var listOfTempMarkerStates = MutableStateFlow(emptyList<MarkerState>())
+  override var listOfTempPlaceData = MutableStateFlow(emptyList<PlaceData>())
 
   override fun getAllSuggestions() {}
 
@@ -70,9 +69,11 @@ object FakeMapViewModel : MapViewModel(TripsRepository("-1", dispatcher = Dispat
 
   override fun getAllUsersPositions() {}
 
-  override fun getAllTempMarkers() {}
+  override fun getAllPlaceData() {}
 
-  override fun saveMarkerState(markerState: MarkerState) {}
+  override fun savePlaceDataState(placeData: PlaceData) {}
+
+  override fun clearAllSharedPreferences() {}
 }
 /** Test class for the Map screen. This class contains the tests for the Map screen. */
 class MapScreenTests : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
@@ -172,7 +173,7 @@ class MapScreenTests : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
   @Test
   fun clearMarkersButtonIsDisplayedWhenNotEmpty() {
     ComposeScreen.onComposeScreen<MapScreen>(composeTestRule) {
-      FakeMapViewModel.listOfTempMarkerStates.value = listOf(MarkerState(LatLng(48.8566, 2.3522)))
+      FakeMapViewModel.listOfTempPlaceData.value = listOf(PlaceData(placeName = "Paris"))
       clearMarkersButton { assertIsDisplayed() }
     }
   }

--- a/app/src/androidTest/java/com/github/se/wanderpals/map/MapScreenTests.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/map/MapScreenTests.kt
@@ -13,6 +13,7 @@ import com.github.se.wanderpals.screens.MapScreen
 import com.github.se.wanderpals.service.MapManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.screens.trip.map.Map
+import com.google.maps.android.compose.MarkerState
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
@@ -60,7 +61,15 @@ class FakeMapViewModel : MapViewModel(TripsRepository("-1", dispatcher = Dispatc
 
   override var stops = MutableStateFlow(listOf(stop1, stop2))
 
+  override fun getAllSuggestions() {}
+
   override fun getAllStops() {}
+
+  override fun getAllUsersPositions() {}
+
+  override fun getAllTempMarkers() {}
+
+  override fun saveMarkerState(markerState: MarkerState) {}
 }
 /** Test class for the Map screen. This class contains the tests for the Map screen. */
 class MapScreenTests : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {

--- a/app/src/androidTest/java/com/github/se/wanderpals/screens/MapScreen.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/screens/MapScreen.kt
@@ -16,4 +16,5 @@ class MapScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val searchButtonIcon: KNode = onNode { hasTestTag("searchButtonIcon") }
   val clearSearchButtonIcon: KNode = onNode { hasTestTag("clearSearchButtonIcon") }
   val listOfPropositions: KNode = onNode { hasTestTag("listOfPropositions") }
+  val clearMarkersButton = onNode { hasTestTag("clearMarkersButton") }
 }

--- a/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
+++ b/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
@@ -23,6 +23,7 @@ import com.github.se.wanderpals.model.viewmodel.MainViewModel
 import com.github.se.wanderpals.model.viewmodel.OverviewViewModel
 import com.github.se.wanderpals.service.MapManager
 import com.github.se.wanderpals.service.SessionManager
+import com.github.se.wanderpals.service.SharedPreferencesManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
 import com.github.se.wanderpals.ui.navigation.Route.ROOT_ROUTE
@@ -131,6 +132,8 @@ class MainActivity : ComponentActivity() {
     super.onCreate(savedInstanceState)
 
     context = this
+
+    SharedPreferencesManager.init(context)
 
     val gso: GoogleSignInOptions =
         GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MapViewModel.kt
@@ -8,8 +8,8 @@ import com.github.se.wanderpals.model.data.Stop
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.service.SharedPreferencesManager
+import com.github.se.wanderpals.ui.screens.trip.map.PlaceData
 import com.google.android.gms.maps.model.LatLng
-import com.google.maps.android.compose.MarkerState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
@@ -28,7 +28,7 @@ open class MapViewModel(tripsRepository: TripsRepository, private val tripId: St
   open var userNames = MutableStateFlow(emptyList<String>())
   open var userPosition = MutableStateFlow(LatLng(0.0, 0.0))
   open var seeUserPosition = MutableStateFlow(false)
-  open var listOfTempMarkerStates = MutableStateFlow(emptyList<MarkerState>())
+  open var listOfTempPlaceData = MutableStateFlow(emptyList<PlaceData>())
 
   /**
    * Execute a job on the view model scope.
@@ -47,27 +47,27 @@ open class MapViewModel(tripsRepository: TripsRepository, private val tripId: St
     getAllStops()
     getAllSuggestions()
     getAllUsersPositions()
-    getAllTempMarkers()
+    getAllPlaceData()
   }
 
   /** Clear all the shared preferences. */
   open fun clearAllSharedPreferences() {
     SharedPreferencesManager.clearAll()
-    listOfTempMarkerStates.value = emptyList()
+    listOfTempPlaceData.value = emptyList()
   }
 
   /**
-   * Save the marker state.
+   * Save the place data.
    *
-   * @param markerState The marker state to save.
+   * @param placeData The place data to save.
    */
-  open fun saveMarkerState(markerState: MarkerState) {
-    listOfTempMarkerStates.value = SharedPreferencesManager.saveMarkerState(markerState)
+  open fun savePlaceDataState(placeData: PlaceData) {
+    listOfTempPlaceData.value = SharedPreferencesManager.savePlaceData(placeData)
   }
 
   /** Get all temporary markers. */
-  open fun getAllTempMarkers() {
-    listOfTempMarkerStates.value = SharedPreferencesManager.getAllTempMarkers()
+  open fun getAllPlaceData() {
+    listOfTempPlaceData.value = SharedPreferencesManager.getAllPlaceData()
   }
 
   /** Get all stops from the trip. */

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MapViewModel.kt
@@ -7,7 +7,9 @@ import com.github.se.wanderpals.model.data.GeoCords
 import com.github.se.wanderpals.model.data.Stop
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.service.SessionManager
+import com.github.se.wanderpals.service.SharedPreferencesManager
 import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.MarkerState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
@@ -26,6 +28,7 @@ open class MapViewModel(tripsRepository: TripsRepository, private val tripId: St
   open var userNames = MutableStateFlow(emptyList<String>())
   open var userPosition = MutableStateFlow(LatLng(0.0, 0.0))
   open var seeUserPosition = MutableStateFlow(false)
+  open var listOfTempMarkerStates = MutableStateFlow(emptyList<MarkerState>())
 
   /**
    * Execute a job on the view model scope.
@@ -44,6 +47,27 @@ open class MapViewModel(tripsRepository: TripsRepository, private val tripId: St
     getAllStops()
     getAllSuggestions()
     getAllUsersPositions()
+    getAllTempMarkers()
+  }
+
+  /** Clear all the shared preferences. */
+  open fun clearAllSharedPreferences() {
+    SharedPreferencesManager.clearAll()
+    listOfTempMarkerStates.value = emptyList()
+  }
+
+  /**
+   * Save the marker state.
+   *
+   * @param markerState The marker state to save.
+   */
+  open fun saveMarkerState(markerState: MarkerState) {
+    listOfTempMarkerStates.value = SharedPreferencesManager.saveMarkerState(markerState)
+  }
+
+  /** Get all temporary markers. */
+  open fun getAllTempMarkers() {
+    listOfTempMarkerStates.value = SharedPreferencesManager.getAllTempMarkers()
   }
 
   /** Get all stops from the trip. */

--- a/app/src/main/java/com/github/se/wanderpals/service/SharedPreferencesManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/SharedPreferencesManager.kt
@@ -1,0 +1,57 @@
+package com.github.se.wanderpals.service
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import com.google.android.gms.maps.model.LatLng
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.google.maps.android.compose.MarkerState
+import java.lang.reflect.Type
+
+/** Class to manage the shared preferences. */
+object SharedPreferencesManager {
+  private const val PREF_NAME_MAP = "PREFERENCE_NAME_MAP"
+  private const val LIST_OF_TEMP_MARKERS = "LIST_OF_TEMP_MARKERS"
+  private lateinit var sharedPreferencesMap: SharedPreferences
+
+  /** Function to initialize the shared preferences. */
+  fun init(context: Context) {
+    sharedPreferencesMap = context.getSharedPreferences(PREF_NAME_MAP, Context.MODE_PRIVATE)
+  }
+
+  /** Function to clear all the shared preferences. */
+  fun clearAll() {
+    sharedPreferencesMap.edit().clear().apply()
+  }
+
+  /**
+   * Save the marker state.
+   *
+   * @param markerState The marker state to save.
+   * @return The list of marker states.
+   */
+  fun saveMarkerState(markerState: MarkerState): MutableList<MarkerState> {
+    val tempMarkers = getAllTempMarkers().toMutableList()
+    tempMarkers.add(markerState)
+    val json = Gson().toJson(tempMarkers.map { it.position })
+    sharedPreferencesMap.edit().putString(LIST_OF_TEMP_MARKERS, json).apply()
+    return tempMarkers
+  }
+
+  /**
+   * Get all the temporary markers.
+   *
+   * @return The list of marker states.
+   */
+  fun getAllTempMarkers(): MutableList<MarkerState> {
+    var arrayItems: List<LatLng> = emptyList()
+    val serializedObject: String? = sharedPreferencesMap.getString(LIST_OF_TEMP_MARKERS, null)
+    Log.d("SharedPreferencesManager", "serializedObject: $serializedObject")
+    if (serializedObject != null) {
+      val type: Type = object : TypeToken<List<LatLng>>() {}.type
+      arrayItems = Gson().fromJson(serializedObject, type)
+    }
+    return arrayItems.map { MarkerState(it) }.toMutableList()
+  }
+}

--- a/app/src/main/java/com/github/se/wanderpals/service/SharedPreferencesManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/SharedPreferencesManager.kt
@@ -3,10 +3,9 @@ package com.github.se.wanderpals.service
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
-import com.google.android.gms.maps.model.LatLng
+import com.github.se.wanderpals.ui.screens.trip.map.PlaceData
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import com.google.maps.android.compose.MarkerState
 import java.lang.reflect.Type
 
 /** Class to manage the shared preferences. */
@@ -26,32 +25,32 @@ object SharedPreferencesManager {
   }
 
   /**
-   * Save the marker state.
+   * Save the place data as a json string in the shared preferences.
    *
-   * @param markerState The marker state to save.
-   * @return The list of marker states.
+   * @param placeData The place data to save.
+   * @return The list of place data with the new place data added
    */
-  fun saveMarkerState(markerState: MarkerState): MutableList<MarkerState> {
-    val tempMarkers = getAllTempMarkers().toMutableList()
-    tempMarkers.add(markerState)
-    val json = Gson().toJson(tempMarkers.map { it.position })
+  fun savePlaceData(placeData: PlaceData): MutableList<PlaceData> {
+    val listPlaceData = getAllPlaceData().toMutableList()
+    listPlaceData.add(placeData)
+    val json = Gson().toJson(listPlaceData)
     sharedPreferencesMap.edit().putString(LIST_OF_TEMP_MARKERS, json).apply()
-    return tempMarkers
+    return listPlaceData
   }
 
   /**
-   * Get all the temporary markers.
+   * Get all the place data from the shared preferences.
    *
-   * @return The list of marker states.
+   * @return The list of place data
    */
-  fun getAllTempMarkers(): MutableList<MarkerState> {
-    var arrayItems: List<LatLng> = emptyList()
+  fun getAllPlaceData(): MutableList<PlaceData> {
+    var arrayItems: List<PlaceData> = emptyList()
     val serializedObject: String? = sharedPreferencesMap.getString(LIST_OF_TEMP_MARKERS, null)
     Log.d("SharedPreferencesManager", "serializedObject: $serializedObject")
     if (serializedObject != null) {
-      val type: Type = object : TypeToken<List<LatLng>>() {}.type
+      val type: Type = object : TypeToken<List<PlaceData>>() {}.type
       arrayItems = Gson().fromJson(serializedObject, type)
     }
-    return arrayItems.map { MarkerState(it) }.toMutableList()
+    return arrayItems.toMutableList()
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/map/Map.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/map/Map.kt
@@ -361,12 +361,14 @@ fun Map(
         Modifier.align(AbsoluteAlignment.BottomRight)
             .padding(horizontal = 16.dp, vertical = 60.dp)) {
           if (listOfMarkers.isNotEmpty()) {
-            Button(onClick = { mapViewModel.clearAllSharedPreferences() }) {
-              Icon(
-                  imageVector = Icons.Default.Clear,
-                  contentDescription = "Clear",
-                  modifier = Modifier.size(24.dp))
-            }
+            Button(
+                onClick = { mapViewModel.clearAllSharedPreferences() },
+                modifier = Modifier.testTag("clearMarkersButton")) {
+                  Icon(
+                      imageVector = Icons.Default.Clear,
+                      contentDescription = "Clear",
+                      modifier = Modifier.size(24.dp))
+                }
           }
 
           Button(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/map/Map.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/map/Map.kt
@@ -128,7 +128,7 @@ fun Map(
   // Bottom Sheet Variables
 
   // place data of the searched location
-  var placeData by remember { mutableStateOf(PlaceData()) }
+  val placeData by remember { mutableStateOf(PlaceData()) }
   // bottom sheet state
   val bottomSheetScaffoldState = rememberBottomSheetScaffoldState()
   // bottom sheet state expanded
@@ -251,7 +251,7 @@ fun Map(
                             textSearchBar = primaryText
                             mapManager.fetchPlace(placeId).addOnSuccessListener { response ->
                               val place = response.place
-                              placeData = placeData.setPlaceData(place, placeId)
+                              placeData.setPlaceData(place, placeId, place.latLng!!)
                               searchedLocation = place.latLng!!
                             }
                           })
@@ -286,6 +286,7 @@ fun Map(
                 state = markerState,
                 title = "Click to Create Suggestions",
                 onInfoWindowClick = {
+                  bottomSheetExpanded = false
                   oldNavActions.setVariablesSuggestion(
                       suggestion =
                           Suggestion(
@@ -303,19 +304,22 @@ fun Map(
 
           // display all the stops on the map
           stopList.forEach { stop ->
+            val latLng = LatLng(stop.geoCords.latitude, stop.geoCords.longitude)
             Marker( // Add a marker to the map
-                state =
-                    MarkerState(position = LatLng(stop.geoCords.latitude, stop.geoCords.longitude)),
+                state = MarkerState(position = latLng),
                 title = stop.title,
                 snippet = stop.description,
                 icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE),
                 onInfoWindowClick = {
+                  bottomSheetExpanded = false
+                  finalLocation = latLng
+
                   // check if stop.stopId contains a "," and if it does, split it and get the first
                   if (stop.stopId.last() != ',' && stop.stopId.contains(',')) {
                     val placeId = stop.stopId.split(",")[1]
                     mapManager.fetchPlace(placeId).addOnSuccessListener { response ->
                       val place = response.place
-                      placeData = placeData.setPlaceData(place, placeId)
+                      placeData.setPlaceData(place, placeId, place.latLng!!)
                       searchedLocation = place.latLng!!
                       bottomSheetExpanded = true
                     }
@@ -325,16 +329,19 @@ fun Map(
 
           // display all the suggestions on the map
           suggestionList.forEach { stop ->
+            val latLng = LatLng(stop.geoCords.latitude, stop.geoCords.longitude)
             Marker( // Add a marker to the map
-                state =
-                    MarkerState(position = LatLng(stop.geoCords.latitude, stop.geoCords.longitude)),
+                state = MarkerState(position = latLng),
                 title = stop.title,
                 snippet = stop.description,
                 icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_GREEN),
                 onInfoWindowClick = {
+                  bottomSheetExpanded = false
+                  finalLocation = latLng
+
                   mapManager.fetchPlace(stop.stopId).addOnSuccessListener { response ->
                     val place = response.place
-                    placeData = placeData.setPlaceData(place, stop.stopId)
+                    placeData.setPlaceData(place, stop.stopId, place.latLng!!)
                     searchedLocation = place.latLng!!
                     bottomSheetExpanded = true
                   }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/map/Map.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/map/Map.kt
@@ -114,7 +114,7 @@ fun Map(
         })
   }
   // list of markers on the map from the search bar
-  var listOfMarkers by remember { mutableStateOf(listOf<MarkerState>()) }
+  val listOfMarkers by mapViewModel.listOfTempMarkerStates.collectAsState()
 
   // Location Variables
 
@@ -199,7 +199,7 @@ fun Map(
             finalLocation = searchedLocation
             finalName = textSearchBar
 
-            listOfMarkers += (MarkerState(position = finalLocation))
+            mapViewModel.saveMarkerState(MarkerState(position = finalLocation))
             bottomSheetExpanded = true
             activeSearchBar = false
           },
@@ -360,6 +360,15 @@ fun Map(
     Column(
         Modifier.align(AbsoluteAlignment.BottomRight)
             .padding(horizontal = 16.dp, vertical = 60.dp)) {
+          if (listOfMarkers.isNotEmpty()) {
+            Button(onClick = { mapViewModel.clearAllSharedPreferences() }) {
+              Icon(
+                  imageVector = Icons.Default.Clear,
+                  contentDescription = "Clear",
+                  modifier = Modifier.size(24.dp))
+            }
+          }
+
           Button(
               onClick = {
                 mapViewModel.executeJob {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/map/PlaceData.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/map/PlaceData.kt
@@ -1,5 +1,6 @@
 package com.github.se.wanderpals.ui.screens.trip.map
 
+import com.google.android.gms.maps.model.LatLng
 import com.google.android.libraries.places.api.model.Place
 
 /** Data class to store the place details. */
@@ -13,11 +14,13 @@ data class PlaceData(
     var placeWebsite: String = "",
     var placeOpeningHours: String = "",
     var placeIconUrl: String = "",
-    var placeBusinessStatus: String = ""
+    var placeBusinessStatus: String = "",
+    var placeCoordinates: LatLng = LatLng(0.0, 0.0)
 ) {
 
   /** Function to set the place data. */
-  fun setPlaceData(place: Place, placeId: String): PlaceData {
+  fun setPlaceData(place: Place, placeId: String, placeCoordinates: LatLng): PlaceData {
+    this.placeCoordinates = placeCoordinates
     this.placeId = placeId
     place.name?.let { it1 -> placeName = it1 }
     place.iconUrl?.let { it1 -> placeIconUrl = it1 }

--- a/app/src/test/java/com/github/se/wanderpals/service/SharedPreferencesManagerTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/service/SharedPreferencesManagerTest.kt
@@ -3,8 +3,7 @@ package com.github.se.wanderpals.service
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import com.google.android.gms.maps.model.LatLng
-import com.google.maps.android.compose.MarkerState
+import com.github.se.wanderpals.ui.screens.trip.map.PlaceData
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -13,37 +12,37 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class SharedPreferencesManagerTest {
 
-  private lateinit var saveOfMarkerState: MutableList<MarkerState>
+  private lateinit var saveOfMarkerState: MutableList<PlaceData>
 
   @Before
   fun saveMarkerState() {
     val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
     SharedPreferencesManager.init(context)
-    saveOfMarkerState = SharedPreferencesManager.getAllTempMarkers()
+    saveOfMarkerState = SharedPreferencesManager.getAllPlaceData()
   }
 
   @Test
   fun testSaveMarkerState() {
-    val markerState = MarkerState(LatLng(37.7749, -122.4194))
-    assert(SharedPreferencesManager.getAllTempMarkers().isEmpty())
-    val savedMarkers = SharedPreferencesManager.saveMarkerState(markerState)
+    val placeData = PlaceData(placeName = "Las Vegas")
+    assert(SharedPreferencesManager.getAllPlaceData().isEmpty())
+    val savedMarkers = SharedPreferencesManager.savePlaceData(placeData)
     assert(savedMarkers.isNotEmpty())
-    assert(savedMarkers.contains(markerState))
+    assert(savedMarkers.contains(placeData))
   }
 
   @Test
   fun testGetAllTempMarkers() {
-    val markerState = MarkerState(LatLng(37.7749, -122.4194))
-    assert(SharedPreferencesManager.saveMarkerState(markerState).isNotEmpty())
-    assert(SharedPreferencesManager.getAllTempMarkers().isNotEmpty())
+    val placeData = PlaceData(placeName = "Las Vegas")
+    assert(SharedPreferencesManager.savePlaceData(placeData).isNotEmpty())
+    assert(SharedPreferencesManager.getAllPlaceData().isNotEmpty())
     SharedPreferencesManager.clearAll()
-    assert(SharedPreferencesManager.getAllTempMarkers().isEmpty())
-    assert(SharedPreferencesManager.saveMarkerState(markerState).isNotEmpty())
+    assert(SharedPreferencesManager.getAllPlaceData().isEmpty())
+    assert(SharedPreferencesManager.savePlaceData(placeData).isNotEmpty())
   }
 
   @After
   fun restoreMarkerState() {
     SharedPreferencesManager.clearAll()
-    saveOfMarkerState.forEach { SharedPreferencesManager.saveMarkerState(it) }
+    saveOfMarkerState.forEach { SharedPreferencesManager.savePlaceData(it) }
   }
 }

--- a/app/src/test/java/com/github/se/wanderpals/service/SharedPreferencesManagerTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/service/SharedPreferencesManagerTest.kt
@@ -1,0 +1,49 @@
+package com.github.se.wanderpals.service
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.MarkerState
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SharedPreferencesManagerTest {
+
+  private lateinit var saveOfMarkerState: MutableList<MarkerState>
+
+  @Before
+  fun saveMarkerState() {
+    val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+    SharedPreferencesManager.init(context)
+    saveOfMarkerState = SharedPreferencesManager.getAllTempMarkers()
+  }
+
+  @Test
+  fun testSaveMarkerState() {
+    val markerState = MarkerState(LatLng(37.7749, -122.4194))
+    assert(SharedPreferencesManager.getAllTempMarkers().isEmpty())
+    val savedMarkers = SharedPreferencesManager.saveMarkerState(markerState)
+    assert(savedMarkers.isNotEmpty())
+    assert(savedMarkers.contains(markerState))
+  }
+
+  @Test
+  fun testGetAllTempMarkers() {
+    val markerState = MarkerState(LatLng(37.7749, -122.4194))
+    assert(SharedPreferencesManager.saveMarkerState(markerState).isNotEmpty())
+    assert(SharedPreferencesManager.getAllTempMarkers().isNotEmpty())
+    SharedPreferencesManager.clearAll()
+    assert(SharedPreferencesManager.getAllTempMarkers().isEmpty())
+    assert(SharedPreferencesManager.saveMarkerState(markerState).isNotEmpty())
+  }
+
+  @After
+  fun restoreMarkerState() {
+    SharedPreferencesManager.clearAll()
+    saveOfMarkerState.forEach { SharedPreferencesManager.saveMarkerState(it) }
+  }
+}


### PR DESCRIPTION
* Created a SharedPreferencesManager that can be used by everyone to save instances of classes or variables. It's currently used to save temporary PlaceDatas that were places on the map throw the search but weren't transformed into suggestions. 

* Replaced the OnInfoWindowClick  with OnClick for stops and suggestions
* Reduced Google Place API calls by fetching when the search is clicked instead of when the proposition is cleared

* Added Tests and Adapted already existing ones
