### PR TITLE
Fixed create suggestion to get the correct username for the suggestion

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/suggestion/CreateSuggestionTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/suggestion/CreateSuggestionTest.kt
@@ -8,6 +8,7 @@ import com.github.se.wanderpals.model.data.Suggestion
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.CreateSuggestionViewModel
 import com.github.se.wanderpals.screens.CreateSuggestionScreen
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
 import com.github.se.wanderpals.ui.screens.suggestion.CreateSuggestion
@@ -128,6 +129,8 @@ class CreateSuggestionTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
             onCancel = { mockNavActions.navigateTo(Route.DASHBOARD) })
       }
 
+      SessionManager.setUserSession("testUser123", "tempUsername")
+
       step("Open create suggestion screen") {
         inputTitle {
           assertIsDisplayed()
@@ -230,6 +233,8 @@ class CreateSuggestionTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
             onSuccess = { mockNavActions.navigateTo(Route.SUGGESTION) },
             onCancel = { mockNavActions.navigateTo(Route.DASHBOARD) })
       }
+
+      SessionManager.setUserSession("testUser123", "tempUsername")
 
       step("Open create suggestion screen") {
         inputTitle {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CreateSuggestion.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CreateSuggestion.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.github.se.wanderpals.model.data.Stop
 import com.github.se.wanderpals.model.data.Suggestion
 import com.github.se.wanderpals.model.viewmodel.CreateSuggestionViewModel
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.screens.DateInteractionSource
 import com.github.se.wanderpals.ui.screens.MyDatePickerDialog
 import java.time.Duration
@@ -317,7 +318,7 @@ fun CreateSuggestion(
                       Suggestion(
                           suggestionId = "", // modified by database
                           userId = "", // modified by database
-                          userName = "tempUsername", // modified by database
+                          userName = SessionManager.getCurrentUser()!!.name, // modified by database
                           text = "", // Empty for now
                           createdAt = LocalDate.now(), // Should add time
                           createdAtTime = LocalTime.now(),


### PR DESCRIPTION
In this PR, the following has been done : 

- When creating a suggestion, the correct username is given instead of a placeholder