### PR TITLE
Dashboard screen UI with suggestion widget refactor (for issue #248)

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/dashboard/DashboardTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/dashboard/DashboardTest.kt
@@ -219,8 +219,6 @@ class DashboardTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeS
 
     // Check that the top bar is displayed
     composeTestRule.onNodeWithTag("dashboardTopBar", useUnmergedTree = true).assertIsDisplayed()
-    // Check that the trip title is displayed
-    composeTestRule.onNodeWithTag("dashboardTripTitle", useUnmergedTree = true).assertIsDisplayed()
     // Check that the suggestion widget is displayed
     composeTestRule.onNodeWithTag("suggestionCard", useUnmergedTree = true).assertIsDisplayed()
     // Check that the suggestion widget title is displayed

--- a/app/src/androidTest/java/com/github/se/wanderpals/dashboard/DashboardTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/dashboard/DashboardTest.kt
@@ -171,6 +171,8 @@ class DashboardTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeS
 
     // Check that the top bar is displayed
     composeTestRule.onNodeWithTag("dashboardTopBar", useUnmergedTree = true).assertIsDisplayed()
+    // Check that the trip title is displayed
+    composeTestRule.onNodeWithTag("dashboardTripTitle", useUnmergedTree = true).assertIsDisplayed()
     // Check that the suggestion widget is displayed
     composeTestRule.onNodeWithTag("suggestionCard", useUnmergedTree = true).assertIsDisplayed()
     // Check that the suggestion widget title is displayed

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/DashboardViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/DashboardViewModel.kt
@@ -10,14 +10,27 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
-open class DashboardViewModel(private val tripsRepository: TripsRepository, tripId: String) :
-    ViewModel() {
+open class DashboardViewModel(val tripsRepository: TripsRepository, tripId: String) : ViewModel() {
   // State flow to hold the list of suggestions
   private val _state = MutableStateFlow(emptyList<Suggestion>())
   open val state: StateFlow<List<Suggestion>> = _state
 
   private val _isLoading = MutableStateFlow(true)
   open val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+  private val _tripTitle = MutableStateFlow<String?>(null)
+  val tripTitle: StateFlow<String?> = _tripTitle.asStateFlow()
+
+  init {
+    loadTripTitle(tripId)
+  }
+
+  private fun loadTripTitle(tripId: String) {
+    viewModelScope.launch {
+      val trip = tripsRepository.getTrip(tripId)
+      _tripTitle.value = trip?.title
+    }
+  }
 
   /** Fetches all trips from the repository and updates the state flow accordingly. */
   open fun loadSuggestion(tripId: String) {

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/DashboardViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/DashboardViewModel.kt
@@ -29,6 +29,7 @@ open class DashboardViewModel(val tripsRepository: TripsRepository, tripId: Stri
     loadTripTitle(tripId)
   }
 
+  /** Fetches the trip title from the repository and updates the state flow accordingly. */
   private fun loadTripTitle(tripId: String) {
     viewModelScope.launch {
       val trip = tripsRepository.getTrip(tripId)

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/dashboard/DashboardSuggestionWidget.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/dashboard/DashboardSuggestionWidget.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -43,27 +42,27 @@ import java.time.format.DateTimeFormatter
 
 @Composable
 fun DashboardSuggestionWidget(viewModel: DashboardViewModel, onClick: () -> Unit = {}) {
-    val suggestionList by viewModel.state.collectAsState()
-    val sortedSuggestion = suggestionList.sortedByDescending { it.createdAt }
+  val suggestionList by viewModel.state.collectAsState()
+  val sortedSuggestion = suggestionList.sortedByDescending { it.createdAt }
 
-    Card(
-        modifier =
-        Modifier.padding(16.dp)
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .testTag("suggestionCard"),
-        colors =
-        CardDefaults.cardColors(
-            containerColor = surfaceVariantLight // This sets the background color of the Card
-        ),
-        shape = RoundedCornerShape(10.dp)) {
+  Card(
+      modifier =
+          Modifier.padding(16.dp)
+              .fillMaxWidth()
+              .clickable(onClick = onClick)
+              .testTag("suggestionCard"),
+      colors =
+          CardDefaults.cardColors(
+              containerColor = surfaceVariantLight // This sets the background color of the Card
+              ),
+      shape = RoundedCornerShape(10.dp)) {
         Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp)) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier =
-                Modifier.clip(RoundedCornerShape(10.dp))
-                    .background(primaryContainerLight)
-                    .padding(8.dp)) {
+          Row(
+              verticalAlignment = Alignment.CenterVertically,
+              modifier =
+                  Modifier.clip(RoundedCornerShape(10.dp))
+                      .background(primaryContainerLight)
+                      .padding(8.dp)) {
                 Icon(
                     Icons.Default.Menu,
                     contentDescription = "suggestionIcon",
@@ -72,110 +71,112 @@ fun DashboardSuggestionWidget(viewModel: DashboardViewModel, onClick: () -> Unit
                 Spacer(modifier = Modifier.width(6.dp))
                 Text(
                     text = "Suggestions",
-                    style = TextStyle(
-                        fontSize = 15.sp,
-                        lineHeight = 20.sp,
-                        fontWeight = FontWeight(500),
-                        color = onPrimaryContainerLight,
-                        letterSpacing = 0.15.sp,
-                    ),
-                    modifier = Modifier.testTag("suggestionTitle")
-                )
-            }
+                    style =
+                        TextStyle(
+                            fontSize = 15.sp,
+                            lineHeight = 20.sp,
+                            fontWeight = FontWeight(500),
+                            color = onPrimaryContainerLight,
+                            letterSpacing = 0.15.sp,
+                        ),
+                    modifier = Modifier.testTag("suggestionTitle"))
+              }
 
-            Spacer(modifier = Modifier.padding(6.dp))
+          Spacer(modifier = Modifier.padding(6.dp))
 
-            if (sortedSuggestion.isEmpty()) {
-                Column(
-                    modifier =
+          if (sortedSuggestion.isEmpty()) {
+            Column(
+                modifier =
                     Modifier.fillMaxWidth()
                         .clip(RoundedCornerShape(10.dp))
                         .background(backgroundLight)
                         .padding(40.dp),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(
-                        text = "No suggestions available",
-                        style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Bold),
-                        modifier = Modifier.testTag("noSuggestions")
-                    )
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally) {
+                  Text(
+                      text = "No suggestions available",
+                      style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Bold),
+                      modifier = Modifier.testTag("noSuggestions"))
                 }
-            } else {
-                SuggestionItem(suggestion = sortedSuggestion[0])
+          } else {
+            SuggestionItem(suggestion = sortedSuggestion[0])
 
-                if (sortedSuggestion.size > 1) {
-                    Spacer(modifier = Modifier.height(8.dp))
-                    SuggestionItem(suggestion = sortedSuggestion[1])
-                }
-
-                if (sortedSuggestion.size > 2) {
-                    Spacer(modifier = Modifier.height(8.dp))
-                    SuggestionItem(suggestion = sortedSuggestion[2])
-                }
+            if (sortedSuggestion.size > 1) {
+              Spacer(modifier = Modifier.height(8.dp))
+              SuggestionItem(suggestion = sortedSuggestion[1])
             }
+
+            if (sortedSuggestion.size > 2) {
+              Spacer(modifier = Modifier.height(8.dp))
+              SuggestionItem(suggestion = sortedSuggestion[2])
+            }
+          }
         }
-    }
+      }
 }
 
 @Composable
 fun SuggestionItem(suggestion: Suggestion) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-        modifier =
-        Modifier.fillMaxWidth()
-            .clip(RoundedCornerShape(10.dp))
-            .background(backgroundLight)
-            .testTag("suggestionItem" + suggestion.suggestionId)) {
+  Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.SpaceBetween,
+      modifier =
+          Modifier.fillMaxWidth()
+              .clip(RoundedCornerShape(10.dp))
+              .background(backgroundLight)
+              .testTag("suggestionItem" + suggestion.suggestionId)) {
         Column(modifier = Modifier.padding(16.dp, 8.dp)) {
-            Text(
-                text = suggestion.stop.title,
-                style = TextStyle(
-                    fontWeight = FontWeight(500),
-                    color = primaryLight,
-                    fontSize = 15.sp,
-                    lineHeight = 20.sp,
-                    letterSpacing = 0.15.sp
-                ),
-                modifier = Modifier.testTag("suggestionTitle" + suggestion.suggestionId))
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text =
-                "Suggested by ${if(suggestion.userName.length > 10) suggestion.userName.subSequence(0, 10).toString()+"..." else suggestion.userName}",
-                style = TextStyle(
-                    fontSize = 14.sp,
-                    lineHeight = 20.sp,
-                    fontWeight = FontWeight(500),
-                    color = tertiaryLight,
-                    letterSpacing = 0.14.sp,
-                ),
-                modifier = Modifier.testTag("suggestionUser" + suggestion.userId))
+          Text(
+              text = suggestion.stop.title,
+              style =
+                  TextStyle(
+                      fontWeight = FontWeight(500),
+                      color = primaryLight,
+                      fontSize = 15.sp,
+                      lineHeight = 20.sp,
+                      letterSpacing = 0.15.sp),
+              modifier = Modifier.testTag("suggestionTitle" + suggestion.suggestionId))
+          Spacer(modifier = Modifier.height(4.dp))
+          Text(
+              text =
+                  "Suggested by ${if(suggestion.userName.length > 10) suggestion.userName.subSequence(0, 10).toString()+"..." else suggestion.userName}",
+              style =
+                  TextStyle(
+                      fontSize = 14.sp,
+                      lineHeight = 20.sp,
+                      fontWeight = FontWeight(500),
+                      color = tertiaryLight,
+                      letterSpacing = 0.14.sp,
+                  ),
+              modifier = Modifier.testTag("suggestionUser" + suggestion.userId))
         }
 
         Column(modifier = Modifier.padding(8.dp)) {
-            val startTime = LocalDateTime.of(suggestion.stop.date, suggestion.stop.startTime)
-            val endTime = startTime.plusMinutes(suggestion.stop.duration.toLong())
-            Text(
-                text = startTime.format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")),
-                style = TextStyle(
-                    fontSize = 14.sp,
-                    lineHeight = 20.sp,
-                    fontWeight = FontWeight(500),
-                    color = secondaryLight,
-                    letterSpacing = 0.14.sp,
-                ),
-                modifier = Modifier.testTag("suggestionStart" + suggestion.suggestionId))
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = endTime.format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")),
-                style = TextStyle(
-                    fontSize = 14.sp,
-                    lineHeight = 20.sp,
-                    fontWeight = FontWeight(500),
-                    color = secondaryLight,
-                    letterSpacing = 0.14.sp,
-                ),
-                modifier = Modifier.testTag("suggestionEnd" + suggestion.suggestionId))
+          val startTime = LocalDateTime.of(suggestion.stop.date, suggestion.stop.startTime)
+          val endTime = startTime.plusMinutes(suggestion.stop.duration.toLong())
+          Text(
+              text = startTime.format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")),
+              style =
+                  TextStyle(
+                      fontSize = 14.sp,
+                      lineHeight = 20.sp,
+                      fontWeight = FontWeight(500),
+                      color = secondaryLight,
+                      letterSpacing = 0.14.sp,
+                  ),
+              modifier = Modifier.testTag("suggestionStart" + suggestion.suggestionId))
+          Spacer(modifier = Modifier.height(4.dp))
+          Text(
+              text = endTime.format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")),
+              style =
+                  TextStyle(
+                      fontSize = 14.sp,
+                      lineHeight = 20.sp,
+                      fontWeight = FontWeight(500),
+                      color = secondaryLight,
+                      letterSpacing = 0.14.sp,
+                  ),
+              modifier = Modifier.testTag("suggestionEnd" + suggestion.suggestionId))
         }
-    }
+      }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/dashboard/DashboardSuggestionWidget.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/dashboard/DashboardSuggestionWidget.kt
@@ -31,122 +31,151 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.model.data.Suggestion
 import com.github.se.wanderpals.model.viewmodel.DashboardViewModel
+import com.github.se.wanderpals.ui.theme.backgroundLight
+import com.github.se.wanderpals.ui.theme.onPrimaryContainerLight
+import com.github.se.wanderpals.ui.theme.primaryContainerLight
+import com.github.se.wanderpals.ui.theme.primaryLight
+import com.github.se.wanderpals.ui.theme.secondaryLight
+import com.github.se.wanderpals.ui.theme.surfaceVariantLight
+import com.github.se.wanderpals.ui.theme.tertiaryLight
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Composable
 fun DashboardSuggestionWidget(viewModel: DashboardViewModel, onClick: () -> Unit = {}) {
-  val suggestionList by viewModel.state.collectAsState()
-  val sortedSuggestion = suggestionList.sortedByDescending { it.createdAt }
+    val suggestionList by viewModel.state.collectAsState()
+    val sortedSuggestion = suggestionList.sortedByDescending { it.createdAt }
 
-  Card(
-      modifier =
-          Modifier.padding(16.dp)
-              .fillMaxWidth()
-              .clickable(onClick = onClick)
-              .testTag("suggestionCard"),
-      colors =
-          CardDefaults.cardColors(
-              containerColor =
-                  MaterialTheme.colorScheme
-                      .surfaceVariant // This sets the background color of the Card
-              ),
-      shape = RoundedCornerShape(6.dp)) {
+    Card(
+        modifier =
+        Modifier.padding(16.dp)
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .testTag("suggestionCard"),
+        colors =
+        CardDefaults.cardColors(
+            containerColor = surfaceVariantLight // This sets the background color of the Card
+        ),
+        shape = RoundedCornerShape(10.dp)) {
         Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp)) {
-          Row(
-              verticalAlignment = Alignment.CenterVertically,
-              modifier =
-                  Modifier.clip(RoundedCornerShape(4.dp))
-                      .background(MaterialTheme.colorScheme.primaryContainer)
-                      .padding(8.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier =
+                Modifier.clip(RoundedCornerShape(10.dp))
+                    .background(primaryContainerLight)
+                    .padding(8.dp)) {
                 Icon(
                     Icons.Default.Menu,
                     contentDescription = "suggestionIcon",
-                    tint = MaterialTheme.colorScheme.onPrimary,
+                    tint = onPrimaryContainerLight,
                     modifier = Modifier.testTag("suggestionIcon"))
-                Spacer(modifier = Modifier.width(4.dp))
+                Spacer(modifier = Modifier.width(6.dp))
                 Text(
                     text = "Suggestions",
-                    style =
-                        TextStyle(
-                            fontSize = 15.sp,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer),
-                    modifier = Modifier.testTag("suggestionTitle"))
-              }
+                    style = TextStyle(
+                        fontSize = 15.sp,
+                        lineHeight = 20.sp,
+                        fontWeight = FontWeight(500),
+                        color = onPrimaryContainerLight,
+                        letterSpacing = 0.15.sp,
+                    ),
+                    modifier = Modifier.testTag("suggestionTitle")
+                )
+            }
 
-          Spacer(modifier = Modifier.padding(6.dp))
+            Spacer(modifier = Modifier.padding(6.dp))
 
-          if (sortedSuggestion.isEmpty()) {
-            Column(
-                modifier =
+            if (sortedSuggestion.isEmpty()) {
+                Column(
+                    modifier =
                     Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(4.dp))
-                        .background(MaterialTheme.colorScheme.surface)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(backgroundLight)
                         .padding(40.dp),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally) {
-                  Text(
-                      text = "No suggestions available",
-                      style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Bold),
-                      modifier = Modifier.testTag("noSuggestions"))
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "No suggestions available",
+                        style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Bold),
+                        modifier = Modifier.testTag("noSuggestions")
+                    )
                 }
-          } else {
-            SuggestionItem(suggestion = sortedSuggestion[0])
+            } else {
+                SuggestionItem(suggestion = sortedSuggestion[0])
 
-            if (sortedSuggestion.size > 1) {
-              Spacer(modifier = Modifier.height(8.dp))
-              SuggestionItem(suggestion = sortedSuggestion[1])
-            }
+                if (sortedSuggestion.size > 1) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    SuggestionItem(suggestion = sortedSuggestion[1])
+                }
 
-            if (sortedSuggestion.size > 2) {
-              Spacer(modifier = Modifier.height(8.dp))
-              SuggestionItem(suggestion = sortedSuggestion[2])
+                if (sortedSuggestion.size > 2) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    SuggestionItem(suggestion = sortedSuggestion[2])
+                }
             }
-          }
         }
-      }
+    }
 }
 
 @Composable
 fun SuggestionItem(suggestion: Suggestion) {
-  Row(
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.SpaceBetween,
-      modifier =
-          Modifier.fillMaxWidth()
-              .clip(RoundedCornerShape(4.dp))
-              .background(MaterialTheme.colorScheme.surface)
-              .testTag("suggestionItem" + suggestion.suggestionId)) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier =
+        Modifier.fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(backgroundLight)
+            .testTag("suggestionItem" + suggestion.suggestionId)) {
         Column(modifier = Modifier.padding(16.dp, 8.dp)) {
-          Text(
-              text = suggestion.stop.title,
-              style =
-                  TextStyle(
-                      fontWeight = FontWeight.Bold,
-                      color = MaterialTheme.colorScheme.primary,
-                      fontSize = 15.sp),
-              modifier = Modifier.testTag("suggestionTitle" + suggestion.suggestionId))
-          Spacer(modifier = Modifier.height(4.dp))
-          Text(
-              text =
-                  "Suggested by ${if(suggestion.userName.length > 10) suggestion.userName.subSequence(0, 10).toString()+"..." else suggestion.userName}",
-              style = TextStyle(color = MaterialTheme.colorScheme.tertiary, fontSize = 14.sp),
-              modifier = Modifier.testTag("suggestionUser" + suggestion.userId))
+            Text(
+                text = suggestion.stop.title,
+                style = TextStyle(
+                    fontWeight = FontWeight(500),
+                    color = primaryLight,
+                    fontSize = 15.sp,
+                    lineHeight = 20.sp,
+                    letterSpacing = 0.15.sp
+                ),
+                modifier = Modifier.testTag("suggestionTitle" + suggestion.suggestionId))
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text =
+                "Suggested by ${if(suggestion.userName.length > 10) suggestion.userName.subSequence(0, 10).toString()+"..." else suggestion.userName}",
+                style = TextStyle(
+                    fontSize = 14.sp,
+                    lineHeight = 20.sp,
+                    fontWeight = FontWeight(500),
+                    color = tertiaryLight,
+                    letterSpacing = 0.14.sp,
+                ),
+                modifier = Modifier.testTag("suggestionUser" + suggestion.userId))
         }
 
         Column(modifier = Modifier.padding(8.dp)) {
-          val startTime = LocalDateTime.of(suggestion.stop.date, suggestion.stop.startTime)
-          val endTime = startTime.plusMinutes(suggestion.stop.duration.toLong())
-          Text(
-              text = startTime.format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")),
-              style = TextStyle(color = MaterialTheme.colorScheme.secondary, fontSize = 14.sp),
-              modifier = Modifier.testTag("suggestionStart" + suggestion.suggestionId))
-          Spacer(modifier = Modifier.height(4.dp))
-          Text(
-              text = endTime.format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")),
-              style = TextStyle(color = MaterialTheme.colorScheme.secondary, fontSize = 14.sp),
-              modifier = Modifier.testTag("suggestionEnd" + suggestion.suggestionId))
+            val startTime = LocalDateTime.of(suggestion.stop.date, suggestion.stop.startTime)
+            val endTime = startTime.plusMinutes(suggestion.stop.duration.toLong())
+            Text(
+                text = startTime.format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")),
+                style = TextStyle(
+                    fontSize = 14.sp,
+                    lineHeight = 20.sp,
+                    fontWeight = FontWeight(500),
+                    color = secondaryLight,
+                    letterSpacing = 0.14.sp,
+                ),
+                modifier = Modifier.testTag("suggestionStart" + suggestion.suggestionId))
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = endTime.format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")),
+                style = TextStyle(
+                    fontSize = 14.sp,
+                    lineHeight = 20.sp,
+                    fontWeight = FontWeight(500),
+                    color = secondaryLight,
+                    letterSpacing = 0.14.sp,
+                ),
+                modifier = Modifier.testTag("suggestionEnd" + suggestion.suggestionId))
         }
-      }
+    }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ElevatedButton
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -86,10 +85,7 @@ fun Dashboard(
     if (isLoading) {
       Box(modifier = Modifier.fillMaxSize()) {
         CircularProgressIndicator(
-            modifier = Modifier
-                .size(50.dp)
-                .align(Alignment.Center)
-                .testTag("loading"))
+            modifier = Modifier.size(50.dp).align(Alignment.Center).testTag("loading"))
       }
     } else {
       Scaffold(
@@ -97,10 +93,9 @@ fun Dashboard(
       ) { contentPadding ->
         Surface(
             modifier =
-            Modifier
-                .background(Color.White)
-                .padding(contentPadding)
-                .testTag("dashboardSuggestions")) {
+                Modifier.background(Color.White)
+                    .padding(contentPadding)
+                    .testTag("dashboardSuggestions")) {
               Column {
                 DashboardSuggestionWidget(
                     viewModel = dashboardViewModel,
@@ -127,11 +122,7 @@ fun Menu(scope: CoroutineScope, drawerState: DrawerState, navActions: Navigation
   ModalDrawerSheet(
       drawerShape = MaterialTheme.shapes.large,
       modifier =
-      Modifier
-          .testTag("menuNav")
-          .requiredWidth(200.dp)
-          .requiredHeight(250.dp)
-          .padding(8.dp),
+          Modifier.testTag("menuNav").requiredWidth(200.dp).requiredHeight(250.dp).padding(8.dp),
   ) {
     ElevatedButton(
         modifier = Modifier.testTag("backToOverview"),
@@ -149,18 +140,13 @@ fun Menu(scope: CoroutineScope, drawerState: DrawerState, navActions: Navigation
         })
     Spacer(modifier = Modifier.padding(2.dp))
     ElevatedButton(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 2.dp)
-            .testTag("AdminButtonTest"),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 2.dp).testTag("AdminButtonTest"),
         content = {
           Row(verticalAlignment = Alignment.CenterVertically) {
             Image(
                 painterResource(id = R.drawable.logo_nsa),
                 contentDescription = "NSA",
-                modifier = Modifier
-                    .clip(CircleShape)
-                    .size(30.dp))
+                modifier = Modifier.clip(CircleShape).size(30.dp))
             Text(text = "Admin", modifier = Modifier.padding(horizontal = 20.dp))
           }
         },
@@ -172,18 +158,13 @@ fun Menu(scope: CoroutineScope, drawerState: DrawerState, navActions: Navigation
         })
     Spacer(modifier = Modifier.padding(2.dp))
     ElevatedButton(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 2.dp)
-            .testTag("FinanceButtonTest"),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 2.dp).testTag("FinanceButtonTest"),
         content = {
           Row(verticalAlignment = Alignment.CenterVertically) {
             Image(
                 painterResource(id = R.drawable.finance_logo),
                 contentDescription = "financeLogo",
-                modifier = Modifier
-                    .clip(CircleShape)
-                    .size(25.dp))
+                modifier = Modifier.clip(CircleShape).size(25.dp))
             Text(text = "Finance", modifier = Modifier.padding(horizontal = 20.dp))
           }
         },
@@ -207,21 +188,15 @@ fun Menu(scope: CoroutineScope, drawerState: DrawerState, navActions: Navigation
  */
 @Composable
 fun TopDashboardBar(scope: CoroutineScope, drawerState: DrawerState) {
-  Column(modifier = Modifier
-      .background(primaryLight)
-      .height(54.dp)
-      .testTag("dashboardTopBar")) {
-      IconButton(
-          modifier = Modifier
-              .padding(start = 22.dp, top = 16.dp, bottom = 16.dp)
-              .width(33.dp)
-              .height(22.dp)
-              .testTag("menuButton"),
-          content = {
-              Icon(Icons.Default.Menu, contentDescription = "Menu", tint = Color.White)
-          },
-          onClick = { scope.launch { drawerState.apply { if (isClosed) open() else close() } } })
-      Row(modifier = Modifier.fillMaxWidth()) {
-    }
+  Column(modifier = Modifier.background(primaryLight).height(54.dp).testTag("dashboardTopBar")) {
+    IconButton(
+        modifier =
+            Modifier.padding(start = 22.dp, top = 16.dp, bottom = 16.dp)
+                .width(33.dp)
+                .height(22.dp)
+                .testTag("menuButton"),
+        content = { Icon(Icons.Default.Menu, contentDescription = "Menu", tint = Color.White) },
+        onClick = { scope.launch { drawerState.apply { if (isClosed) open() else close() } } })
+    Row(modifier = Modifier.fillMaxWidth()) {}
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
@@ -233,7 +233,7 @@ fun TopDashboardBar(
                         fontWeight = FontWeight(500),
                         color = Color.White,
                     ),
-                modifier = Modifier.padding(start = 24.dp).testTag("dashboardTripTitle"))
+                modifier = Modifier.padding(start = 24.dp))
             Row(modifier = Modifier.fillMaxWidth()) {} // to fill the remaining space of the top bar
           }
         }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
@@ -223,17 +223,19 @@ fun TopDashboardBar(
                 scope.launch { drawerState.apply { if (isClosed) open() else close() } }
               })
 
-          Text( // Trip title
-              text = tripTitle!!,
-              style =
-                  TextStyle(
-                      fontSize = 24.sp,
-                      lineHeight = 20.sp,
-                      fontWeight = FontWeight(500),
-                      color = Color.White,
-                  ),
-              modifier = Modifier.padding(start = 24.dp).testTag("dashboardTripTitle"))
-          Row(modifier = Modifier.fillMaxWidth()) {} // to fill the remaining space of the top bar
-    }
+          if (tripTitle != null) {
+            Text( // Trip title
+                text = tripTitle!!,
+                style =
+                    TextStyle(
+                        fontSize = 24.sp,
+                        lineHeight = 20.sp,
+                        fontWeight = FontWeight(500),
+                        color = Color.White,
+                    ),
+                modifier = Modifier.padding(start = 24.dp).testTag("dashboardTripTitle"))
+            Row(modifier = Modifier.fillMaxWidth()) {} // to fill the remaining space of the top bar
+          }
+        }
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
@@ -234,7 +234,10 @@ fun TopDashboardBar(
                         color = Color.White,
                     ),
                 modifier = Modifier.padding(start = 24.dp))
-            Row(modifier = Modifier.fillMaxWidth()) {} // to fill the remaining space of the top bar
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()) {} // in order to fill the remaining space of the top bar
           }
         }
   }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -22,6 +24,7 @@ import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
@@ -46,6 +49,7 @@ import com.github.se.wanderpals.model.viewmodel.DashboardViewModel
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
 import com.github.se.wanderpals.ui.screens.dashboard.DashboardSuggestionWidget
+import com.github.se.wanderpals.ui.theme.primaryLight
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -82,7 +86,10 @@ fun Dashboard(
     if (isLoading) {
       Box(modifier = Modifier.fillMaxSize()) {
         CircularProgressIndicator(
-            modifier = Modifier.size(50.dp).align(Alignment.Center).testTag("loading"))
+            modifier = Modifier
+                .size(50.dp)
+                .align(Alignment.Center)
+                .testTag("loading"))
       }
     } else {
       Scaffold(
@@ -90,9 +97,10 @@ fun Dashboard(
       ) { contentPadding ->
         Surface(
             modifier =
-                Modifier.background(Color.White)
-                    .padding(contentPadding)
-                    .testTag("dashboardSuggestions")) {
+            Modifier
+                .background(Color.White)
+                .padding(contentPadding)
+                .testTag("dashboardSuggestions")) {
               Column {
                 DashboardSuggestionWidget(
                     viewModel = dashboardViewModel,
@@ -119,7 +127,11 @@ fun Menu(scope: CoroutineScope, drawerState: DrawerState, navActions: Navigation
   ModalDrawerSheet(
       drawerShape = MaterialTheme.shapes.large,
       modifier =
-          Modifier.testTag("menuNav").requiredWidth(200.dp).requiredHeight(250.dp).padding(8.dp),
+      Modifier
+          .testTag("menuNav")
+          .requiredWidth(200.dp)
+          .requiredHeight(250.dp)
+          .padding(8.dp),
   ) {
     ElevatedButton(
         modifier = Modifier.testTag("backToOverview"),
@@ -137,13 +149,18 @@ fun Menu(scope: CoroutineScope, drawerState: DrawerState, navActions: Navigation
         })
     Spacer(modifier = Modifier.padding(2.dp))
     ElevatedButton(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 2.dp).testTag("AdminButtonTest"),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 2.dp)
+            .testTag("AdminButtonTest"),
         content = {
           Row(verticalAlignment = Alignment.CenterVertically) {
             Image(
                 painterResource(id = R.drawable.logo_nsa),
                 contentDescription = "NSA",
-                modifier = Modifier.clip(CircleShape).size(30.dp))
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .size(30.dp))
             Text(text = "Admin", modifier = Modifier.padding(horizontal = 20.dp))
           }
         },
@@ -155,13 +172,18 @@ fun Menu(scope: CoroutineScope, drawerState: DrawerState, navActions: Navigation
         })
     Spacer(modifier = Modifier.padding(2.dp))
     ElevatedButton(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 2.dp).testTag("FinanceButtonTest"),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 2.dp)
+            .testTag("FinanceButtonTest"),
         content = {
           Row(verticalAlignment = Alignment.CenterVertically) {
             Image(
                 painterResource(id = R.drawable.finance_logo),
                 contentDescription = "financeLogo",
-                modifier = Modifier.clip(CircleShape).size(25.dp))
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .size(25.dp))
             Text(text = "Finance", modifier = Modifier.padding(horizontal = 20.dp))
           }
         },
@@ -185,13 +207,21 @@ fun Menu(scope: CoroutineScope, drawerState: DrawerState, navActions: Navigation
  */
 @Composable
 fun TopDashboardBar(scope: CoroutineScope, drawerState: DrawerState) {
-  Column(modifier = Modifier.padding(8.dp).testTag("dashboardTopBar")) {
-    Row(modifier = Modifier.fillMaxWidth()) {
-      ElevatedButton(
-          modifier = Modifier.testTag("menuButton"),
-          content = { Icon(Icons.Default.Menu, contentDescription = "Menu") },
+  Column(modifier = Modifier
+      .background(primaryLight)
+      .height(54.dp)
+      .testTag("dashboardTopBar")) {
+      IconButton(
+          modifier = Modifier
+              .padding(start = 22.dp, top = 16.dp, bottom = 16.dp)
+              .width(33.dp)
+              .height(22.dp)
+              .testTag("menuButton"),
+          content = {
+              Icon(Icons.Default.Menu, contentDescription = "Menu", tint = Color.White)
+          },
           onClick = { scope.launch { drawerState.apply { if (isClosed) open() else close() } } })
+      Row(modifier = Modifier.fillMaxWidth()) {
     }
-    HorizontalDivider(modifier = Modifier.padding(8.dp))
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
@@ -215,7 +215,7 @@ fun TopDashboardBar(
                 scope.launch { drawerState.apply { if (isClosed) open() else close() } }
               })
 
-          Text(
+          Text( // Trip title
               text = tripTitle!!,
               style =
                   TextStyle(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
@@ -42,7 +42,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.R
 import com.github.se.wanderpals.model.viewmodel.DashboardViewModel
 import com.github.se.wanderpals.ui.navigation.NavigationActions
@@ -89,7 +92,7 @@ fun Dashboard(
       }
     } else {
       Scaffold(
-          topBar = { TopDashboardBar(scope, drawerState) },
+          topBar = { TopDashboardBar(scope, drawerState, dashboardViewModel) },
       ) { contentPadding ->
         Surface(
             modifier =
@@ -187,16 +190,42 @@ fun Menu(scope: CoroutineScope, drawerState: DrawerState, navActions: Navigation
  * Contains a menu button to open the drawer.
  */
 @Composable
-fun TopDashboardBar(scope: CoroutineScope, drawerState: DrawerState) {
+fun TopDashboardBar(
+    scope: CoroutineScope,
+    drawerState: DrawerState,
+    dashboardViewModel: DashboardViewModel,
+) {
+  // Collect the trip title from the view model
+  val tripTitle by dashboardViewModel.tripTitle.collectAsState()
+
   Column(modifier = Modifier.background(primaryLight).height(54.dp).testTag("dashboardTopBar")) {
-    IconButton(
-        modifier =
-            Modifier.padding(start = 22.dp, top = 16.dp, bottom = 16.dp)
-                .width(33.dp)
-                .height(22.dp)
-                .testTag("menuButton"),
-        content = { Icon(Icons.Default.Menu, contentDescription = "Menu", tint = Color.White) },
-        onClick = { scope.launch { drawerState.apply { if (isClosed) open() else close() } } })
-    Row(modifier = Modifier.fillMaxWidth()) {}
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(horizontal = 16.dp)) {
+          IconButton(
+              modifier =
+                  Modifier.padding(start = 22.dp, top = 16.dp, bottom = 16.dp)
+                      .width(33.dp)
+                      .height(22.dp)
+                      .testTag("menuButton"),
+              content = {
+                Icon(Icons.Default.Menu, contentDescription = "Menu", tint = Color.White)
+              },
+              onClick = {
+                scope.launch { drawerState.apply { if (isClosed) open() else close() } }
+              })
+
+          Text(
+              text = tripTitle!!,
+              style =
+                  TextStyle(
+                      fontSize = 24.sp,
+                      lineHeight = 20.sp,
+                      fontWeight = FontWeight(500),
+                      color = Color.White,
+                  ),
+              modifier = Modifier.padding(start = 24.dp).testTag("dashboardTripTitle"))
+          Row(modifier = Modifier.fillMaxWidth()) {} // to fill the remaining space of the top bar
+    }
   }
 }


### PR DESCRIPTION
In this pull request,
I followed the layout and the styling of the dashboard screen on Figma mockups. 
I also refined the layout and the styling, based on Figma mockups,  of the suggestion widget which is displayed on the dashboard screen.
And on the dashboard screen, I added the title of the trip beside the menu icon.