### PR TITLE
Trip overview screen UI based on Figma

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
@@ -127,11 +127,9 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
 
       buttonTrip1 { assertIsDisplayed() }
       buttonTrip2 { assertIsDisplayed() }
-      buttonTrip3 { assertIsDisplayed() }
 
       shareTripButton1 { assertIsDisplayed() }
       shareTripButton2 { assertIsDisplayed() }
-      shareTripButton3 { assertIsDisplayed() }
 
       joinTripButton { assertIsDisplayed() }
       createTripButton { assertIsDisplayed() }
@@ -297,11 +295,9 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
 
       buttonTrip1 { assertIsDisplayed() }
       buttonTrip2 { assertIsDisplayed() }
-      buttonTrip3 { assertIsDisplayed() }
 
       shareTripButton1 { assertIsDisplayed() }
       shareTripButton2 { assertIsDisplayed() }
-      shareTripButton3 { assertIsDisplayed() }
 
       joinTripButton { assertIsDisplayed() }
       createTripButton { assertIsDisplayed() }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewBottomBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewBottomBar.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -15,7 +14,6 @@ import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,6 +24,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.github.se.wanderpals.ui.theme.onPrimaryContainerLight
+import com.github.se.wanderpals.ui.theme.primaryContainerLight
+
 
 /**
  * Composable function that represents the bottom bar for the overview screen. Provides options for
@@ -44,15 +45,13 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
       Button(
           onClick = { onLinkClick() },
           modifier =
-              Modifier.width(300.dp)
-                  .height(70.dp)
+              Modifier.width(320.dp)
+                  .height(60.dp)
                   .padding(bottom = 20.dp)
                   .align(Alignment.TopCenter)
                   .testTag("joinTripButton"),
-          colors =
-              ButtonDefaults.buttonColors(
-                  containerColor = MaterialTheme.colorScheme.primaryContainer,
-                  contentColor = MaterialTheme.colorScheme.onPrimaryContainer)) {
+          colors = ButtonDefaults.buttonColors(containerColor = primaryContainerLight)
+      ) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically,
@@ -60,17 +59,21 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
               Icon(
                   imageVector = Icons.Default.Share,
                   contentDescription = Icons.Default.Share.name,
-                  modifier = Modifier.size(20.dp))
+                  modifier = Modifier.width(18.dp).height(20.dp),
+                  tint = onPrimaryContainerLight
+              )
               Text(
-                  text = "Join a trip",
+                  text = "Join a Trip",
                   style =
                       TextStyle(
-                          fontSize = 18.sp,
-                          lineHeight = 18.sp,
+                          fontSize = 20.sp,
+                          lineHeight = 20.sp,
                           fontWeight = FontWeight(500),
+                          color = onPrimaryContainerLight,
                           textAlign = TextAlign.Center,
-                          letterSpacing = 0.5.sp,
-                      ))
+                          letterSpacing = 0.1.sp,
+                      )
+              )
             }
           }
     }
@@ -80,15 +83,13 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
       Button(
           onClick = { onCreateTripClick() },
           modifier =
-              Modifier.width(300.dp)
-                  .height(70.dp)
+              Modifier.width(320.dp)
+                  .height(60.dp)
                   .padding(bottom = 20.dp)
                   .align(Alignment.TopCenter)
                   .testTag("createTripButton"),
-          colors =
-              ButtonDefaults.buttonColors(
-                  containerColor = MaterialTheme.colorScheme.primaryContainer,
-                  contentColor = MaterialTheme.colorScheme.onPrimaryContainer)) {
+          colors = ButtonDefaults.buttonColors(containerColor = primaryContainerLight)
+      ) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically,
@@ -96,17 +97,21 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
               Icon(
                   imageVector = Icons.Default.Add,
                   contentDescription = Icons.Default.Add.name,
-                  modifier = Modifier.size(20.dp))
+                  modifier = Modifier.width(18.dp).height(18.dp),
+                  tint = onPrimaryContainerLight
+              )
               Text(
-                  text = "Create a new trip",
+                  text = "Create a New Trip",
                   style =
                       TextStyle(
-                          fontSize = 18.sp,
+                          fontSize = 20.sp,
                           lineHeight = 20.sp,
                           fontWeight = FontWeight(500),
+                          color = onPrimaryContainerLight,
                           textAlign = TextAlign.Center,
-                          letterSpacing = 0.5.sp,
-                      ))
+                          letterSpacing = 0.1.sp,
+                      )
+              )
             }
           }
     }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewBottomBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewBottomBar.kt
@@ -44,7 +44,7 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
       Button(
           onClick = { onLinkClick() },
           modifier =
-              Modifier.width(320.dp)
+              Modifier.width(360.dp)
                   .height(70.dp)
                   .padding(bottom = 20.dp)
                   .align(Alignment.TopCenter)
@@ -79,7 +79,7 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
       Button(
           onClick = { onCreateTripClick() },
           modifier =
-              Modifier.width(320.dp)
+              Modifier.width(360.dp)
                   .height(70.dp)
                   .padding(bottom = 20.dp)
                   .align(Alignment.TopCenter)

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewBottomBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewBottomBar.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.ui.theme.onPrimaryContainerLight
 import com.github.se.wanderpals.ui.theme.primaryContainerLight
 
-
 /**
  * Composable function that represents the bottom bar for the overview screen. Provides options for
  * joining a trip and creating a new trip.
@@ -50,8 +49,7 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
                   .padding(bottom = 20.dp)
                   .align(Alignment.TopCenter)
                   .testTag("joinTripButton"),
-          colors = ButtonDefaults.buttonColors(containerColor = primaryContainerLight)
-      ) {
+          colors = ButtonDefaults.buttonColors(containerColor = primaryContainerLight)) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically,
@@ -60,8 +58,7 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
                   imageVector = Icons.Default.Share,
                   contentDescription = Icons.Default.Share.name,
                   modifier = Modifier.width(18.dp).height(20.dp),
-                  tint = onPrimaryContainerLight
-              )
+                  tint = onPrimaryContainerLight)
               Text(
                   text = "Join a Trip",
                   style =
@@ -72,8 +69,7 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
                           color = onPrimaryContainerLight,
                           textAlign = TextAlign.Center,
                           letterSpacing = 0.1.sp,
-                      )
-              )
+                      ))
             }
           }
     }
@@ -88,8 +84,7 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
                   .padding(bottom = 20.dp)
                   .align(Alignment.TopCenter)
                   .testTag("createTripButton"),
-          colors = ButtonDefaults.buttonColors(containerColor = primaryContainerLight)
-      ) {
+          colors = ButtonDefaults.buttonColors(containerColor = primaryContainerLight)) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically,
@@ -98,8 +93,7 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
                   imageVector = Icons.Default.Add,
                   contentDescription = Icons.Default.Add.name,
                   modifier = Modifier.width(18.dp).height(18.dp),
-                  tint = onPrimaryContainerLight
-              )
+                  tint = onPrimaryContainerLight)
               Text(
                   text = "Create a New Trip",
                   style =
@@ -110,8 +104,7 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
                           color = onPrimaryContainerLight,
                           textAlign = TextAlign.Center,
                           letterSpacing = 0.1.sp,
-                      )
-              )
+                      ))
             }
           }
     }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewBottomBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewBottomBar.kt
@@ -45,7 +45,7 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
           onClick = { onLinkClick() },
           modifier =
               Modifier.width(320.dp)
-                  .height(60.dp)
+                  .height(70.dp)
                   .padding(bottom = 20.dp)
                   .align(Alignment.TopCenter)
                   .testTag("joinTripButton"),
@@ -80,7 +80,7 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
           onClick = { onCreateTripClick() },
           modifier =
               Modifier.width(320.dp)
-                  .height(60.dp)
+                  .height(70.dp)
                   .padding(bottom = 20.dp)
                   .align(Alignment.TopCenter)
                   .testTag("createTripButton"),

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
@@ -102,7 +102,7 @@ fun OverviewContent(
         // Title for the list of trips
         Text(
             text = "My trip projects",
-            modifier = Modifier.padding(start = 27.dp, top = 10.dp, bottom=20.dp),
+            modifier = Modifier.padding(start = 27.dp, top = 10.dp, bottom = 20.dp),
             style =
                 TextStyle(
                     fontSize = 20.sp,

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
@@ -102,7 +102,7 @@ fun OverviewContent(
         // Title for the list of trips
         Text(
             text = "My trip projects",
-            modifier = Modifier.padding(start = 27.dp, top = 10.dp),
+            modifier = Modifier.padding(start = 27.dp, top = 10.dp, bottom=20.dp),
             style =
                 TextStyle(
                     fontSize = 20.sp,

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.DockedSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -43,7 +42,10 @@ fun OverviewTopBar(searchText: String, onSearchTextChanged: (String) -> Unit) {
   Box(modifier = Modifier.fillMaxWidth()) {
     // DockedSearchBar component
     DockedSearchBar(
-        modifier = Modifier.align(Alignment.Center).padding(top = 16.dp, bottom=14.dp).testTag("dockedSearchBar"),
+        modifier =
+            Modifier.align(Alignment.Center)
+                .padding(top = 16.dp, bottom = 14.dp)
+                .testTag("dockedSearchBar"),
         query = searchText,
         onQueryChange = { newText -> onSearchTextChanged(newText) },
         onSearch = {},
@@ -52,24 +54,24 @@ fun OverviewTopBar(searchText: String, onSearchTextChanged: (String) -> Unit) {
         placeholder = { Text("Search a trip") },
         trailingIcon = {
           // Show search icon if search text is empty, otherwise show clear icon
-              if (searchText.isNotEmpty()) {
-                  IconButton(
-                      modifier = Modifier.testTag("clearSearchButton"),
-                      onClick = { onSearchTextChanged(EMPTY_SEARCH) }) {
-                      Icon(
-                          imageVector = Icons.Default.Clear,
-                          contentDescription = Icons.Default.Clear.name,
-                          modifier = Modifier.size(24.dp),
-                          tint = onSurfaceVariantLight)
-                  }
-              }
+          if (searchText.isNotEmpty()) {
+            IconButton(
+                modifier = Modifier.testTag("clearSearchButton"),
+                onClick = { onSearchTextChanged(EMPTY_SEARCH) }) {
+                  Icon(
+                      imageVector = Icons.Default.Clear,
+                      contentDescription = Icons.Default.Clear.name,
+                      modifier = Modifier.size(24.dp),
+                      tint = onSurfaceVariantLight)
+                }
+          }
         },
         leadingIcon = {
-            Icon(
-                imageVector = Icons.Default.Search,
-                contentDescription = Icons.Default.Search.name,
-                modifier = Modifier.size(24.dp),
-                tint = onSurfaceVariantLight)
+          Icon(
+              imageVector = Icons.Default.Search,
+              contentDescription = Icons.Default.Search.name,
+              modifier = Modifier.size(24.dp),
+              tint = onSurfaceVariantLight)
         }) {}
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.github.se.wanderpals.ui.theme.onSurfaceVariantLight
 
 // Constant for empty search text
 const val EMPTY_SEARCH = ""
@@ -42,7 +43,7 @@ fun OverviewTopBar(searchText: String, onSearchTextChanged: (String) -> Unit) {
   Box(modifier = Modifier.fillMaxWidth()) {
     // DockedSearchBar component
     DockedSearchBar(
-        modifier = Modifier.align(Alignment.Center).padding(top = 16.dp).testTag("dockedSearchBar"),
+        modifier = Modifier.align(Alignment.Center).padding(top = 16.dp, bottom=14.dp).testTag("dockedSearchBar"),
         query = searchText,
         onQueryChange = { newText -> onSearchTextChanged(newText) },
         onSearch = {},
@@ -51,27 +52,24 @@ fun OverviewTopBar(searchText: String, onSearchTextChanged: (String) -> Unit) {
         placeholder = { Text("Search a trip") },
         trailingIcon = {
           // Show search icon if search text is empty, otherwise show clear icon
-          if (searchText.isEmpty()) {
+              if (searchText.isNotEmpty()) {
+                  IconButton(
+                      modifier = Modifier.testTag("clearSearchButton"),
+                      onClick = { onSearchTextChanged(EMPTY_SEARCH) }) {
+                      Icon(
+                          imageVector = Icons.Default.Clear,
+                          contentDescription = Icons.Default.Clear.name,
+                          modifier = Modifier.size(24.dp),
+                          tint = onSurfaceVariantLight)
+                  }
+              }
+        },
+        leadingIcon = {
             Icon(
                 imageVector = Icons.Default.Search,
                 contentDescription = Icons.Default.Search.name,
-                modifier = Modifier.size(24.dp))
-          } else {
-            IconButton(
-                modifier = Modifier.testTag("clearSearchButton"),
-                onClick = { onSearchTextChanged(EMPTY_SEARCH) }) {
-                  Icon(
-                      imageVector = Icons.Default.Clear,
-                      contentDescription = Icons.Default.Clear.name,
-                      modifier = Modifier.size(24.dp))
-                }
-          }
-        },
-        leadingIcon = {
-          Icon(
-              imageVector = Icons.Default.Menu,
-              contentDescription = Icons.Default.Menu.name,
-              modifier = Modifier.size(24.dp))
+                modifier = Modifier.size(24.dp),
+                tint = onSurfaceVariantLight)
         }) {}
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
@@ -36,7 +36,7 @@ const val EMPTY_SEARCH = ""
 @Composable
 fun OverviewTopBar(searchText: String, onSearchTextChanged: (String) -> Unit) {
 
-  // State to track search bar activation
+  // State to track search bar activation:
   var active by remember { mutableStateOf(false) }
 
   Box(modifier = Modifier.fillMaxWidth()) {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -33,12 +33,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
+import com.github.se.wanderpals.ui.theme.primaryContainerLight
 import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.delay
 
@@ -106,40 +108,65 @@ fun OverviewTrip(trip: Trip, navigationActions: NavigationActions) {
         shape = RoundedCornerShape(size = 15.dp),
         colors =
             ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.primaryContainer)) {
+                containerColor = primaryContainerLight)) {
           // Column containing trip information
           Column(modifier = Modifier.width(320.dp)) {
-            // Trip title
-            Text(
-                text = trip.title,
-                modifier = Modifier.height(24.dp),
-                style =
-                    TextStyle(
-                        fontSize = 16.sp,
-                        lineHeight = 24.sp,
-                        fontWeight = FontWeight(500),
-                        color = MaterialTheme.colorScheme.onPrimaryContainer,
-                        letterSpacing = 0.5.sp,
-                    ))
-            Spacer(modifier = Modifier.height(3.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween) {
-                  // Start date
+              Row(){
+                  // Trip title
                   Text(
-                      text =
-                          "From : %s"
-                              .format(
-                                  trip.startDate.format(DateTimeFormatter.ofPattern(DATE_PATTERN))),
+                      text = trip.title,
                       modifier = Modifier.height(24.dp),
                       style =
-                          TextStyle(
-                              fontSize = 12.sp,
-                              lineHeight = 24.sp,
-                              fontWeight = FontWeight(500),
-                              color = MaterialTheme.colorScheme.onPrimaryContainer,
-                              letterSpacing = 0.5.sp,
-                          ))
+                      TextStyle(
+                          fontSize = 16.sp,
+                          lineHeight = 24.sp,
+                          fontWeight = FontWeight(500),
+                          color = MaterialTheme.colorScheme.onPrimaryContainer,
+                          letterSpacing = 0.5.sp,
+                      ),
+                      textAlign = TextAlign.Start
+                  )
+
+                  Spacer(Modifier.weight(1f))
+
+                  // Start date
+                  Text(
+                      text = trip.startDate.format(DateTimeFormatter.ofPattern(DATE_PATTERN)),
+                      modifier = Modifier.height(24.dp),
+                      style =
+                      TextStyle(
+                          fontSize = 12.sp,
+                          lineHeight = 24.sp,
+                          fontWeight = FontWeight(500),
+                          color = MaterialTheme.colorScheme.onPrimaryContainer,
+                          letterSpacing = 0.5.sp,
+                      ),
+                      textAlign = TextAlign.End
+                  )
+
+                  Spacer(modifier = Modifier.width(11.dp)) // Space between start and end date
+                  // End date
+                  Text(
+                      text = trip.endDate.format(DateTimeFormatter.ofPattern(DATE_PATTERN)),
+                      modifier = Modifier.height(24.dp),
+                      style =
+                      TextStyle(
+                          fontSize = 12.sp,
+                          lineHeight = 24.sp,
+                          fontWeight = FontWeight(500),
+                          color = MaterialTheme.colorScheme.onPrimaryContainer,
+                          letterSpacing = 0.5.sp,
+                      ),
+                      textAlign = TextAlign.End
+                  )
+              }
+
+//            Row(
+//                modifier = Modifier.fillMaxWidth(),
+//                horizontalArrangement = Arrangement.SpaceBetween) {
+
+//todo: cont change icon place & change the styling of the text, icon, button and round corner; add avatar to search box
+              //todo: change two bottons below's color
                   // Share trip code button
                   IconButton(
                       modifier = Modifier.size(20.dp).testTag("shareTripButton" + trip.tripId),
@@ -155,22 +182,7 @@ fun OverviewTrip(trip: Trip, navigationActions: NavigationActions) {
                                 Modifier.background(
                                     if (isSelected.value) Color.LightGray else Color.Transparent))
                       }
-                }
-            // End date
 
-            Text(
-                text =
-                    "To : %s"
-                        .format(trip.endDate.format(DateTimeFormatter.ofPattern(DATE_PATTERN))),
-                modifier = Modifier.height(24.dp),
-                style =
-                    TextStyle(
-                        fontSize = 12.sp,
-                        lineHeight = 24.sp,
-                        fontWeight = FontWeight(500),
-                        color = MaterialTheme.colorScheme.onPrimaryContainer,
-                        letterSpacing = 0.5.sp,
-                    ))
           }
         }
   }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -3,7 +3,6 @@ package com.github.se.wanderpals.ui.screens.overview
 import android.content.Context
 import android.content.Intent
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,7 +19,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -101,93 +99,103 @@ fun OverviewTrip(trip: Trip, navigationActions: NavigationActions) {
           navigationActions.navigateTo(Route.TRIP)
         },
         modifier =
-        Modifier
-            .align(Alignment.TopCenter)
-            .width(360.dp)
-            .height(130.dp)
-            .padding(top = 1.dp)
-            .testTag("buttonTrip" + trip.tripId),
+            Modifier.align(Alignment.TopCenter)
+                .width(360.dp)
+                .height(130.dp)
+                .padding(top = 1.dp)
+                .testTag("buttonTrip" + trip.tripId),
         shape = RoundedCornerShape(size = 15.dp),
-        colors =
-            ButtonDefaults.buttonColors(
-                containerColor = primaryContainerLight)) {
+        colors = ButtonDefaults.buttonColors(containerColor = primaryContainerLight)) {
           // Column containing trip information
           Column(modifier = Modifier.width(320.dp)) {
-              Row(
-                  modifier = Modifier.fillMaxWidth().padding(top= 8.dp)  // Ensure padding for visual spacing
-              ) {
+            Row(
+                modifier =
+                    Modifier.fillMaxWidth().padding(top = 8.dp) // Ensure padding for visual spacing
+                ) {
                   // Trip title
                   Text(
                       text = trip.title,
                       modifier = Modifier.height(24.dp),
-                      style = TextStyle(
-                          fontSize = 18.sp,
-                          lineHeight = 24.sp,
-                          fontWeight = FontWeight(500),
-                          color = onPrimaryContainerLight,
-                          letterSpacing = 0.5.sp,
-                      ),
-                      textAlign = TextAlign.Start
-                  )
+                      style =
+                          TextStyle(
+                              fontSize = 18.sp,
+                              lineHeight = 24.sp,
+                              fontWeight = FontWeight(500),
+                              color = onPrimaryContainerLight,
+                              letterSpacing = 0.5.sp,
+                          ),
+                      textAlign = TextAlign.Start)
 
                   Spacer(Modifier.weight(1f))
 
                   // Start date
                   Text(
                       text = trip.startDate.format(DateTimeFormatter.ofPattern(DATE_PATTERN)),
-                      modifier = Modifier.height(24.dp).padding(top=4.dp), // the padding is for having the text on the same line and in the same height as the trip title
-                      style = TextStyle(
-                          fontSize = 14.sp,
-                          lineHeight = 24.sp,
-                          fontWeight = FontWeight(500),
-                          color = onPrimaryContainerLight,
-                          letterSpacing = 0.5.sp,
-                      ),
-                      textAlign = TextAlign.End
-                  )
+                      modifier =
+                          Modifier.height(24.dp)
+                              .padding(
+                                  top =
+                                      4
+                                          .dp), // the padding is for having the text on the same
+                                                // line and in the same height as the trip title
+                      style =
+                          TextStyle(
+                              fontSize = 14.sp,
+                              lineHeight = 24.sp,
+                              fontWeight = FontWeight(500),
+                              color = onPrimaryContainerLight,
+                              letterSpacing = 0.5.sp,
+                          ),
+                      textAlign = TextAlign.End)
 
                   Spacer(modifier = Modifier.width(11.dp)) // Space between start and end date
 
                   // End date
                   Text(
                       text = trip.endDate.format(DateTimeFormatter.ofPattern(DATE_PATTERN)),
-                      modifier = Modifier.height(24.dp).padding(top=4.dp), // the padding is for having the text on the same line and in the same height as the trip title
-                      style = TextStyle(
-                          fontSize = 14.sp,
-                          lineHeight = 24.sp,
-                          fontWeight = FontWeight(500),
-                          color = onPrimaryContainerLight,
-                          letterSpacing = 0.5.sp,
-                      ),
-                      textAlign = TextAlign.End
-                  )
-              }
+                      modifier =
+                          Modifier.height(24.dp)
+                              .padding(
+                                  top =
+                                      4
+                                          .dp), // the padding is for having the text on the same
+                                                // line and in the same height as the trip title
+                      style =
+                          TextStyle(
+                              fontSize = 14.sp,
+                              lineHeight = 24.sp,
+                              fontWeight = FontWeight(500),
+                              color = onPrimaryContainerLight,
+                              letterSpacing = 0.5.sp,
+                          ),
+                      textAlign = TextAlign.End)
+                }
 
-              Spacer(Modifier.height(50.dp))
-              Row(
-                  modifier = Modifier.fillMaxWidth() // Ensure padding for visual spacing
-              ){
-                  Spacer(Modifier.weight(1f))  // Pushes the icon to the end
+            Spacer(Modifier.height(50.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth() // Ensure padding for visual spacing
+                ) {
+                  Spacer(Modifier.weight(1f)) // Pushes the icon to the end
 
                   // Share trip code button
                   IconButton(
-                      modifier = Modifier
-                          .width(24.dp)
-                          .height(28.dp)
-                          .testTag("shareTripButton" + trip.tripId),
+                      modifier =
+                          Modifier.width(24.dp)
+                              .height(28.dp)
+                              .testTag("shareTripButton" + trip.tripId),
                       onClick = {
-                          isSelected.value = true
-                          context.shareTripCodeIntent(trip.tripId)
+                        isSelected.value = true
+                        context.shareTripCodeIntent(trip.tripId)
                       }) {
-                      Icon(
-                          imageVector = Icons.Default.Share,
-                          contentDescription = null,
-                          tint = Color.White,
-                          modifier =
-                          Modifier.background(
-                              if (isSelected.value) Color.LightGray else Color.Transparent))
-                  }
-              }
+                        Icon(
+                            imageVector = Icons.Default.Share,
+                            contentDescription = null,
+                            tint = Color.White,
+                            modifier =
+                                Modifier.background(
+                                    if (isSelected.value) Color.LightGray else Color.Transparent))
+                      }
+                }
           }
         }
   }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -134,10 +134,8 @@ fun OverviewTrip(trip: Trip, navigationActions: NavigationActions) {
                       modifier =
                           Modifier.height(24.dp)
                               .padding(
-                                  top =
-                                      4
-                                          .dp), // the padding is for having the text on the same
-                                                // line and in the same height as the trip title
+                                  top = 4.dp), // the padding is for having the text on the same
+                      // line and in the same height as the trip title
                       style =
                           TextStyle(
                               fontSize = 14.sp,
@@ -156,10 +154,8 @@ fun OverviewTrip(trip: Trip, navigationActions: NavigationActions) {
                       modifier =
                           Modifier.height(24.dp)
                               .padding(
-                                  top =
-                                      4
-                                          .dp), // the padding is for having the text on the same
-                                                // line and in the same height as the trip title
+                                  top = 4.dp), // the padding is for having the text on the same
+                      // line and in the same height as the trip title
                       style =
                           TextStyle(
                               fontSize = 14.sp,

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -40,6 +40,7 @@ import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
+import com.github.se.wanderpals.ui.theme.onPrimaryContainerLight
 import com.github.se.wanderpals.ui.theme.primaryContainerLight
 import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.delay
@@ -91,7 +92,7 @@ fun OverviewTrip(trip: Trip, navigationActions: NavigationActions) {
     }
   }
 
-  Box(modifier = Modifier.fillMaxWidth()) {
+  Box(modifier = Modifier.fillMaxWidth().padding(bottom = 30.dp)) {
     // Button representing the trip overview
     Button(
         onClick = {
@@ -100,28 +101,30 @@ fun OverviewTrip(trip: Trip, navigationActions: NavigationActions) {
           navigationActions.navigateTo(Route.TRIP)
         },
         modifier =
-            Modifier.align(Alignment.TopCenter)
-                .width(360.dp)
-                .height(100.dp)
-                .padding(top = 16.dp)
-                .testTag("buttonTrip" + trip.tripId),
+        Modifier
+            .align(Alignment.TopCenter)
+            .width(360.dp)
+            .height(130.dp)
+            .padding(top = 1.dp)
+            .testTag("buttonTrip" + trip.tripId),
         shape = RoundedCornerShape(size = 15.dp),
         colors =
             ButtonDefaults.buttonColors(
                 containerColor = primaryContainerLight)) {
           // Column containing trip information
           Column(modifier = Modifier.width(320.dp)) {
-              Row(){
+              Row(
+                  modifier = Modifier.fillMaxWidth().padding(top= 8.dp)  // Ensure padding for visual spacing
+              ) {
                   // Trip title
                   Text(
                       text = trip.title,
                       modifier = Modifier.height(24.dp),
-                      style =
-                      TextStyle(
-                          fontSize = 16.sp,
+                      style = TextStyle(
+                          fontSize = 18.sp,
                           lineHeight = 24.sp,
                           fontWeight = FontWeight(500),
-                          color = MaterialTheme.colorScheme.onPrimaryContainer,
+                          color = onPrimaryContainerLight,
                           letterSpacing = 0.5.sp,
                       ),
                       textAlign = TextAlign.Start
@@ -132,57 +135,59 @@ fun OverviewTrip(trip: Trip, navigationActions: NavigationActions) {
                   // Start date
                   Text(
                       text = trip.startDate.format(DateTimeFormatter.ofPattern(DATE_PATTERN)),
-                      modifier = Modifier.height(24.dp),
-                      style =
-                      TextStyle(
-                          fontSize = 12.sp,
+                      modifier = Modifier.height(24.dp).padding(top=4.dp), // the padding is for having the text on the same line and in the same height as the trip title
+                      style = TextStyle(
+                          fontSize = 14.sp,
                           lineHeight = 24.sp,
                           fontWeight = FontWeight(500),
-                          color = MaterialTheme.colorScheme.onPrimaryContainer,
+                          color = onPrimaryContainerLight,
                           letterSpacing = 0.5.sp,
                       ),
                       textAlign = TextAlign.End
                   )
 
                   Spacer(modifier = Modifier.width(11.dp)) // Space between start and end date
+
                   // End date
                   Text(
                       text = trip.endDate.format(DateTimeFormatter.ofPattern(DATE_PATTERN)),
-                      modifier = Modifier.height(24.dp),
-                      style =
-                      TextStyle(
-                          fontSize = 12.sp,
+                      modifier = Modifier.height(24.dp).padding(top=4.dp), // the padding is for having the text on the same line and in the same height as the trip title
+                      style = TextStyle(
+                          fontSize = 14.sp,
                           lineHeight = 24.sp,
                           fontWeight = FontWeight(500),
-                          color = MaterialTheme.colorScheme.onPrimaryContainer,
+                          color = onPrimaryContainerLight,
                           letterSpacing = 0.5.sp,
                       ),
                       textAlign = TextAlign.End
                   )
               }
 
-//            Row(
-//                modifier = Modifier.fillMaxWidth(),
-//                horizontalArrangement = Arrangement.SpaceBetween) {
+              Spacer(Modifier.height(50.dp))
+              Row(
+                  modifier = Modifier.fillMaxWidth() // Ensure padding for visual spacing
+              ){
+                  Spacer(Modifier.weight(1f))  // Pushes the icon to the end
 
-//todo: cont change icon place & change the styling of the text, icon, button and round corner; add avatar to search box
-              //todo: change two bottons below's color
                   // Share trip code button
                   IconButton(
-                      modifier = Modifier.size(20.dp).testTag("shareTripButton" + trip.tripId),
+                      modifier = Modifier
+                          .width(24.dp)
+                          .height(28.dp)
+                          .testTag("shareTripButton" + trip.tripId),
                       onClick = {
-                        isSelected.value = true
-                        context.shareTripCodeIntent(trip.tripId)
+                          isSelected.value = true
+                          context.shareTripCodeIntent(trip.tripId)
                       }) {
-                        Icon(
-                            imageVector = Icons.Default.Share,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                            modifier =
-                                Modifier.background(
-                                    if (isSelected.value) Color.LightGray else Color.Transparent))
-                      }
-
+                      Icon(
+                          imageVector = Icons.Default.Share,
+                          contentDescription = null,
+                          tint = Color.White,
+                          modifier =
+                          Modifier.background(
+                              if (isSelected.value) Color.LightGray else Color.Transparent))
+                  }
+              }
           }
         }
   }


### PR DESCRIPTION
In this pull request,
I updated the trip overview screen UI based on the Figma mockup User Flow 5 (for issue #250) . This includes thus the search bar `OverviewTopBar.kt`. The `OverviewTrip.kt`, the `OverviewBottomBar.kt` and the `OverviewContent.kt` have been adapted to the Figma mockup User Flow 5 too.

For now, we don't add the images yet. We will put them later in the OverviewTrip boxes. 
The height of the OverviewTrip boxes becomes larger in order to put images inside them.

Note that the search bar in the trip overview should not have a user icon because there is no global user at the moment and no menu icon because it is useless. The search bar's original menu icon has been replaced with the loop icon, and when the search text is not empty, the cross icon is displayed so that the user can erase what he/she is searching. 