### PR TITLE
Bug fixes regarding NavGraphs, Permissions, Quitting trip

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/endToEndTests/EndToEndTestMilestone1.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/endToEndTests/EndToEndTestMilestone1.kt
@@ -18,6 +18,7 @@ import com.github.se.wanderpals.screens.CreateTripoScreen
 import com.github.se.wanderpals.screens.OverviewScreen
 import com.github.se.wanderpals.screens.TripScreen
 import com.github.se.wanderpals.service.MapManager
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
 import com.github.se.wanderpals.ui.navigation.rememberMultiNavigationAppState
@@ -51,6 +52,8 @@ class EndToEndTestMilestone1 : TestCase(kaspressoBuilder = Kaspresso.Builder.wit
 
   @Before
   fun testSetup() {
+
+    SessionManager.setUserSession(userId = "user1")
 
     val context = ApplicationProvider.getApplicationContext<Context>()
     val mapManager = MapManager(context)

--- a/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
@@ -15,6 +15,7 @@ import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.OverviewViewModel
 import com.github.se.wanderpals.screens.OverviewScreen
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
 import com.github.se.wanderpals.ui.screens.overview.Overview
@@ -64,7 +65,7 @@ class OverviewViewModelTest :
           description = "A ski trip to the snowy mountains.",
           imageUrl = "https://example.com/winter_ski_trip.jpg",
           stops = listOf("ski_resort1", "ski_resort2"),
-          users = listOf("user4", "user5"),
+          users = listOf("user1", "user4", "user5"),
           suggestions = listOf("suggestion3", "suggestion4", "suggestion5"))
 
   private val trip3 =
@@ -77,7 +78,7 @@ class OverviewViewModelTest :
           description = "Exploring famous landmarks and enjoying city life.",
           imageUrl = "https://example.com/city_exploration.jpg",
           stops = listOf("city_stop1", "city_stop2"),
-          users = listOf("user6", "user7", "user8"),
+          users = listOf("user1", "user6", "user7", "user8"),
           suggestions = emptyList())
   private val _state = MutableStateFlow(listOf(trip1, trip2, trip3))
   override val state: StateFlow<List<Trip>> = _state
@@ -90,7 +91,8 @@ class OverviewViewModelTest :
   }
 
   override fun createTrip(trip: Trip) {
-    _state.value = _state.value.toMutableList().apply { add(trip) }
+    val newTrip = trip.copy(users = listOf("user1"))
+    _state.value = _state.value.toMutableList().apply { add(newTrip) }
   }
 
   override fun getAllTrips() {}
@@ -109,6 +111,8 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
 
   @Before
   fun testSetup() {
+    SessionManager.setUserSession(userId = "user1")
+
     composeTestRule.setContent {
       Overview(overviewViewModel = overviewViewModelTest, navigationActions = mockNavActions)
     }

--- a/app/src/main/java/com/github/se/wanderpals/service/MapManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/MapManager.kt
@@ -95,11 +95,6 @@ class MapManager(private val context: Context) {
           ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
               PackageManager.PERMISSION_GRANTED) {
         Log.d("MapActivity", "Location permission already granted")
-      } else if (ContextCompat.checkSelfPermission(
-          context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_DENIED &&
-          ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
-              PackageManager.PERMISSION_DENIED) {
-        Log.d("MapActivity", "Location permission already denied")
       } else {
         Log.d("MapActivity", "Requesting location permission")
         locationPermissionRequest.launch(

--- a/app/src/main/java/com/github/se/wanderpals/service/MapManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/MapManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
+import androidx.core.content.ContextCompat
 import com.github.se.wanderpals.BuildConfig
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
@@ -89,9 +90,23 @@ class MapManager(private val context: Context) {
   /** Function to ask for location permission. */
   fun askLocationPermission() {
     if (::locationPermissionRequest.isInitialized) {
-      locationPermissionRequest.launch(
-          arrayOf(
-              Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION))
+      if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
+          PackageManager.PERMISSION_GRANTED ||
+          ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+              PackageManager.PERMISSION_GRANTED) {
+        Log.d("MapActivity", "Location permission already granted")
+      } else if (ContextCompat.checkSelfPermission(
+          context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_DENIED &&
+          ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+              PackageManager.PERMISSION_DENIED) {
+        Log.d("MapActivity", "Location permission already denied")
+      } else {
+        Log.d("MapActivity", "Requesting location permission")
+        locationPermissionRequest.launch(
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION))
+      }
     }
   }
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/navigation/NavigationActions.kt
@@ -125,15 +125,29 @@ data class NavigationActions(
    * @param route The route to navigate to.
    */
   fun navigateTo(route: String) {
-    Log.d("NavigationAction", "navigateTo before")
-    if (TRIP_DESTINATIONS.any { it.route == route }) {
+    if (TRIP_DESTINATIONS.any { it.route == route } && checkIfNavGraphWasSet(tripNavigation)) {
       lastlyUsedController = tripNavigation
       tripNavigation.navigateTo(route)
-    } else if (MAIN_ROUTES.any { it == route }) {
+    } else if (MAIN_ROUTES.any { it == route } && checkIfNavGraphWasSet(mainNavigation)) {
       lastlyUsedController = mainNavigation
       mainNavigation.navigateTo(route)
     }
-    Log.d("NavigationAction", "navigateTo after")
+  }
+
+  /**
+   * Check if the nav graph was set.
+   *
+   * @param nav The navigation state.
+   * @return True if the nav graph was set, false otherwise.
+   */
+  private fun checkIfNavGraphWasSet(nav: MultiNavigationAppState): Boolean {
+    return try {
+      nav.getNavController.graph
+      true
+    } catch (e: Exception) {
+      Log.d("NavigationAction", "Nav graph was not set")
+      false
+    }
   }
 
   /**

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -24,8 +25,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -81,6 +84,9 @@ fun OverviewTrip(trip: Trip, navigationActions: NavigationActions) {
   // Mutable state to check if the icon button for sharing the trip is selected
   val isSelected = remember { mutableStateOf(false) }
 
+  // Mutable state to check if the dialog is open
+  var dialogIsOpen by remember { mutableStateOf(false) }
+
   // Use of a launch effect to reset the value of isSelected to false after 100ms
   LaunchedEffect(isSelected.value) {
     if (isSelected.value) {
@@ -89,13 +95,32 @@ fun OverviewTrip(trip: Trip, navigationActions: NavigationActions) {
     }
   }
 
+  if (dialogIsOpen) {
+    AlertDialog(
+        onDismissRequest = { dialogIsOpen = false },
+        title = { Text("You are no longer part of this trip.") },
+        text = { Text("please refresh the page to see the updated list of trips.") },
+        confirmButton = {
+          Button(
+              onClick = { dialogIsOpen = false },
+          ) {
+            Text("Close")
+          }
+        })
+  }
+
   Box(modifier = Modifier.fillMaxWidth()) {
     // Button representing the trip overview
     Button(
         onClick = {
-          SessionManager.setTripName(trip.title)
-          navigationActions.setVariablesTrip(trip.tripId)
-          navigationActions.navigateTo(Route.TRIP)
+          if (trip.users.find { it == SessionManager.getCurrentUser()!!.userId } != null) {
+            dialogIsOpen = false
+            SessionManager.setTripName(trip.title)
+            navigationActions.setVariablesTrip(trip.tripId)
+            navigationActions.navigateTo(Route.TRIP)
+          } else {
+            dialogIsOpen = true
+          }
         },
         modifier =
             Modifier.align(Alignment.TopCenter)


### PR DESCRIPTION
This PR addresses three bugs that were found by other members during their own coding:
* Sometimes the NavGraph isn't set yet and when pressing to fast on the NavBar when coming from the overview, you can try to navigate before the navigation was set. Fixed by checking if a call to this graph throws an exception
* When quitting a trip from the Admin Panel, the overview wouldn't sometimes update (I guess not garbage collected) and would still display a clickable trip even tho it shouldn't. Now displays a warning and asks the user to refresh.
* Maps sometimes still asked for permission even though it was granted or denied, now added a check