### PR TITLE
fixed editing comment + fixed admin screen

### DIFF
--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SuggestionsViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SuggestionsViewModel.kt
@@ -275,6 +275,7 @@ open class SuggestionsViewModel(
 
   open fun confirmDeleteComment(suggestion: Suggestion) {
     deleteComment(suggestion) // Assuming deleteComment handles all necessary logic
+    cancelEditComment()
     hideDeleteDialog()
     hideBottomSheet()
   }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionDetail.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionDetail.kt
@@ -344,7 +344,7 @@ private fun onDone(
   } else {
     if (string.isNotBlank()) {
       viewModel.addComment(
-          suggestion, Comment("", "", "tempUsername", string, LocalDate.now(), LocalTime.now()))
+          suggestion, Comment("", "", "", string, LocalDate.now(), LocalTime.now()))
       exec()
     }
   }


### PR DESCRIPTION
In this PR, the following has been done : 

- After editing and then deleting a comment, the app won't crash anymore when sending a comment.
- The owner now cannot delete themselves from the trip without giving their role first
- The owner cannot demote themselves anymore without giving their role first
- Users can now promote other users up to their role - 1 and can now demote themselves to any role below them
- Changed the display a bit to accommodate changes: grayed out inaccessible roles when editing, removed some buttons for the owner which he cannot do