### PR TITLE
Bypass sign in when starting the app and logout functionality

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
@@ -14,6 +14,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.OverviewViewModel
+import com.github.se.wanderpals.navigationActions
 import com.github.se.wanderpals.screens.OverviewScreen
 import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
@@ -114,6 +115,7 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
     SessionManager.setUserSession(userId = "user1")
 
     composeTestRule.setContent {
+      navigationActions = mockNavActions
       Overview(overviewViewModel = overviewViewModelTest, navigationActions = mockNavActions)
     }
   }
@@ -143,6 +145,8 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
 
       dialog { assertIsNotDisplayed() }
       emailDialog { assertIsNotDisplayed() }
+      profilePhoto { assertIsDisplayed() }
+      logoutDialog { assertIsNotDisplayed() }
     }
   }
 
@@ -176,6 +180,8 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
 
       dialog { assertIsNotDisplayed() }
       emailDialog { assertIsNotDisplayed() }
+      profilePhoto { assertIsNotDisplayed() }
+      logoutDialog { assertIsNotDisplayed() }
     }
   }
 
@@ -209,6 +215,8 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
 
       dialog { assertIsNotDisplayed() }
       emailDialog { assertIsNotDisplayed() }
+      profilePhoto { assertIsNotDisplayed() }
+      logoutDialog { assertIsNotDisplayed() }
     }
   }
 
@@ -242,6 +250,8 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
 
       dialog { assertIsNotDisplayed() }
       emailDialog { assertIsNotDisplayed() }
+      profilePhoto { assertIsNotDisplayed() }
+      logoutDialog { assertIsNotDisplayed() }
     }
   }
 
@@ -275,6 +285,8 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
 
       dialog { assertIsNotDisplayed() }
       emailDialog { assertIsNotDisplayed() }
+      profilePhoto { assertIsNotDisplayed() }
+      logoutDialog { assertIsNotDisplayed() }
     }
   }
 
@@ -308,6 +320,8 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
 
       dialog { assertIsNotDisplayed() }
       emailDialog { assertIsNotDisplayed() }
+      profilePhoto { assertIsDisplayed() }
+      logoutDialog { assertIsNotDisplayed() }
     }
   }
 
@@ -406,6 +420,53 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
         performClick()
       }
       emailDialog { assertIsDisplayed() }
+    }
+  }
+
+  @Test
+  fun logoutDialogIsDisplayed() = run {
+    ComposeScreen.onComposeScreen<OverviewScreen>(composeTestRule) {
+      profilePhoto {
+        assertIsDisplayed()
+        performClick()
+      }
+      logoutDialog { assertIsDisplayed() }
+      cancelLogoutButton { assertIsDisplayed() }
+      confirmLogoutButton { assertIsDisplayed() }
+    }
+  }
+
+  @Test
+  fun logoutNavigation() = run {
+    ComposeScreen.onComposeScreen<OverviewScreen>(composeTestRule) {
+      profilePhoto {
+        assertIsDisplayed()
+        performClick()
+      }
+      logoutDialog { assertIsDisplayed() }
+      confirmLogoutButton {
+        assertIsDisplayed()
+        performClick()
+      }
+      verify { mockNavActions.navigateTo(Route.SIGN_IN) }
+      confirmVerified(mockNavActions)
+    }
+  }
+
+  @Test
+  fun cancelLogout() = run {
+    ComposeScreen.onComposeScreen<OverviewScreen>(composeTestRule) {
+      profilePhoto {
+        assertIsDisplayed()
+        performClick()
+      }
+      logoutDialog { assertIsDisplayed() }
+      cancelLogoutButton {
+        assertIsDisplayed()
+        performClick()
+      }
+      logoutDialog { assertIsNotDisplayed() }
+      overviewScreen { assertIsDisplayed() }
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/screens/OverviewScreen.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/screens/OverviewScreen.kt
@@ -34,4 +34,8 @@ class OverviewScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
 
   val dialog: KNode = onNode { hasTestTag("dialog") }
   val emailDialog: KNode = onNode { hasTestTag("emailDialog") }
+  val logoutDialog: KNode = onNode { hasTestTag("logoutDialog") }
+  val confirmLogoutButton: KNode = onNode { hasTestTag("confirmLogoutButton") }
+  val cancelLogoutButton: KNode = onNode { hasTestTag("cancelLogoutButton") }
+  val profilePhoto: KNode = onNode { hasTestTag("profilePhoto") }
 }

--- a/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
+++ b/app/src/main/java/com/github/se/wanderpals/MainActivity.kt
@@ -161,10 +161,15 @@ class MainActivity : ComponentActivity() {
 
             SessionManager.setUserSession(
                 userId = currentUser.uid,
-                name = currentUser.displayName ?: "",
+                name =
+                    currentUser.isAnonymous.takeIf { it }?.let { "Anonymous User" }
+                        ?: currentUser.displayName
+                        ?: "",
                 email = currentUser.email ?: "",
                 profilePhoto = currentUser.photoUrl.toString(),
-                nickname = viewModel.getUserName(currentUser.email ?: ""))
+                nickname =
+                    currentUser.isAnonymous.takeIf { it }?.let { "Anonymous User" }
+                        ?: viewModel.getUserName(currentUser.email ?: ""))
           }
 
           NavHost(

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -1451,6 +1451,8 @@ open class TripsRepository(
             email = currentUser.email,
             nickname = currentUser.nickname,
             role = role,
+            lastPosition = currentUser.geoCords,
+            profilePictureURL = currentUser.profilePhoto,
             notificationTokenId = SessionManager.getNotificationToken())
     addUserToTrip(tripId, user)
   }

--- a/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/repository/TripsRepository.kt
@@ -37,7 +37,7 @@ import kotlinx.coroutines.withContext
  *   in short)
  */
 open class TripsRepository(
-    val uid: String,
+    var uid: String,
     private val dispatcher: CoroutineDispatcher // Inject dispatcher
 ) {
 

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AdminViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AdminViewModel.kt
@@ -1,5 +1,6 @@
 package com.github.se.wanderpals.model.viewmodel
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -7,6 +8,8 @@ import com.github.se.wanderpals.model.data.Role
 import com.github.se.wanderpals.model.data.User
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.service.SessionManager
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.UserProfileChangeRequest
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
@@ -63,6 +66,10 @@ open class AdminViewModel(
     val user = listOfUsers.value.find { it.userId == currentUser.value?.userId }
     if (user != null) {
       modifyUser(user.copy(profilePictureURL = profilePhoto))
+      FirebaseAuth.getInstance()
+          .currentUser
+          ?.updateProfile(
+              UserProfileChangeRequest.Builder().setPhotoUri(Uri.parse(profilePhoto)).build())
     }
   }
   // Send a a Uri to the repository to upload the image

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/MainViewModel.kt
@@ -27,8 +27,13 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
    * @param userId The unique identifier for the user, used to initialize the repository.
    */
   fun initRepository(userId: String) {
-    tripsRepository = TripsRepository(userId, Dispatchers.IO)
-    tripsRepository.initFirestore()
+    Log.d("MainViewModel", "initRepository: $userId")
+    if (::tripsRepository.isInitialized) {
+      tripsRepository.uid = userId
+    } else {
+      tripsRepository = TripsRepository(userId, Dispatchers.IO)
+      tripsRepository.initFirestore()
+    }
   }
 
   /**

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/OverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/OverviewViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.viewModelScope
 import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.service.NotificationsManager
+import com.github.se.wanderpals.service.SessionManager
+import com.github.se.wanderpals.service.SessionUser
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -36,6 +38,10 @@ open class OverviewViewModel(private val tripsRepository: TripsRepository) : Vie
   private val _userToSend = MutableStateFlow("")
   open val userToSend: StateFlow<String> = _userToSend.asStateFlow()
 
+  // State flow to hold the current user
+  private var _currentUser = MutableStateFlow(SessionManager.getCurrentUser())
+  open val currentUser: StateFlow<SessionUser?> = _currentUser.asStateFlow()
+
   /** Fetches all trips from the repository and updates the state flow accordingly. */
   open fun getAllTrips() {
     viewModelScope.launch {
@@ -45,6 +51,8 @@ open class OverviewViewModel(private val tripsRepository: TripsRepository) : Vie
       _state.value = tripsRepository.getAllTrips()
       // Set loading state to false after data is fetched
       _isLoading.value = false
+      // Update the current user
+      _currentUser.value = SessionManager.getCurrentUser()
     }
   }
   /**

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SessionViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SessionViewModel.kt
@@ -20,7 +20,9 @@ class SessionViewModel(private val tripsRepository: TripsRepository) : ViewModel
             Log.d("SessionViewModel", "Failed to find user with userId $userId , in trip $tripId")
           } else {
             SessionManager.setRole(user.role)
-            SessionManager.setPhoto(user.profilePictureURL)
+            tripsRepository.updateUserInTrip(
+                tripId,
+                user.copy(profilePictureURL = SessionManager.getCurrentUser()?.profilePhoto!!))
           }
         } catch (e: Exception) {
           Log.e("SessionViewModel", "Failed to update user role", e)

--- a/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
@@ -1,8 +1,12 @@
 package com.github.se.wanderpals.service
 
+import android.net.Uri
+import android.util.Log
 import com.github.se.wanderpals.model.data.GeoCords
 import com.github.se.wanderpals.model.data.Role
 import com.google.android.gms.maps.model.LatLng
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.UserProfileChangeRequest
 
 /** Represents a simplified user model within the session management context. */
 data class SessionUser(
@@ -11,10 +15,13 @@ data class SessionUser(
     var email: String = "",
     var role: Role = Role.VIEWER,
     var geoCords: GeoCords = GeoCords(0.0, 0.0),
-    var profilePhoto: String = "",
+    var profilePhoto: String = default_profile_photo,
     var tripName: String = "",
     val nickname: String = ""
 )
+
+const val default_profile_photo =
+    "https://firebasestorage.googleapis.com/v0/b/wanderpals.appspot.com/o/images%2FDEFAULT_PROFILE_PHOTO.png?alt=media&token=a57fa34b-87ea-47e1-ae72-21a94178940e"
 
 /**
  * Global object to manage session information such as current user and active trip details.
@@ -35,17 +42,30 @@ object SessionManager {
    * @param role The user's role within the application, optional.
    * @param geoCords The user's geographic coordinates, optional.
    */
+  @Suppress("UselessCallOnNotNull")
   fun setUserSession(
       userId: String = currentUser?.userId ?: "",
       name: String = currentUser?.name ?: "",
       email: String = currentUser?.email ?: "",
       role: Role = currentUser?.role ?: Role.VIEWER,
       geoCords: GeoCords = currentUser?.geoCords ?: GeoCords(0.0, 0.0),
-      profilePhoto: String = currentUser?.profilePhoto ?: "",
+      profilePhoto: String = currentUser?.profilePhoto ?: default_profile_photo,
       tripName: String = currentUser?.tripName ?: "",
       nickname: String = currentUser?.nickname ?: ""
   ) {
-    currentUser = SessionUser(userId, name, email, role, geoCords, profilePhoto, tripName, nickname)
+    val profilePhotoUse = profilePhoto.isNullOrEmpty().let { default_profile_photo }
+    currentUser =
+        SessionUser(userId, name, email, role, geoCords, profilePhotoUse, tripName, nickname)
+
+    if (FirebaseAuth.getInstance().currentUser?.photoUrl.toString().isNullOrEmpty()) {
+      FirebaseAuth.getInstance()
+          .currentUser
+          ?.updateProfile(
+              UserProfileChangeRequest.Builder()
+                  .setPhotoUri(Uri.parse(profilePhotoUse))
+                  .setDisplayName(name)
+                  .build())
+    }
   }
 
   /**

--- a/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
@@ -73,8 +73,7 @@ object SessionManager {
   /** See if Firebase is initialized */
   fun isFirebaseInitialized(): Boolean {
     return try {
-      FirebaseAuth.getInstance()
-      true
+      FirebaseAuth.getInstance().currentUser != null
     } catch (e: Exception) {
       Log.e("SessionManager", "Firebase not initialized")
       false

--- a/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
@@ -64,7 +64,7 @@ object SessionManager {
         SessionUser(userId, name, email, role, geoCords, profilePhotoUse, tripName, nickname)
     _profilePicture.value = profilePhotoUse
 
-    if (FirebaseAuth.getInstance().currentUser?.photoUrl.toString().isNullOrEmpty()) {
+    if (profilePhoto.isNullOrEmpty()) {
       FirebaseAuth.getInstance()
           .currentUser
           ?.updateProfile(

--- a/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
@@ -1,11 +1,15 @@
 package com.github.se.wanderpals.service
 
 import android.net.Uri
+import androidx.compose.runtime.getValue
 import com.github.se.wanderpals.model.data.GeoCords
 import com.github.se.wanderpals.model.data.Role
 import com.google.android.gms.maps.model.LatLng
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.UserProfileChangeRequest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /** Represents a simplified user model within the session management context. */
 data class SessionUser(
@@ -27,6 +31,9 @@ const val default_profile_photo =
  * Provides utility methods to handle user permissions based on roles and trip data.
  */
 object SessionManager {
+
+  private val _profilePicture: MutableStateFlow<String> = MutableStateFlow(default_profile_photo)
+  val profilePicture: StateFlow<String> = _profilePicture.asStateFlow()
 
   private var currentUser: SessionUser? = null
 
@@ -55,6 +62,7 @@ object SessionManager {
     val profilePhotoUse = profilePhoto.isNullOrEmpty().let { default_profile_photo }
     currentUser =
         SessionUser(userId, name, email, role, geoCords, profilePhotoUse, tripName, nickname)
+    _profilePicture.value = profilePhotoUse
 
     if (FirebaseAuth.getInstance().currentUser?.photoUrl.toString().isNullOrEmpty()) {
       FirebaseAuth.getInstance()
@@ -141,6 +149,7 @@ object SessionManager {
 
   fun setPhoto(photoUrl: String) {
     currentUser?.profilePhoto = photoUrl
+    _profilePicture.value = photoUrl
   }
 
   fun setTripName(tripName: String) {

--- a/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/SessionManager.kt
@@ -1,7 +1,6 @@
 package com.github.se.wanderpals.service
 
 import android.net.Uri
-import android.util.Log
 import com.github.se.wanderpals.model.data.GeoCords
 import com.github.se.wanderpals.model.data.Role
 import com.google.android.gms.maps.model.LatLng

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/Admin.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/Admin.kt
@@ -183,7 +183,6 @@ fun Admin(adminViewModel: AdminViewModel, storageReference: StorageReference?) {
                   Log.d("Admin", "Image URL: ${currentUser?.profilePhoto}")
                 }
               }
-          adminViewModel.modifyCurrentUserProfilePhoto(selectedImages[0].toString())
           AsyncImage( // Icon for the admin screen
               model = currentUser?.profilePhoto!!,
               contentDescription = "Admin Icon",

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/Overview.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/Overview.kt
@@ -82,6 +82,7 @@ fun Overview(overviewViewModel: OverviewViewModel, navigationActions: Navigation
         topBar = {
           // Top bar with search functionality based on the title of the trips
           OverviewTopBar(
+              overviewViewModel = overviewViewModel,
               searchText = searchText,
               onSearchTextChanged = { newSearchText -> searchText = newSearchText })
         },

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
@@ -113,7 +113,7 @@ fun OverviewTopBar(searchText: String, onSearchTextChanged: (String) -> Unit) {
                         .clip(CircleShape)
                         .border(3.dp, onSurfaceVariantLight, CircleShape)
                         .clickable { logout = true }
-                        .testTag("IconOverflowMenu"))
+                        .testTag("profilePhoto"))
           }
         },
         leadingIcon = {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
@@ -1,6 +1,5 @@
 package com.github.se.wanderpals.ui.screens.overview
 
-import android.app.AlertDialog
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -106,7 +105,7 @@ fun OverviewTopBar(searchText: String, onSearchTextChanged: (String) -> Unit) {
                 }
           } else {
             AsyncImage(
-                model = SessionManager.getCurrentUser()?.profilePhoto ?: "",
+                model = FirebaseAuth.getInstance().currentUser?.photoUrl.toString(),
                 contentDescription = "Profile photo",
                 contentScale = ContentScale.Crop,
                 modifier =

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
@@ -30,8 +30,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.github.se.wanderpals.model.viewmodel.OverviewViewModel
 import com.github.se.wanderpals.navigationActions
 import com.github.se.wanderpals.service.SessionManager
+import com.github.se.wanderpals.service.default_profile_photo
 import com.github.se.wanderpals.ui.navigation.Route
 import com.github.se.wanderpals.ui.theme.onSurfaceVariantLight
 import com.google.firebase.auth.FirebaseAuth
@@ -47,13 +49,17 @@ const val EMPTY_SEARCH = ""
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun OverviewTopBar(searchText: String, onSearchTextChanged: (String) -> Unit) {
+fun OverviewTopBar(
+    overviewViewModel: OverviewViewModel,
+    searchText: String,
+    onSearchTextChanged: (String) -> Unit
+) {
 
   // State to track search bar activation:
   var active by remember { mutableStateOf(false) }
   var logout by remember { mutableStateOf(false) }
 
-  val picture by SessionManager.profilePicture.collectAsState()
+  val currentUser by overviewViewModel.currentUser.collectAsState()
 
   if (logout) {
     AlertDialog(
@@ -108,7 +114,7 @@ fun OverviewTopBar(searchText: String, onSearchTextChanged: (String) -> Unit) {
                 }
           } else {
             AsyncImage(
-                model = picture,
+                model = (currentUser?.profilePhoto ?: default_profile_photo),
                 contentDescription = "Profile photo",
                 contentScale = ContentScale.Crop,
                 modifier =

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -51,6 +52,8 @@ fun OverviewTopBar(searchText: String, onSearchTextChanged: (String) -> Unit) {
   // State to track search bar activation:
   var active by remember { mutableStateOf(false) }
   var logout by remember { mutableStateOf(false) }
+
+  val picture by SessionManager.profilePicture.collectAsState()
 
   if (logout) {
     AlertDialog(
@@ -105,7 +108,7 @@ fun OverviewTopBar(searchText: String, onSearchTextChanged: (String) -> Unit) {
                 }
           } else {
             AsyncImage(
-                model = FirebaseAuth.getInstance().currentUser?.photoUrl.toString(),
+                model = picture,
                 contentDescription = "Profile photo",
                 contentScale = ContentScale.Crop,
                 modifier =

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTopBar.kt
@@ -1,17 +1,23 @@
 package com.github.se.wanderpals.ui.screens.overview
 
+import android.app.AlertDialog
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DockedSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -19,9 +25,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.github.se.wanderpals.navigationActions
+import com.github.se.wanderpals.service.SessionManager
+import com.github.se.wanderpals.ui.navigation.Route
 import com.github.se.wanderpals.ui.theme.onSurfaceVariantLight
+import com.google.firebase.auth.FirebaseAuth
 
 // Constant for empty search text
 const val EMPTY_SEARCH = ""
@@ -38,6 +51,33 @@ fun OverviewTopBar(searchText: String, onSearchTextChanged: (String) -> Unit) {
 
   // State to track search bar activation:
   var active by remember { mutableStateOf(false) }
+  var logout by remember { mutableStateOf(false) }
+
+  if (logout) {
+    AlertDialog(
+        onDismissRequest = { logout = false },
+        title = { Text("Confirm Logout") },
+        text = { Text("Are you sure you want to logout?") },
+        confirmButton = {
+          TextButton(
+              onClick = {
+                logout = false
+                SessionManager.logout()
+                FirebaseAuth.getInstance().signOut()
+                navigationActions.navigateTo(Route.SIGN_IN)
+              },
+              modifier = Modifier.testTag("confirmLogoutButton")) {
+                Text("Confirm")
+              }
+        },
+        dismissButton = {
+          TextButton(
+              onClick = { logout = false }, modifier = Modifier.testTag("cancelLogoutButton")) {
+                Text("Cancel")
+              }
+        },
+        modifier = Modifier.testTag("logoutDialog"))
+  }
 
   Box(modifier = Modifier.fillMaxWidth()) {
     // DockedSearchBar component
@@ -64,6 +104,17 @@ fun OverviewTopBar(searchText: String, onSearchTextChanged: (String) -> Unit) {
                       modifier = Modifier.size(24.dp),
                       tint = onSurfaceVariantLight)
                 }
+          } else {
+            AsyncImage(
+                model = SessionManager.getCurrentUser()?.profilePhoto ?: "",
+                contentDescription = "Profile photo",
+                contentScale = ContentScale.Crop,
+                modifier =
+                    Modifier.size(34.dp)
+                        .clip(CircleShape)
+                        .border(3.dp, onSurfaceVariantLight, CircleShape)
+                        .clickable { logout = true }
+                        .testTag("IconOverflowMenu"))
           }
         },
         leadingIcon = {


### PR DESCRIPTION
In this PR:
* Added a check to see if a previous user has already signed in, if yes, directly start at Overview with the variables correctly set.
* UID inside of TripRepository can now be changed, this is done because sometime the user logs out but sign ins right after with a different uid, recreating the class doesn't work
* Added a default profile picture for accounts that don't have any
* Added a profile picture inside of Overview, when clicked, displays a prompt asking you if you want to log out


What is fixed:
* Fixed the name of a user that signs in with a vanilla email not having a name because displayName was empty
* Updating the user throw TripsRepository didn't set all variables, now fixed
* Uploading a profile picture to the FirebaseUser as well when changed
* Fixed sometime wrong path was uploaded inside of the profile picture