### PR TITLE
Adjusted the display in finance

### DIFF
--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.github.se.wanderpals.model.data.Expense
-import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.data.User
 import com.github.se.wanderpals.model.repository.TripsRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,8 +23,6 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
 
   private val _isLoading = MutableStateFlow(true)
   open val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
-
-  var trip: Trip? = null
 
   /** Fetches all expenses from the trip and updates the state flow accordingly. */
   open fun updateStateLists() {
@@ -47,8 +44,6 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
   open fun addExpense(tripId: String, expense: Expense) {
     viewModelScope.launch { tripsRepository.addExpenseToTrip(tripId, expense) }
   }
-
-  open fun getTrip() = viewModelScope.launch { trip = tripsRepository.getTrip(tripId) }
 
   class FinanceViewModelFactory(
       private val tripsRepository: TripsRepository,

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
@@ -42,7 +42,11 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
 
   /** Adds an expense to the trip. */
   open fun addExpense(tripId: String, expense: Expense) {
-    viewModelScope.launch { tripsRepository.addExpenseToTrip(tripId, expense) }
+    viewModelScope.launch {
+      tripsRepository.addExpenseToTrip(tripId, expense)
+      _expenseStateList.value += expense
+      val ahahaah = 0
+    }
   }
 
   class FinanceViewModelFactory(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
@@ -194,7 +194,9 @@ fun Trip(
                                   FinanceViewModel.FinanceViewModelFactory(
                                       tripsRepository, oldNavActions.variables.currentTrip),
                               key = "FinanceViewModel")
-                      CreateExpense(tripId, viewModel, oldNavActions)
+                      CreateExpense(tripId, viewModel, oldNavActions) {
+                        viewModel.updateStateLists()
+                      }
                     }
                   }
             }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CreateExpense.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CreateExpense.kt
@@ -71,7 +71,12 @@ import java.time.format.DateTimeFormatter
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CreateExpense(tripId: String, viewModel: FinanceViewModel, navActions: NavigationActions) {
+fun CreateExpense(
+    tripId: String,
+    viewModel: FinanceViewModel,
+    navActions: NavigationActions,
+    onDone: () -> Unit = {}
+) {
 
   LaunchedEffect(key1 = Unit) { viewModel.loadMembers(tripId) }
 
@@ -345,6 +350,7 @@ fun CreateExpense(tripId: String, viewModel: FinanceViewModel, navActions: Navig
                                         names = selectedUsers.map { it.name })
                                 errorText = ""
                                 viewModel.addExpense(tripId, expense)
+                                onDone()
                                 navActions.goBack()
                               }
                             },

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
@@ -70,7 +70,7 @@ fun Finance(financeViewModel: FinanceViewModel, navigationActions: NavigationAct
       },
       bottomBar = {
         if (currentSelectedOption == FinanceOption.EXPENSES) {
-          FinanceBottomBar(expenseList, financeViewModel.trip)
+          FinanceBottomBar(expenseList)
         }
       },
       floatingActionButton = {
@@ -91,10 +91,7 @@ fun Finance(financeViewModel: FinanceViewModel, navigationActions: NavigationAct
       }) {
           // Content
           innerPadding ->
-        LaunchedEffect(Unit) {
-          financeViewModel.updateStateLists()
-          financeViewModel.getTrip()
-        }
+        LaunchedEffect(Unit) { financeViewModel.updateStateLists() }
         when (currentSelectedOption) {
           FinanceOption.EXPENSES -> {
             ExpensesContent(innerPadding = innerPadding, expenseList = expenseList)

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/FinanceBottomBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/FinanceBottomBar.kt
@@ -16,14 +16,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.se.wanderpals.model.data.Expense
-import com.github.se.wanderpals.model.data.Trip
+import com.github.se.wanderpals.service.SessionManager
 
 /**
  * Composable function for displaying the bottom bar in the Finance screen. Provides information
  * about total expenses for the user and total expenses for the trip.
  */
 @Composable
-fun FinanceBottomBar(expenses: List<Expense>, trip: Trip?) {
+fun FinanceBottomBar(expenses: List<Expense>) {
   Row(
       modifier =
           Modifier.fillMaxWidth()
@@ -41,7 +41,11 @@ fun FinanceBottomBar(expenses: List<Expense>, trip: Trip?) {
                   color = Color.White,
                   modifier = Modifier.align(Alignment.Start))
               Text(
-                  text = expenses.sumOf { it.amount }.toString(),
+                  text =
+                      expenses
+                          .filter { it.userId == SessionManager.getCurrentUser()?.userId }
+                          .sumOf { it.amount }
+                          .toString(),
                   color = Color.White,
                   modifier = Modifier.align(Alignment.Start),
               )
@@ -55,7 +59,7 @@ fun FinanceBottomBar(expenses: List<Expense>, trip: Trip?) {
                   color = Color.White,
                   modifier = Modifier.align(Alignment.End))
               Text(
-                  text = trip?.totalBudget?.toString() ?: "",
+                  text = expenses.sumOf { it.amount }.toString(),
                   color = Color.White,
                   modifier = Modifier.align(Alignment.End))
             }


### PR DESCRIPTION
In this PR, the following has been done : 

- Adjusted the bottom text in finance to display the intended information: the current expense of the user and the total expense of all users.
- The expense screen now correctly updates when creating an expense