### PR TITLE
Invite user to trip using his app username

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
@@ -135,10 +135,14 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
       shareTripButton1 { assertIsDisplayed() }
       shareTripButton2 { assertIsDisplayed() }
 
+      sendTripButton1 { assertIsDisplayed() }
+      sendTripButton2 { assertIsDisplayed() }
+
       joinTripButton { assertIsDisplayed() }
       createTripButton { assertIsDisplayed() }
 
       dialog { assertIsNotDisplayed() }
+      emailDialog { assertIsNotDisplayed() }
     }
   }
 
@@ -163,10 +167,15 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
       shareTripButton2 { assertIsNotDisplayed() }
       shareTripButton3 { assertIsNotDisplayed() }
 
+      sendTripButton1 { assertIsNotDisplayed() }
+      sendTripButton2 { assertIsNotDisplayed() }
+      sendTripButton3 { assertIsNotDisplayed() }
+
       joinTripButton { assertIsDisplayed() }
       createTripButton { assertIsDisplayed() }
 
       dialog { assertIsNotDisplayed() }
+      emailDialog { assertIsNotDisplayed() }
     }
   }
 
@@ -191,10 +200,15 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
       shareTripButton2 { assertIsNotDisplayed() }
       shareTripButton3 { assertIsDisplayed() }
 
+      sendTripButton1 { assertIsNotDisplayed() }
+      sendTripButton2 { assertIsNotDisplayed() }
+      sendTripButton3 { assertIsDisplayed() }
+
       joinTripButton { assertIsDisplayed() }
       createTripButton { assertIsDisplayed() }
 
       dialog { assertIsNotDisplayed() }
+      emailDialog { assertIsNotDisplayed() }
     }
   }
 
@@ -219,10 +233,15 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
       shareTripButton2 { assertIsDisplayed() }
       shareTripButton3 { assertIsNotDisplayed() }
 
+      sendTripButton1 { assertIsNotDisplayed() }
+      sendTripButton2 { assertIsDisplayed() }
+      sendTripButton3 { assertIsNotDisplayed() }
+
       joinTripButton { assertIsDisplayed() }
       createTripButton { assertIsDisplayed() }
 
       dialog { assertIsNotDisplayed() }
+      emailDialog { assertIsNotDisplayed() }
     }
   }
 
@@ -247,10 +266,15 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
       shareTripButton2 { assertIsDisplayed() }
       shareTripButton3 { assertIsNotDisplayed() }
 
+      sendTripButton1 { assertIsDisplayed() }
+      sendTripButton2 { assertIsDisplayed() }
+      sendTripButton3 { assertIsNotDisplayed() }
+
       joinTripButton { assertIsDisplayed() }
       createTripButton { assertIsDisplayed() }
 
       dialog { assertIsNotDisplayed() }
+      emailDialog { assertIsNotDisplayed() }
     }
   }
 
@@ -275,10 +299,15 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
       shareTripButton2 { assertIsNotDisplayed() }
       shareTripButton3 { assertIsNotDisplayed() }
 
+      sendTripButton1 { assertIsNotDisplayed() }
+      sendTripButton2 { assertIsNotDisplayed() }
+      sendTripButton3 { assertIsNotDisplayed() }
+
       joinTripButton { assertIsDisplayed() }
       createTripButton { assertIsDisplayed() }
 
       dialog { assertIsNotDisplayed() }
+      emailDialog { assertIsNotDisplayed() }
     }
   }
 
@@ -303,10 +332,14 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
       shareTripButton1 { assertIsDisplayed() }
       shareTripButton2 { assertIsDisplayed() }
 
+      sendTripButton1 { assertIsDisplayed() }
+      sendTripButton2 { assertIsDisplayed() }
+
       joinTripButton { assertIsDisplayed() }
       createTripButton { assertIsDisplayed() }
 
       dialog { assertIsNotDisplayed() }
+      emailDialog { assertIsNotDisplayed() }
     }
   }
 
@@ -363,5 +396,16 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
             hasAction(Intent.ACTION_CHOOSER), hasExtra(`is`(Intent.EXTRA_INTENT), expectedIntent)))
 
     Intents.release()
+  }
+
+  @Test
+  fun sendTripButtonNavigatesToTheSendTripView() = run {
+    ComposeScreen.onComposeScreen<OverviewScreen>(composeTestRule) {
+      sendTripButton2 {
+        assertIsDisplayed()
+        performClick()
+      }
+      emailDialog { assertIsDisplayed() }
+    }
   }
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/screens/OverviewScreen.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/screens/OverviewScreen.kt
@@ -28,5 +28,10 @@ class OverviewScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val shareTripButton2: KNode = onNode { hasTestTag("shareTripButton2") }
   val shareTripButton3: KNode = onNode { hasTestTag("shareTripButton3") }
 
+  val sendTripButton1: KNode = onNode { hasTestTag("sendTripButton1") }
+  val sendTripButton2: KNode = onNode { hasTestTag("sendTripButton2") }
+  val sendTripButton3: KNode = onNode { hasTestTag("sendTripButton3") }
+
   val dialog: KNode = onNode { hasTestTag("dialog") }
+  val emailDialog: KNode = onNode { hasTestTag("emailDialog") }
 }

--- a/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
+++ b/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
@@ -161,7 +161,10 @@ class MainActivity : ComponentActivity() {
                               val uid = result.user?.uid ?: ""
                               viewModel.initRepository(uid)
                               SessionManager.setUserSession(
-                                  userId = uid, name = "Anonymous User", email = "")
+                                  userId = uid,
+                                  name = "Anonymous User",
+                                  email = "",
+                                  nickname = "Anonymous User")
                               navigationActions.navigateTo(Route.OVERVIEW)
                             }
                             .addOnFailureListener {

--- a/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
+++ b/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
@@ -54,9 +54,7 @@ class MainActivity : ComponentActivity() {
 
   private lateinit var context: Context
 
-  private val viewModel: MainViewModel by viewModels {
-    MainViewModel.MainViewModelFactory(application)
-  }
+  val viewModel: MainViewModel by viewModels { MainViewModel.MainViewModelFactory(application) }
 
   private val launcher =
       registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -81,8 +79,9 @@ class MainActivity : ComponentActivity() {
                           userId = uid,
                           name = account.displayName ?: "",
                           email = account.email ?: "",
+                          nickname = viewModel.getUserName(account.email ?: ""),
                           profilePhoto = it.result.user?.photoUrl.toString())
-
+                      viewModel.setUserName(account.email ?: "")
                       navigationActions.navigateTo(Route.OVERVIEW)
                     } else {
                       Toast.makeText(context, "FireBase Failed", Toast.LENGTH_SHORT).show()
@@ -176,7 +175,9 @@ class MainActivity : ComponentActivity() {
                           SessionManager.setUserSession(
                               userId = uid,
                               name = result.user?.displayName ?: "",
-                              email = result.user?.email ?: "")
+                              email = result.user?.email ?: "",
+                              nickname = viewModel.getUserName(result.user?.email ?: ""))
+                          viewModel.setUserName(email)
                           navigationActions.navigateTo(Route.OVERVIEW)
                         }
                         FirebaseAuth.getInstance()

--- a/app/src/main/java/com/github/se/wanderpals/model/data/User.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/data/User.kt
@@ -5,9 +5,10 @@ package com.github.se.wanderpals.model.data
  * now includes additional fields such as nickname, lastPosition, and profilePictureURL.
  *
  * @param userId Unique identifier for the user.
- * @param name User's full name for display and identification.
+ * @param name User's full name for display and identification. User's name for casual display or
+ *   alternative identification.
  * @param email User's email address, used for communication and login.
- * @param nickname User's nickname for casual display or alternative identification.
+ * @param nickname User's nickname for identification
  * @param role User's role within the application, influencing access and capabilities.
  * @param lastPosition Geographic coordinates representing the user's last known position.
  * @param profilePictureURL URL to the user's profile picture.

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -1449,7 +1449,7 @@ open class TripsRepository(
             userId = uid,
             name = currentUser.name,
             email = currentUser.email,
-            nickname = currentUser.name,
+            nickname = currentUser.nickname,
             role = role,
             notificationTokenId = SessionManager.getNotificationToken())
     addUserToTrip(tripId, user)

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MainViewModel.kt
@@ -1,11 +1,13 @@
 package com.github.se.wanderpals.model.viewmodel
 
 import android.app.Application
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.github.se.wanderpals.model.repository.TripsRepository
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 
 /**
  * ViewModel to manage data for the main user interface components. It handles the initialization
@@ -37,6 +39,34 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
    */
   fun getTripsRepository(): TripsRepository {
     return tripsRepository
+  }
+
+  /**
+   * Get a username
+   *
+   * @param email The email to get the username for.
+   */
+  fun getUserName(email: String): String {
+    val userName = email.substringBefore('@')
+    val after = email.substringAfter('@')
+    return if (after == "gmail.com") {
+      val returnName = "$userName@gml"
+      Log.d("MainViewModel", "getUserName: $returnName")
+      returnName
+    } else {
+      val returnName = "$userName@mle${after.hashCode().mod(1000)}"
+      Log.d("MainViewModel", "getUserName: $returnName")
+      returnName
+    }
+  }
+
+  /**
+   * Set a username
+   *
+   * @param email The email to set the username for.
+   */
+  fun setUserName(email: String) {
+    runBlocking { tripsRepository.addEmailToUsername(getUserName(email), email) }
   }
 
   /**

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/OverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/OverviewViewModel.kt
@@ -28,6 +28,14 @@ open class OverviewViewModel(private val tripsRepository: TripsRepository) : Vie
   private val _isLoading = MutableStateFlow(true)
   open val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
+  // State flow to track if the user can send a trip
+  private val _canSend = MutableStateFlow(false)
+  open val canSend: StateFlow<Boolean> = _canSend.asStateFlow()
+
+  // State flow to track the user that we want to send the trip
+  private val _userToSend = MutableStateFlow("")
+  open val userToSend: StateFlow<String> = _userToSend.asStateFlow()
+
   /** Fetches all trips from the repository and updates the state flow accordingly. */
   open fun getAllTrips() {
     viewModelScope.launch {
@@ -73,6 +81,27 @@ open class OverviewViewModel(private val tripsRepository: TripsRepository) : Vie
       }
     }
     return success
+  }
+
+  /**
+   * Add a user to which send an email
+   *
+   * @param user The user to send the trip.
+   */
+  open fun addUserToSend(user: String) {
+    runBlocking {
+      val it = tripsRepository.getUserEmail(user)
+      if (it != null) {
+        _userToSend.value = it
+        _canSend.value = true
+      }
+    }
+  }
+
+  /** Clear the user to send the trip */
+  open fun clearUserToSend() {
+    _userToSend.value = ""
+    _canSend.value = false
   }
 
   class OverviewViewModelFactory(private val tripsRepository: TripsRepository) :

--- a/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
@@ -9,11 +9,11 @@ data class SessionUser(
     val userId: String = "",
     var name: String = "",
     var email: String = "",
-    val nickname: String = "",
     var role: Role = Role.VIEWER,
     var geoCords: GeoCords = GeoCords(0.0, 0.0),
     var profilePhoto: String = "",
-    var tripName: String = ""
+    var tripName: String = "",
+    val nickname: String = ""
 )
 
 /**
@@ -39,13 +39,13 @@ object SessionManager {
       userId: String = currentUser?.userId ?: "",
       name: String = currentUser?.name ?: "",
       email: String = currentUser?.email ?: "",
-      nickname: String = currentUser?.nickname ?: "",
       role: Role = currentUser?.role ?: Role.VIEWER,
       geoCords: GeoCords = currentUser?.geoCords ?: GeoCords(0.0, 0.0),
       profilePhoto: String = currentUser?.profilePhoto ?: "",
-      tripName: String = currentUser?.tripName ?: ""
+      tripName: String = currentUser?.tripName ?: "",
+      nickname: String = currentUser?.nickname ?: ""
   ) {
-    currentUser = SessionUser(userId, name, email, nickname, role, geoCords, profilePhoto, tripName)
+    currentUser = SessionUser(userId, name, email, role, geoCords, profilePhoto, tripName, nickname)
   }
 
   /**

--- a/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
@@ -9,6 +9,7 @@ data class SessionUser(
     val userId: String = "",
     var name: String = "",
     var email: String = "",
+    val nickname: String = "",
     var role: Role = Role.VIEWER,
     var geoCords: GeoCords = GeoCords(0.0, 0.0),
     var profilePhoto: String = "",
@@ -38,12 +39,13 @@ object SessionManager {
       userId: String = currentUser?.userId ?: "",
       name: String = currentUser?.name ?: "",
       email: String = currentUser?.email ?: "",
+      nickname: String = currentUser?.nickname ?: "",
       role: Role = currentUser?.role ?: Role.VIEWER,
       geoCords: GeoCords = currentUser?.geoCords ?: GeoCords(0.0, 0.0),
       profilePhoto: String = currentUser?.profilePhoto ?: "",
       tripName: String = currentUser?.tripName ?: ""
   ) {
-    currentUser = SessionUser(userId, name, email, role, geoCords, profilePhoto, tripName)
+    currentUser = SessionUser(userId, name, email, nickname, role, geoCords, profilePhoto, tripName)
   }
 
   /**

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/Admin.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/Admin.kt
@@ -179,7 +179,7 @@ fun Admin(adminViewModel: AdminViewModel) {
             modifier = Modifier.padding(start = 10.dp, top = 30.dp)) {
               if (currentUser != null) {
                 Text(
-                    text = currentUser!!.name,
+                    text = currentUser!!.nickname,
                     style = MaterialTheme.typography.displaySmall,
                     fontSize = 20.sp,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
@@ -119,7 +119,10 @@ fun OverviewContent(
             @Composable {
               LazyColumn(Modifier.padding(top = 10.dp, bottom = 20.dp).fillMaxSize()) {
                 items(filteredTripsByTitle) { trip ->
-                  OverviewTrip(trip = trip, navigationActions = navigationActions)
+                  OverviewTrip(
+                      trip = trip,
+                      navigationActions = navigationActions,
+                      overviewViewModel = overviewViewModel)
                 }
               }
             }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -310,7 +310,7 @@ fun DialogHandlerEmail(
         closeDialogueAction()
       }) {
         Surface(
-            modifier = Modifier.height(220.dp).testTag("dialog"),
+            modifier = Modifier.height(220.dp).testTag("emailDialog"),
             color = MaterialTheme.colorScheme.background,
             shape = RoundedCornerShape(16.dp)) {
               Column(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
@@ -195,7 +196,9 @@ fun OverviewTrip(
                               color = onPrimaryContainerLight,
                               letterSpacing = 0.1.sp,
                           ),
-                      textAlign = TextAlign.Start)
+                      textAlign = TextAlign.Start,
+                      overflow = TextOverflow.Ellipsis,
+                      maxLines = 1)
 
                   Spacer(Modifier.weight(1f))
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.model.data.Trip
+import com.github.se.wanderpals.model.viewmodel.OverviewViewModel
 import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
@@ -65,43 +66,6 @@ fun Context.shareTripCodeIntent(tripId: String) {
   startActivity(shareIntent)
 }
 
-fun formatTripTitle(title: String, maxLineLength: Int = 12): String {
-  if (title.length <= maxLineLength) return title
-
-  val words = title.split(" ")
-  val builder = StringBuilder()
-  var currentLineLength = 0
-
-  words.forEach { word ->
-    if (currentLineLength + word.length > maxLineLength) {
-      if (currentLineLength != 0) {
-        builder.append("-\n-")
-        currentLineLength = 1 // account for the hyphen at the beginning of the new line
-      }
-      if (word.length > maxLineLength) {
-        // If the word is longer than the max line length, split the word itself
-        word.chunked(maxLineLength - 1).forEach { chunk ->
-          if (currentLineLength + chunk.length > maxLineLength - 1) {
-            builder.append("-\n-")
-            currentLineLength = 1
-          }
-          builder.append(chunk)
-          currentLineLength += chunk.length
-        }
-      } else {
-        builder.append(word)
-        currentLineLength += word.length
-      }
-    } else {
-      if (currentLineLength > 0) builder.append(" ")
-      builder.append(word)
-      currentLineLength += word.length + 1 // +1 for the space
-    }
-  }
-
-  return builder.toString()
-}
-
 /**
  * Composable function that represents an overview of a trip. Displays basic trip information such
  * as title, start date, and end date.
@@ -110,7 +74,11 @@ fun formatTripTitle(title: String, maxLineLength: Int = 12): String {
  * @param navigationActions The navigation actions used for navigating to detailed trip view.
  */
 @Composable
-fun OverviewTrip(trip: Trip, navigationActions: NavigationActions) {
+fun OverviewTrip(
+    trip: Trip,
+    navigationActions: NavigationActions,
+    overviewViewModel: OverviewViewModel
+) {
 
   // Date pattern for formatting start and end dates
   val DATE_PATTERN = "dd/MM/yyyy"

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -121,6 +121,7 @@ fun OverviewTrip(
 
   // Mutable state to check if the icon button for sharing the trip is selected
   val isSelected = remember { mutableStateOf(false) }
+  val isEmailSelected = remember { mutableStateOf(false) }
 
   // Mutable state to check if the dialog is open
   var dialogIsOpen by remember { mutableStateOf(false) }
@@ -131,6 +132,13 @@ fun OverviewTrip(
     if (isSelected.value) {
       delay(100)
       isSelected.value = false
+    }
+  }
+
+  LaunchedEffect(isEmailSelected.value) {
+    if (isEmailSelected.value) {
+      delay(100)
+      isEmailSelected.value = false
     }
   }
 
@@ -254,7 +262,7 @@ fun OverviewTrip(
                               .height(28.dp)
                               .testTag("sendTripButton" + trip.tripId),
                       onClick = {
-                        isSelected.value = true
+                        isEmailSelected.value = true
                         dialogIsOpenEmail = true
                       }) {
                         Icon(
@@ -263,7 +271,8 @@ fun OverviewTrip(
                             tint = Color.White,
                             modifier =
                                 Modifier.background(
-                                    if (isSelected.value) Color.LightGray else Color.Transparent))
+                                    if (isEmailSelected.value) Color.LightGray
+                                    else Color.Transparent))
                       }
 
                   Spacer(Modifier.width(10.dp))


### PR DESCRIPTION
In this PR, I've added the functionality of sending an email to a user by clicking an icon on the trip. This creates a Dialog Window where you need to write the username of the user you want to add. If an email isn't available for this user, the dialog does nothing and the email can't be sent. If the username exists, it enables a button which can be pressed, which then executes an Intent that opens an emails already filled out ready to be sent. 

The username is generated with picking the value before the "@" and adding "@gml" for gmail sign in, or "@mleXXX" for email sign in. With XXX being a modulo number of a hashcode.

The username is also now displayed on the Admin Page