### PR TITLE
Fixed a bug where the owner couldn't update the role of other users

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/dashboard/AdminTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/dashboard/AdminTest.kt
@@ -363,4 +363,34 @@ class AdminTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
         .assertIsDisplayed()
         .assertTextContains("Johnson2@epfl.ch")
   }
+
+  @Test
+  fun OwnerCanModifyRoles() {
+    val viewModel = FakeAdminViewModel()
+    val User2 = viewModel.listOfUsers.value[1]
+    val User1 = viewModel.listOfUsers.value[0]
+    SessionManager.setUserSession(
+        userId = User2.userId,
+        User2.name,
+        User2.email,
+        User2.role,
+        profilePhoto = User2.profilePictureURL)
+    viewModel.listOfUsers.value = listOf(User2, User1)
+    viewModel.currentUser.value = SessionManager.getCurrentUser()
+    composeTestRule.setContent {
+      SessionManager.setUserSession(
+          userId = User2.userId,
+          User2.name,
+          User2.email,
+          User2.role,
+          profilePhoto = User2.profilePictureURL)
+      Admin(viewModel)
+    }
+
+    ComposeScreen.onComposeScreen<AdminScreen>(composeTestRule) {
+      editRoleButton { performClick() }
+      composeTestRule.onNodeWithText("MEMBER").performClick()
+      ConfirmRoleChangeButton { performClick() }
+    }
+  }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/Admin.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/Admin.kt
@@ -227,7 +227,8 @@ fun Admin(adminViewModel: AdminViewModel) {
                           modifier = Modifier.padding(start = 30.dp).testTag("userName"))
 
                       // to change the role of a user
-                      if (currentUser!!.role != Role.OWNER) {
+                      if (currentUser!!.role == Role.OWNER && currentUser!!.userId != user.userId ||
+                          currentUser!!.role != Role.OWNER) {
                         IconButton(
                             onClick = {
                               userToUpdate = user


### PR DESCRIPTION
In this PR, the following has been done : 

- Fixed a bug where the owner couldn't update the role of other users