### PR TITLE
Expenses info display on click

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/finance/FinanceTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/finance/FinanceTest.kt
@@ -95,7 +95,7 @@ class FinanceViewModelTest :
 
   override fun deleteExpense(expense: Expense) {
     _expenseStateList.value = _expenseStateList.value.filter { it.expenseId != expense.expenseId }
-    hideDeleteDialog()
+    setShowDeleteDialogState(false)
   }
 }
 

--- a/app/src/androidTest/java/com/github/se/wanderpals/finance/FinanceTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/finance/FinanceTest.kt
@@ -2,7 +2,6 @@ package com.github.se.wanderpals.finance
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -35,9 +34,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -89,7 +86,6 @@ class FinanceViewModelTest :
   private val _selectedExpense = MutableStateFlow(expense1)
   override val selectedExpense: StateFlow<Expense?> = _selectedExpense.asStateFlow()
 
-
   fun removeExpenseList() {
     _expenseStateList.value = listOf()
   }
@@ -121,7 +117,6 @@ class FinanceTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSup
 
   private val financeViewModelTest = FinanceViewModelTest()
 
-
   private fun setUpFinanceTest(role: Role = Role.OWNER) {
     SessionManager.setUserSession()
     SessionManager.setRole(role)
@@ -131,13 +126,11 @@ class FinanceTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSup
     }
   }
 
-  private fun setUpExpenseInfoTest(role : Role = Role.OWNER){
-      SessionManager.setUserSession()
-      SessionManager.setRole(role)
-      navigationActions = mockNavActions
-      composeTestRule.setContent {
-          ExpenseInfo(financeViewModel = financeViewModelTest)
-      }
+  private fun setUpExpenseInfoTest(role: Role = Role.OWNER) {
+    SessionManager.setUserSession()
+    SessionManager.setRole(role)
+    navigationActions = mockNavActions
+    composeTestRule.setContent { ExpenseInfo(financeViewModel = financeViewModelTest) }
   }
 
   @Test
@@ -243,25 +236,25 @@ class FinanceTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSup
     composeTestRule.onNodeWithTag("OtherTotalAmount").assertTextEquals("0.00 CHF")
   }
 
-
   @Test
   fun expenseInfoDisplaysCorrectly() = run {
-      setUpExpenseInfoTest()
-      composeTestRule.onNodeWithTag("expenseInfo").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("expenseAmount1").assertIsDisplayed()
-      financeViewModelTest.expenseStateList.value.first().names.forEach {name ->
-          composeTestRule.onNodeWithTag(name + "1").assertTextEquals(name)
-      }
-  }
-    @Test
-    fun expenseInfoGoBackToFinanceRouteWhenClickingOnBackButton() = run{
-        setUpExpenseInfoTest()
-        composeTestRule.onNodeWithTag("expenseInfoBackButton").performClick()
-        verify { mockNavActions.goBack() }
-        confirmVerified(mockNavActions)
+    setUpExpenseInfoTest()
+    composeTestRule.onNodeWithTag("expenseInfo").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("expenseAmount1").assertIsDisplayed()
+    financeViewModelTest.expenseStateList.value.first().names.forEach { name ->
+      composeTestRule.onNodeWithTag(name + "1").assertTextEquals(name)
     }
+  }
 
-    @Test
+  @Test
+  fun expenseInfoGoBackToFinanceRouteWhenClickingOnBackButton() = run {
+    setUpExpenseInfoTest()
+    composeTestRule.onNodeWithTag("expenseInfoBackButton").performClick()
+    verify { mockNavActions.goBack() }
+    confirmVerified(mockNavActions)
+  }
+
+  @Test
   fun expensesDeletesCorrectly() = run {
     setUpExpenseInfoTest()
     ComposeScreen.onComposeScreen<FinanceScreen>(composeTestRule) {
@@ -272,9 +265,9 @@ class FinanceTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSup
       confirmVerified(mockNavActions)
       composeTestRule.onNodeWithTag("deleteExpenseDialog").assertIsNotDisplayed()
       assert(financeViewModelTest.expenseStateList.value.size == 2)
-
     }
   }
+
   @Test
   fun expensesDeletesCancel() = run {
     setUpExpenseInfoTest()
@@ -286,10 +279,11 @@ class FinanceTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSup
       composeTestRule.onNodeWithTag("expenseInfo").assertIsDisplayed()
     }
   }
+
   @Test
   fun viewerCantDeleteExpense() = run {
     setUpExpenseInfoTest(Role.VIEWER)
     composeTestRule.onNodeWithTag("deleteTextButton").performClick()
     composeTestRule.onNodeWithTag("deleteExpenseDialog").assertIsNotDisplayed()
-    }
+  }
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/data/Expense.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/data/Expense.kt
@@ -17,12 +17,12 @@ import java.time.LocalDate
  */
 data class Expense(
     val expenseId: String = "",
-    val title: String= "",
+    val title: String = "",
     val amount: Double = 0.0,
     val category: Category = Category.OTHER,
     val userId: String = "",
     val userName: String = "",
     val participantsIds: List<String> = emptyList(),
     val names: List<String> = emptyList(),
-    val localDate: LocalDate= LocalDate.of(0, 1, 1)
+    val localDate: LocalDate = LocalDate.of(0, 1, 1)
 )

--- a/app/src/main/java/com/github/se/wanderpals/model/data/Expense.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/data/Expense.kt
@@ -16,13 +16,13 @@ import java.time.LocalDate
  * @property localDate The date when the expense was incurred.
  */
 data class Expense(
-    val expenseId: String,
-    val title: String,
-    val amount: Double,
-    val category: Category,
-    val userId: String,
-    val userName: String,
-    val participantsIds: List<String>,
-    val names: List<String>,
-    val localDate: LocalDate
+    val expenseId: String = "",
+    val title: String= "",
+    val amount: Double = 0.0,
+    val category: Category = Category.OTHER,
+    val userId: String = "",
+    val userName: String = "",
+    val participantsIds: List<String> = emptyList(),
+    val names: List<String> = emptyList(),
+    val localDate: LocalDate= LocalDate.of(0, 1, 1)
 )

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
@@ -59,15 +59,13 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
     setShowDeleteDialogState(false)
   }
 
-  open fun setShowDeleteDialogState(value : Boolean){
+  open fun setShowDeleteDialogState(value: Boolean) {
     _showDeleteDialog.value = value
   }
 
-
-  open fun setSelectedExpense(expense : Expense){
+  open fun setSelectedExpense(expense: Expense) {
     _selectedExpense.value = expense
   }
-
 
   class FinanceViewModelFactory(
       private val tripsRepository: TripsRepository,

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
@@ -56,16 +56,13 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
   open fun deleteExpense(expense: Expense) {
     runBlocking { tripsRepository.removeExpenseFromTrip(tripId, expense.expenseId) }
     viewModelScope.launch { updateStateLists() }
-    hideDeleteDialog()
+    setShowDeleteDialogState(false)
   }
 
-  open fun showDeleteDialog() {
-    _showDeleteDialog.value = true
+  open fun setShowDeleteDialogState(value : Boolean){
+    _showDeleteDialog.value = value
   }
 
-  open fun hideDeleteDialog() {
-    _showDeleteDialog.value = false
-  }
 
   open fun setSelectedExpense(expense : Expense){
     _selectedExpense.value = expense

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
@@ -59,8 +59,7 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
     hideDeleteDialog()
   }
 
-  open fun showDeleteDialog(expense: Expense) {
-    _selectedExpense.value = expense
+  open fun showDeleteDialog() {
     _showDeleteDialog.value = true
   }
 

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
@@ -68,6 +68,11 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
     _showDeleteDialog.value = false
   }
 
+  open fun setSelectedExpense(expense : Expense){
+    _selectedExpense.value = expense
+  }
+
+
   class FinanceViewModelFactory(
       private val tripsRepository: TripsRepository,
       private val tripId: String

--- a/app/src/main/java/com/github/se/wanderpals/ui/navigation/Destination.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/navigation/Destination.kt
@@ -52,5 +52,4 @@ val TRIP_DESTINATIONS =
         Destination(
             route = Route.CREATE_EXPENSE, icon = Icons.Default.Create, text = "Create Expense"),
         Destination(route = Route.STOPS_LIST, icon = Icons.Default.Menu, text = "Stops List"),
-        Destination(route = Route.EXPENSE_INFO, icon = Icons.Default.Create, text = "Expense info")
-    )
+        Destination(route = Route.EXPENSE_INFO, icon = Icons.Default.Create, text = "Expense info"))

--- a/app/src/main/java/com/github/se/wanderpals/ui/navigation/Destination.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/navigation/Destination.kt
@@ -51,4 +51,6 @@ val TRIP_DESTINATIONS =
         Destination(route = Route.FINANCE, icon = Icons.Default.Menu, text = "finance"),
         Destination(
             route = Route.CREATE_EXPENSE, icon = Icons.Default.Create, text = "Create Expense"),
-        Destination(route = Route.STOPS_LIST, icon = Icons.Default.Menu, text = "Stops List"))
+        Destination(route = Route.STOPS_LIST, icon = Icons.Default.Menu, text = "Stops List"),
+        Destination(route = Route.EXPENSE_INFO, icon = Icons.Default.Create, text = "Expense info")
+    )

--- a/app/src/main/java/com/github/se/wanderpals/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/navigation/NavigationActions.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.github.se.wanderpals.model.data.Expense
 import com.github.se.wanderpals.model.data.GeoCords
 import com.github.se.wanderpals.model.data.Suggestion
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -191,6 +192,16 @@ data class NavigationActions(
     variables.currentAddress = suggestion.stop.address
   }
 
+
+  /**
+   * Set the variables for the navigation actions.
+   *
+   * @param expense The expense.
+   */
+  fun setVariablesExpense(expense: Expense) {
+    variables.expense = expense
+  }
+
   /**
    * Serializes the navigation variables into a string format.
    *
@@ -240,4 +251,5 @@ class NavigationActionsVariables {
   var currentGeoCords: GeoCords = GeoCords(0.0, 0.0)
   var currentAddress: String = ""
   var suggestionId: String = ""
+  var expense = Expense()
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/navigation/NavigationActions.kt
@@ -192,7 +192,6 @@ data class NavigationActions(
     variables.currentAddress = suggestion.stop.address
   }
 
-
   /**
    * Set the variables for the navigation actions.
    *

--- a/app/src/main/java/com/github/se/wanderpals/ui/navigation/Route.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/navigation/Route.kt
@@ -19,4 +19,5 @@ object Route {
   const val FINANCE = "finance"
   const val CREATE_EXPENSE = "createExpense"
   const val STOPS_LIST = "stopsList"
+  const val EXPENSE_INFO = "expenseInfo"
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
@@ -212,8 +212,8 @@ fun Trip(
 
                       financeViewModel.setSelectedExpense(oldNavActions.variables.expense)
                       ExpenseInfo(
-                          /*financeViewModel = financeViewModel,
-                          navigationActions = oldNavActions*/
+                          financeViewModel = financeViewModel,
+                          navigationActions = oldNavActions
                       )
 
                   }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
@@ -213,7 +213,6 @@ fun Trip(
                       financeViewModel.setSelectedExpense(oldNavActions.variables.expense)
                       ExpenseInfo(
                           financeViewModel = financeViewModel,
-                          navigationActions = oldNavActions
                       )
 
                   }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
@@ -212,8 +212,8 @@ fun Trip(
 
                       financeViewModel.setSelectedExpense(oldNavActions.variables.expense)
                       ExpenseInfo(
-                          financeViewModel = financeViewModel,
-                          navigationActions = oldNavActions
+                          /*financeViewModel = financeViewModel,
+                          navigationActions = oldNavActions*/
                       )
 
                   }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
@@ -187,7 +187,8 @@ fun Trip(
                                   FinanceViewModel.FinanceViewModelFactory(
                                       tripsRepository, oldNavActions.variables.currentTrip),
                               key = "FinanceViewModel")
-                      Finance(financeViewModel = financeViewModel, navigationActions = oldNavActions)
+                      Finance(
+                          financeViewModel = financeViewModel, navigationActions = oldNavActions)
                     }
                     composable(Route.CREATE_EXPENSE) {
                       oldNavActions.updateCurrentRouteOfTrip(Route.CREATE_EXPENSE)
@@ -201,21 +202,20 @@ fun Trip(
                         financeViewModel.updateStateLists()
                       }
                     }
-                  composable(Route.EXPENSE_INFO) {
+                    composable(Route.EXPENSE_INFO) {
                       oldNavActions.updateCurrentRouteOfTrip(Route.EXPENSE_INFO)
                       val financeViewModel: FinanceViewModel =
                           viewModel(
                               factory =
-                              FinanceViewModel.FinanceViewModelFactory(
-                                  tripsRepository, oldNavActions.variables.currentTrip),
+                                  FinanceViewModel.FinanceViewModelFactory(
+                                      tripsRepository, oldNavActions.variables.currentTrip),
                               key = "FinanceViewModel")
 
                       financeViewModel.setSelectedExpense(oldNavActions.variables.expense)
                       ExpenseInfo(
                           financeViewModel = financeViewModel,
                       )
-
-                  }
+                    }
                     composable(Route.STOPS_LIST) {
                       oldNavActions.updateCurrentRouteOfTrip(Route.STOPS_LIST)
                       val viewModel: StopsListViewModel =
@@ -240,9 +240,7 @@ fun BottomBar(navActions: NavigationActions) {
   val currentRoute by navActions.currentRouteTrip.collectAsState()
 
   NavigationBar(
-      modifier = Modifier
-          .testTag("bottomNav")
-          .height(56.dp),
+      modifier = Modifier.testTag("bottomNav").height(56.dp),
       containerColor = NavigationBarDefaults.containerColor,
       contentColor = MaterialTheme.colorScheme.contentColorFor(containerColor),
       tonalElevation = NavigationBarDefaults.Elevation,
@@ -250,9 +248,7 @@ fun BottomBar(navActions: NavigationActions) {
   ) {
     TRIP_BOTTOM_BAR.forEach { destination ->
       NavigationBarItem(
-          modifier = Modifier
-              .testTag(destination.text)
-              .size(56.dp),
+          modifier = Modifier.testTag(destination.text).size(56.dp),
           selected = currentRoute == destination.route,
           onClick = { navActions.navigateTo(destination.route) },
           icon = { Image(imageVector = destination.icon, contentDescription = null) },

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
@@ -40,6 +40,7 @@ import com.github.se.wanderpals.ui.navigation.TRIP_BOTTOM_BAR
 import com.github.se.wanderpals.ui.screens.suggestion.SuggestionDetail
 import com.github.se.wanderpals.ui.screens.trip.agenda.Agenda
 import com.github.se.wanderpals.ui.screens.trip.finance.CreateExpense
+import com.github.se.wanderpals.ui.screens.trip.finance.ExpenseInfo
 import com.github.se.wanderpals.ui.screens.trip.finance.Finance
 import com.github.se.wanderpals.ui.screens.trip.map.Map
 import com.github.se.wanderpals.ui.screens.trip.notifications.CreateAnnouncement
@@ -180,26 +181,42 @@ fun Trip(
                     }
                     composable(Route.FINANCE) {
                       oldNavActions.updateCurrentRouteOfTrip(Route.FINANCE)
-                      val viewModel: FinanceViewModel =
+                      val financeViewModel: FinanceViewModel =
                           viewModel(
                               factory =
                                   FinanceViewModel.FinanceViewModelFactory(
                                       tripsRepository, oldNavActions.variables.currentTrip),
                               key = "FinanceViewModel")
-                      Finance(financeViewModel = viewModel, navigationActions = oldNavActions)
+                      Finance(financeViewModel = financeViewModel, navigationActions = oldNavActions)
                     }
                     composable(Route.CREATE_EXPENSE) {
                       oldNavActions.updateCurrentRouteOfTrip(Route.CREATE_EXPENSE)
-                      val viewModel: FinanceViewModel =
+                      val financeViewModel: FinanceViewModel =
                           viewModel(
                               factory =
                                   FinanceViewModel.FinanceViewModelFactory(
                                       tripsRepository, oldNavActions.variables.currentTrip),
                               key = "FinanceViewModel")
-                      CreateExpense(tripId, viewModel, oldNavActions) {
-                        viewModel.updateStateLists()
+                      CreateExpense(tripId, financeViewModel, oldNavActions) {
+                        financeViewModel.updateStateLists()
                       }
                     }
+                  composable(Route.EXPENSE_INFO) {
+                      oldNavActions.updateCurrentRouteOfTrip(Route.EXPENSE_INFO)
+                      val financeViewModel: FinanceViewModel =
+                          viewModel(
+                              factory =
+                              FinanceViewModel.FinanceViewModelFactory(
+                                  tripsRepository, oldNavActions.variables.currentTrip),
+                              key = "FinanceViewModel")
+
+                      financeViewModel.setSelectedExpense(oldNavActions.variables.expense)
+                      ExpenseInfo(
+                          financeViewModel = financeViewModel,
+                          navigationActions = oldNavActions
+                      )
+
+                  }
                     composable(Route.STOPS_LIST) {
                       oldNavActions.updateCurrentRouteOfTrip(Route.STOPS_LIST)
                       val viewModel: StopsListViewModel =
@@ -224,7 +241,9 @@ fun BottomBar(navActions: NavigationActions) {
   val currentRoute by navActions.currentRouteTrip.collectAsState()
 
   NavigationBar(
-      modifier = Modifier.testTag("bottomNav").height(56.dp),
+      modifier = Modifier
+          .testTag("bottomNav")
+          .height(56.dp),
       containerColor = NavigationBarDefaults.containerColor,
       contentColor = MaterialTheme.colorScheme.contentColorFor(containerColor),
       tonalElevation = NavigationBarDefaults.Elevation,
@@ -232,7 +251,9 @@ fun BottomBar(navActions: NavigationActions) {
   ) {
     TRIP_BOTTOM_BAR.forEach { destination ->
       NavigationBarItem(
-          modifier = Modifier.testTag(destination.text).size(56.dp),
+          modifier = Modifier
+              .testTag(destination.text)
+              .size(56.dp),
           selected = currentRoute == destination.route,
           onClick = { navActions.navigateTo(destination.route) },
           icon = { Image(imageVector = destination.icon, contentDescription = null) },

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
@@ -60,7 +60,7 @@ fun ExpenseInfo(financeViewModel: FinanceViewModel,navigationActions : Navigatio
 
     if (showDeleteDialog) {
         AlertDialog(
-            onDismissRequest = { financeViewModel.hideDeleteDialog() },
+            onDismissRequest = { financeViewModel.setShowDeleteDialogState(false) },
             title = { Text("Confirm Deletion") },
             text = {
                 Text("Are you sure you want to delete this expense?")
@@ -77,7 +77,7 @@ fun ExpenseInfo(financeViewModel: FinanceViewModel,navigationActions : Navigatio
             },
             dismissButton = {
                 TextButton(
-                    onClick = { financeViewModel.hideDeleteDialog() },
+                    onClick = { financeViewModel.setShowDeleteDialogState(false) },
                     modifier = Modifier.testTag("cancelDeleteExpenseButton")) {
                     Text("Cancel")
                 }
@@ -91,7 +91,7 @@ fun ExpenseInfo(financeViewModel: FinanceViewModel,navigationActions : Navigatio
     ) {
 
         ExpenseTopInfo(expense) {
-            financeViewModel.showDeleteDialog()
+            financeViewModel.setShowDeleteDialogState(true)
         }
 
         ExpenseParticipantsInfo(expense = expense)

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
@@ -1,0 +1,16 @@
+package com.github.se.wanderpals.ui.screens.trip.finance
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import com.github.se.wanderpals.model.viewmodel.FinanceViewModel
+import com.github.se.wanderpals.ui.navigation.NavigationActions
+
+@Composable
+fun ExpenseInfo(financeViewModel: FinanceViewModel,navigationActions : NavigationActions){
+    val selectedExpense by financeViewModel.selectedExpense.collectAsState()
+    val expense = selectedExpense!!
+    Text(expense.expenseId)
+}
+
+

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
@@ -45,7 +45,15 @@ import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.navigation.Route
 import java.time.format.DateTimeFormatter
 
-
+/**
+ * Composable function for displaying detailed information about an expense, including :
+ * the title,cost,date and participants related to this expense.
+ * If user has permission higher than viewer, the user can delete the expense.
+ *
+ * This composable takes a [FinanceViewModel] as a parameter to interact with expense data.
+ *
+ * @param financeViewModel The view model containing the expense data and related actions.
+ */
 @Composable
 fun ExpenseInfo(financeViewModel: FinanceViewModel) {
     val selectedExpense by financeViewModel.selectedExpense.collectAsState()
@@ -53,6 +61,7 @@ fun ExpenseInfo(financeViewModel: FinanceViewModel) {
 
     val showDeleteDialog by financeViewModel.showDeleteDialog.collectAsState()
 
+    // Dialog for deleting expense
     if (showDeleteDialog) {
         AlertDialog(
             onDismissRequest = { financeViewModel.setShowDeleteDialogState(false) },
@@ -79,20 +88,28 @@ fun ExpenseInfo(financeViewModel: FinanceViewModel) {
             },
             modifier = Modifier.testTag("deleteExpenseDialog"))
     }
+
     Column(
         modifier = Modifier.fillMaxWidth().testTag("expenseInfo"),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-
-        ExpenseTopInfo(expense) {
+        // Top information of the expenses
+        ExpenseTopInfo(expense = expense) {
             financeViewModel.setShowDeleteDialogState(true)
         }
 
+        // Display of the list of participant related to the expense
         ExpenseParticipantsInfo(expense = expense)
     }
 }
 
+/**
+ * Composable function for displaying top information about an expense.
+ *
+ * @param expense The expense object containing information to be displayed.
+ * @param onDeleteExpenseClick Callback function invoked when the delete expense action is triggered.
+ */
 @Composable
 fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
     val userIsViewer = SessionManager.getCurrentUser()!!.role == Role.VIEWER
@@ -115,6 +132,7 @@ fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                // Go-back button
                 IconButton(
                     modifier = Modifier.align(Alignment.Top).testTag("expenseInfoBackButton"),
                     onClick = { navigationActions.goBack()}
@@ -125,6 +143,7 @@ fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
                         contentDescription = "Back",
                     )
                 }
+                // Delete text (clickable)
                 ClickableText(
                     modifier = Modifier.testTag("deleteTextButton"),
                     onClick = { if(!userIsViewer){
@@ -139,8 +158,9 @@ fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
                     ),
                 )
             }
-            Text(
 
+            // Expense title
+            Text(
                 text = expense.title,
                 style = MaterialTheme.typography.bodyLarge.copy(
                     color = Color.White,
@@ -151,6 +171,7 @@ fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
                 maxLines = 1
             )
 
+            //Expense amount
             Text(
                 modifier = Modifier.padding(top = 10.dp).testTag("expenseAmount"+expense.expenseId),
                 text = String.format("%.2f CHF", expense.amount),
@@ -160,6 +181,7 @@ fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
                     fontWeight = FontWeight.Bold
                 )
             )
+            // Username and local date
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -201,6 +223,12 @@ fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
     }
 }
 
+/**
+ * Composable function for displaying information about participants involved in an expense.
+ * Show their name and the amount they have been paid.
+ *
+ * @param expense The expense object containing participant information.
+ */
 @Composable
 fun ExpenseParticipantsInfo(expense: Expense) {
     LazyColumn(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
@@ -1,16 +1,161 @@
 package com.github.se.wanderpals.ui.screens.trip.finance
+import android.graphics.Paint.Align
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.wanderpals.model.data.Category
+import com.github.se.wanderpals.model.data.Expense
 import com.github.se.wanderpals.model.viewmodel.FinanceViewModel
 import com.github.se.wanderpals.ui.navigation.NavigationActions
+import com.github.se.wanderpals.ui.navigation.Route
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+
+@Preview
+@Composable
+fun ExpenseInfo(/*financeViewModel: FinanceViewModel,navigationActions : NavigationActions*/){
+    //val selectedExpense by financeViewModel.selectedExpense.collectAsState()
+    val expense =  Expense(
+        expenseId = "3",
+        title = "Museum tickets",
+        amount = 25.0,
+        category = Category.ACTIVITIES,
+        userId = "user3",
+        userName = "Bob",
+        participantsIds = listOf("user1", "user3"),
+        names = listOf("John", "Bob"),
+        localDate = LocalDate.now()
+    )
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+        ExpenseTopInfo(expense)
+
+
+    }
+}
 
 @Composable
-fun ExpenseInfo(financeViewModel: FinanceViewModel,navigationActions : NavigationActions){
-    val selectedExpense by financeViewModel.selectedExpense.collectAsState()
-    val expense = selectedExpense!!
-    Text(expense.expenseId)
+fun ExpenseTopInfo(expense : Expense){
+    Surface(
+        color = MaterialTheme.colorScheme.primary,
+        contentColor = Color.White
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 15.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ){
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth().padding(top = 5.dp,end = 10.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(
+                    modifier = Modifier.align(Alignment.Top),
+                    onClick = { /*navigationActions.navigateTo(Route.FINANCE) */},
+                ) {
+                    Icon(
+                        modifier = Modifier.size(35.dp),
+                        imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                        contentDescription = "Back",
+                    )
+                }
+                ClickableText(
+                    onClick = { /* Action à exécuter lors du clic sur le texte "Modify" */ },
+
+                    text = AnnotatedString(
+                        text = "Delete",
+                        spanStyle = SpanStyle(fontSize = 18.sp, color = Color.White)),
+                )
+            }
+            Text(
+
+                text = expense.title,
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    color = Color.White,
+                    fontSize = 25.sp,
+                    fontWeight = FontWeight.Bold),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1
+            )
+
+            Text(
+                modifier = Modifier.padding(top = 10.dp),
+                text = "${expense.amount} CHF",
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    color = Color.White,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold)
+            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 5.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = "Paid by ${expense.userName}",
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        color = Color.White,),
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1
+                )
+                Text(
+                    modifier = Modifier.padding(horizontal = 10.dp),
+                    text = expense.localDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")),
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        color = Color.White,),
+                    maxLines = 1
+                )
+            }
+            Text(
+                modifier = Modifier.padding(bottom = 5.dp).align(Alignment.Start),
+                text = "For ${expense.participantsIds.size} participant(s) :",
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold),
+                textAlign = TextAlign.Start
+            )
+
+        }
+    }
 }
 
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
@@ -38,8 +38,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.model.data.Expense
+import com.github.se.wanderpals.model.data.Role
 import com.github.se.wanderpals.model.viewmodel.FinanceViewModel
 import com.github.se.wanderpals.navigationActions
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.navigation.Route
 import java.time.format.DateTimeFormatter
 
@@ -93,6 +95,8 @@ fun ExpenseInfo(financeViewModel: FinanceViewModel) {
 
 @Composable
 fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
+    val userIsViewer = SessionManager.getCurrentUser()!!.role == Role.VIEWER
+
     Surface(
         color = MaterialTheme.colorScheme.primary,
         contentColor = Color.White
@@ -113,7 +117,7 @@ fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
             ) {
                 IconButton(
                     modifier = Modifier.align(Alignment.Top),
-                    onClick = { navigationActions.goBack()},
+                    onClick = { navigationActions.goBack()}
                 ) {
                     Icon(
                         modifier = Modifier.size(35.dp),
@@ -123,11 +127,15 @@ fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
                 }
                 ClickableText(
                     modifier = Modifier.testTag("deleteTextButton"),
-                    onClick = { onDeleteExpenseClick() },
+                    onClick = { if(!userIsViewer){
+                        onDeleteExpenseClick()
+                    } },
 
                     text = AnnotatedString(
                         text = "DELETE",
-                        spanStyle = SpanStyle(fontSize = 16.sp, color = Color.White)
+                        spanStyle = SpanStyle(
+                            fontSize = 16.sp,
+                            color = if (userIsViewer) Color.LightGray else Color.White)
                     ),
                 )
             }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
@@ -116,7 +116,7 @@ fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 IconButton(
-                    modifier = Modifier.align(Alignment.Top),
+                    modifier = Modifier.align(Alignment.Top).testTag("expenseInfoBackButton"),
                     onClick = { navigationActions.goBack()}
                 ) {
                     Icon(
@@ -152,7 +152,7 @@ fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
             )
 
             Text(
-                modifier = Modifier.padding(top = 10.dp),
+                modifier = Modifier.padding(top = 10.dp).testTag("expenseAmount"+expense.expenseId),
                 text = String.format("%.2f CHF", expense.amount),
                 style = MaterialTheme.typography.bodyLarge.copy(
                     color = Color.White,
@@ -218,7 +218,7 @@ fun ExpenseParticipantsInfo(expense: Expense) {
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier.weight(1f).testTag(userName+expense.expenseId),
                         text = userName,
                         style = MaterialTheme.typography.bodyLarge,
                         maxLines = 1,

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
@@ -1,11 +1,10 @@
 package com.github.se.wanderpals.ui.screens.trip.finance
 
-import android.graphics.Paint.Align
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -21,7 +20,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -34,25 +32,20 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.github.se.wanderpals.model.data.Category
 import com.github.se.wanderpals.model.data.Expense
 import com.github.se.wanderpals.model.viewmodel.FinanceViewModel
 import com.github.se.wanderpals.navigationActions
-import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
-import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 
 @Composable
-fun ExpenseInfo(financeViewModel: FinanceViewModel,navigationActions : NavigationActions) {
+fun ExpenseInfo(financeViewModel: FinanceViewModel) {
     val selectedExpense by financeViewModel.selectedExpense.collectAsState()
     val expense = selectedExpense!!
 
@@ -85,7 +78,7 @@ fun ExpenseInfo(financeViewModel: FinanceViewModel,navigationActions : Navigatio
             modifier = Modifier.testTag("deleteExpenseDialog"))
     }
     Column(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().testTag("expenseInfo"),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -129,6 +122,7 @@ fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
                     )
                 }
                 ClickableText(
+                    modifier = Modifier.testTag("deleteTextButton"),
                     onClick = { onDeleteExpenseClick() },
 
                     text = AnnotatedString(
@@ -185,7 +179,7 @@ fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
             }
             Text(
                 modifier = Modifier
-                    .padding(bottom = 5.dp)
+                    .padding(bottom = 10.dp)
                     .align(Alignment.Start),
                 text = "For ${expense.participantsIds.size} participant(s) :",
                 style = MaterialTheme.typography.bodyLarge.copy(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
@@ -1,14 +1,22 @@
 package com.github.se.wanderpals.ui.screens.trip.finance
+
 import android.graphics.Paint.Align
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -43,9 +51,9 @@ import java.time.format.DateTimeFormatter
 
 @Preview
 @Composable
-fun ExpenseInfo(/*financeViewModel: FinanceViewModel,navigationActions : NavigationActions*/){
+fun ExpenseInfo(/*financeViewModel: FinanceViewModel,navigationActions : NavigationActions*/) {
     //val selectedExpense by financeViewModel.selectedExpense.collectAsState()
-    val expense =  Expense(
+    val expense = Expense(
         expenseId = "3",
         title = "Museum tickets",
         amount = 25.0,
@@ -56,6 +64,7 @@ fun ExpenseInfo(/*financeViewModel: FinanceViewModel,navigationActions : Navigat
         names = listOf("John", "Bob"),
         localDate = LocalDate.now()
     )
+    val expenseList = listOf(expense, expense, expense)
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.Center,
@@ -64,30 +73,62 @@ fun ExpenseInfo(/*financeViewModel: FinanceViewModel,navigationActions : Navigat
 
         ExpenseTopInfo(expense)
 
+        LazyColumn(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            items(expense.names) { userName ->
+                Box(modifier = Modifier.fillMaxWidth().height(80.dp).padding(horizontal = 15.dp)){
+                    Row(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            modifier = Modifier.weight(1f),
+                            text = userName,
+                            style = MaterialTheme.typography.bodyLarge,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            text = String.format("%.2f CHF", expense.amount / expense.participantsIds.size),
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                    }
+                }
+                HorizontalDivider(
+                    color = Color.Gray, thickness = 1.dp, modifier = Modifier.fillMaxWidth())
 
+
+            }
+        }
     }
+
+
 }
 
+
 @Composable
-fun ExpenseTopInfo(expense : Expense){
+fun ExpenseTopInfo(expense: Expense) {
     Surface(
         color = MaterialTheme.colorScheme.primary,
         contentColor = Color.White
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 15.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 15.dp),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
-        ){
+        ) {
             Row(
                 modifier = Modifier
-                    .fillMaxWidth().padding(top = 5.dp,end = 10.dp),
+                    .fillMaxWidth()
+                    .padding(top = 5.dp, end = 10.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 IconButton(
                     modifier = Modifier.align(Alignment.Top),
-                    onClick = { /*navigationActions.navigateTo(Route.FINANCE) */},
+                    onClick = { /*navigationActions.navigateTo(Route.FINANCE) */ },
                 ) {
                     Icon(
                         modifier = Modifier.size(35.dp),
@@ -100,7 +141,8 @@ fun ExpenseTopInfo(expense : Expense){
 
                     text = AnnotatedString(
                         text = "Delete",
-                        spanStyle = SpanStyle(fontSize = 18.sp, color = Color.White)),
+                        spanStyle = SpanStyle(fontSize = 18.sp, color = Color.White)
+                    ),
                 )
             }
             Text(
@@ -109,7 +151,8 @@ fun ExpenseTopInfo(expense : Expense){
                 style = MaterialTheme.typography.bodyLarge.copy(
                     color = Color.White,
                     fontSize = 25.sp,
-                    fontWeight = FontWeight.Bold),
+                    fontWeight = FontWeight.Bold
+                ),
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1
             )
@@ -120,7 +163,8 @@ fun ExpenseTopInfo(expense : Expense){
                 style = MaterialTheme.typography.bodyLarge.copy(
                     color = Color.White,
                     fontSize = 20.sp,
-                    fontWeight = FontWeight.Bold)
+                    fontWeight = FontWeight.Bold
+                )
             )
             Row(
                 modifier = Modifier
@@ -133,7 +177,8 @@ fun ExpenseTopInfo(expense : Expense){
                     modifier = Modifier.weight(1f),
                     text = "Paid by ${expense.userName}",
                     style = MaterialTheme.typography.bodyLarge.copy(
-                        color = Color.White,),
+                        color = Color.White,
+                    ),
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1
                 )
@@ -141,16 +186,20 @@ fun ExpenseTopInfo(expense : Expense){
                     modifier = Modifier.padding(horizontal = 10.dp),
                     text = expense.localDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")),
                     style = MaterialTheme.typography.bodyLarge.copy(
-                        color = Color.White,),
+                        color = Color.White,
+                    ),
                     maxLines = 1
                 )
             }
             Text(
-                modifier = Modifier.padding(bottom = 5.dp).align(Alignment.Start),
+                modifier = Modifier
+                    .padding(bottom = 5.dp)
+                    .align(Alignment.Start),
                 text = "For ${expense.participantsIds.size} participant(s) :",
                 style = MaterialTheme.typography.bodyLarge.copy(
                     color = Color.White,
-                    fontWeight = FontWeight.Bold),
+                    fontWeight = FontWeight.Bold
+                ),
                 textAlign = TextAlign.Start
             )
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
@@ -140,8 +140,8 @@ fun ExpenseTopInfo(expense: Expense) {
                     onClick = { /* Action à exécuter lors du clic sur le texte "Modify" */ },
 
                     text = AnnotatedString(
-                        text = "Delete",
-                        spanStyle = SpanStyle(fontSize = 18.sp, color = Color.White)
+                        text = "DELETE",
+                        spanStyle = SpanStyle(fontSize = 16.sp, color = Color.White)
                     ),
                 )
             }
@@ -169,7 +169,7 @@ fun ExpenseTopInfo(expense: Expense) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 5.dp),
+                    .padding(vertical = 15.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
@@ -1,6 +1,5 @@
 package com.github.se.wanderpals.ui.screens.trip.finance
 
-
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -46,9 +45,9 @@ import com.github.se.wanderpals.ui.navigation.Route
 import java.time.format.DateTimeFormatter
 
 /**
- * Composable function for displaying detailed information about an expense, including :
- * the title,cost,date and participants related to this expense.
- * If user has permission higher than viewer, the user can delete the expense.
+ * Composable function for displaying detailed information about an expense, including : the
+ * title,cost,date and participants related to this expense. If user has permission higher than
+ * viewer, the user can delete the expense.
  *
  * This composable takes a [FinanceViewModel] as a parameter to interact with expense data.
  *
@@ -56,217 +55,171 @@ import java.time.format.DateTimeFormatter
  */
 @Composable
 fun ExpenseInfo(financeViewModel: FinanceViewModel) {
-    val selectedExpense by financeViewModel.selectedExpense.collectAsState()
-    val expense = selectedExpense!!
+  val selectedExpense by financeViewModel.selectedExpense.collectAsState()
+  val expense = selectedExpense!!
 
-    val showDeleteDialog by financeViewModel.showDeleteDialog.collectAsState()
+  val showDeleteDialog by financeViewModel.showDeleteDialog.collectAsState()
 
-    // Dialog for deleting expense
-    if (showDeleteDialog) {
-        AlertDialog(
-            onDismissRequest = { financeViewModel.setShowDeleteDialogState(false) },
-            title = { Text("Confirm Deletion") },
-            text = {
-                Text("Are you sure you want to delete this expense?")
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        financeViewModel.deleteExpense(expense)
-                        navigationActions.navigateTo(Route.FINANCE)
-                              },
-                    modifier = Modifier.testTag("confirmDeleteExpenseButton")) {
-                    Text("Confirm", color = Color.Red)
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = { financeViewModel.setShowDeleteDialogState(false) },
-                    modifier = Modifier.testTag("cancelDeleteExpenseButton")) {
-                    Text("Cancel")
-                }
-            },
-            modifier = Modifier.testTag("deleteExpenseDialog"))
-    }
+  // Dialog for deleting expense
+  if (showDeleteDialog) {
+    AlertDialog(
+        onDismissRequest = { financeViewModel.setShowDeleteDialogState(false) },
+        title = { Text("Confirm Deletion") },
+        text = { Text("Are you sure you want to delete this expense?") },
+        confirmButton = {
+          TextButton(
+              onClick = {
+                financeViewModel.deleteExpense(expense)
+                navigationActions.navigateTo(Route.FINANCE)
+              },
+              modifier = Modifier.testTag("confirmDeleteExpenseButton")) {
+                Text("Confirm", color = Color.Red)
+              }
+        },
+        dismissButton = {
+          TextButton(
+              onClick = { financeViewModel.setShowDeleteDialogState(false) },
+              modifier = Modifier.testTag("cancelDeleteExpenseButton")) {
+                Text("Cancel")
+              }
+        },
+        modifier = Modifier.testTag("deleteExpenseDialog"))
+  }
 
-    Column(
-        modifier = Modifier.fillMaxWidth().testTag("expenseInfo"),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+  Column(
+      modifier = Modifier.fillMaxWidth().testTag("expenseInfo"),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally) {
         // Top information of the expenses
-        ExpenseTopInfo(expense = expense) {
-            financeViewModel.setShowDeleteDialogState(true)
-        }
+        ExpenseTopInfo(expense = expense) { financeViewModel.setShowDeleteDialogState(true) }
 
         // Display of the list of participant related to the expense
         ExpenseParticipantsInfo(expense = expense)
-    }
+      }
 }
 
 /**
  * Composable function for displaying top information about an expense.
  *
  * @param expense The expense object containing information to be displayed.
- * @param onDeleteExpenseClick Callback function invoked when the delete expense action is triggered.
+ * @param onDeleteExpenseClick Callback function invoked when the delete expense action is
+ *   triggered.
  */
 @Composable
-fun ExpenseTopInfo(expense: Expense,onDeleteExpenseClick : () -> Unit) {
-    val userIsViewer = SessionManager.getCurrentUser()!!.role == Role.VIEWER
+fun ExpenseTopInfo(expense: Expense, onDeleteExpenseClick: () -> Unit) {
+  val userIsViewer = SessionManager.getCurrentUser()!!.role == Role.VIEWER
 
-    Surface(
-        color = MaterialTheme.colorScheme.primary,
-        contentColor = Color.White
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 15.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 5.dp, end = 10.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
+  Surface(color = MaterialTheme.colorScheme.primary, contentColor = Color.White) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 15.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally) {
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(top = 5.dp, end = 10.dp),
+              horizontalArrangement = Arrangement.SpaceBetween,
+              verticalAlignment = Alignment.CenterVertically) {
                 // Go-back button
                 IconButton(
                     modifier = Modifier.align(Alignment.Top).testTag("expenseInfoBackButton"),
-                    onClick = { navigationActions.goBack()}
-                ) {
-                    Icon(
-                        modifier = Modifier.size(35.dp),
-                        imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
-                        contentDescription = "Back",
-                    )
-                }
+                    onClick = { navigationActions.goBack() }) {
+                      Icon(
+                          modifier = Modifier.size(35.dp),
+                          imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                          contentDescription = "Back",
+                      )
+                    }
                 // Delete text (clickable)
                 ClickableText(
                     modifier = Modifier.testTag("deleteTextButton"),
-                    onClick = { if(!userIsViewer){
+                    onClick = {
+                      if (!userIsViewer) {
                         onDeleteExpenseClick()
-                    } },
-
-                    text = AnnotatedString(
-                        text = "DELETE",
-                        spanStyle = SpanStyle(
-                            fontSize = 16.sp,
-                            color = if (userIsViewer) Color.LightGray else Color.White)
-                    ),
+                      }
+                    },
+                    text =
+                        AnnotatedString(
+                            text = "DELETE",
+                            spanStyle =
+                                SpanStyle(
+                                    fontSize = 16.sp,
+                                    color = if (userIsViewer) Color.LightGray else Color.White)),
                 )
-            }
+              }
 
-            // Expense title
-            Text(
-                text = expense.title,
-                style = MaterialTheme.typography.bodyLarge.copy(
-                    color = Color.White,
-                    fontSize = 25.sp,
-                    fontWeight = FontWeight.Bold
-                ),
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 1
-            )
+          // Expense title
+          Text(
+              text = expense.title,
+              style =
+                  MaterialTheme.typography.bodyLarge.copy(
+                      color = Color.White, fontSize = 25.sp, fontWeight = FontWeight.Bold),
+              overflow = TextOverflow.Ellipsis,
+              maxLines = 1)
 
-            //Expense amount
-            Text(
-                modifier = Modifier.padding(top = 10.dp).testTag("expenseAmount"+expense.expenseId),
-                text = String.format("%.2f CHF", expense.amount),
-                style = MaterialTheme.typography.bodyLarge.copy(
-                    color = Color.White,
-                    fontSize = 20.sp,
-                    fontWeight = FontWeight.Bold
-                )
-            )
-            // Username and local date
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 15.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
+          // Expense amount
+          Text(
+              modifier = Modifier.padding(top = 10.dp).testTag("expenseAmount" + expense.expenseId),
+              text = String.format("%.2f CHF", expense.amount),
+              style =
+                  MaterialTheme.typography.bodyLarge.copy(
+                      color = Color.White, fontSize = 20.sp, fontWeight = FontWeight.Bold))
+          // Username and local date
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(vertical = 15.dp),
+              horizontalArrangement = Arrangement.SpaceBetween,
+              verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     modifier = Modifier.weight(1f),
                     text = "Paid by ${expense.userName}",
-                    style = MaterialTheme.typography.bodyLarge.copy(
-                        color = Color.White,
-                    ),
+                    style =
+                        MaterialTheme.typography.bodyLarge.copy(
+                            color = Color.White,
+                        ),
                     overflow = TextOverflow.Ellipsis,
-                    maxLines = 1
-                )
+                    maxLines = 1)
                 Text(
                     modifier = Modifier.padding(horizontal = 10.dp),
                     text = expense.localDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")),
-                    style = MaterialTheme.typography.bodyLarge.copy(
-                        color = Color.White,
-                    ),
-                    maxLines = 1
-                )
-            }
-            Text(
-                modifier = Modifier
-                    .padding(bottom = 10.dp)
-                    .align(Alignment.Start),
-                text = "For ${expense.participantsIds.size} participant(s) :",
-                style = MaterialTheme.typography.bodyLarge.copy(
-                    color = Color.White,
-                    fontWeight = FontWeight.Bold
-                ),
-                textAlign = TextAlign.Start
-            )
-
+                    style =
+                        MaterialTheme.typography.bodyLarge.copy(
+                            color = Color.White,
+                        ),
+                    maxLines = 1)
+              }
+          Text(
+              modifier = Modifier.padding(bottom = 10.dp).align(Alignment.Start),
+              text = "For ${expense.participantsIds.size} participant(s) :",
+              style =
+                  MaterialTheme.typography.bodyLarge.copy(
+                      color = Color.White, fontWeight = FontWeight.Bold),
+              textAlign = TextAlign.Start)
         }
-    }
+  }
 }
 
 /**
- * Composable function for displaying information about participants involved in an expense.
- * Show their name and the amount they have been paid.
+ * Composable function for displaying information about participants involved in an expense. Show
+ * their name and the amount they have been paid.
  *
  * @param expense The expense object containing participant information.
  */
 @Composable
 fun ExpenseParticipantsInfo(expense: Expense) {
-    LazyColumn(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        items(expense.names) { userName ->
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(80.dp)
-                    .padding(horizontal = 15.dp)
-            ) {
-                Row(
-                    modifier = Modifier.fillMaxSize(),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        modifier = Modifier.weight(1f).testTag(userName+expense.expenseId),
-                        text = userName,
-                        style = MaterialTheme.typography.bodyLarge,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    Text(
-                        text = String.format(
-                            "%.2f CHF",
-                            expense.amount / expense.participantsIds.size
-                        ),
-                        style = MaterialTheme.typography.bodyLarge
-                    )
-                }
-            }
-            HorizontalDivider(
-                color = Color.Gray, thickness = 1.dp, modifier = Modifier.fillMaxWidth()
-            )
-
+  LazyColumn(modifier = Modifier.fillMaxSize()) {
+    items(expense.names) { userName ->
+      Box(modifier = Modifier.fillMaxWidth().height(80.dp).padding(horizontal = 15.dp)) {
+        Row(modifier = Modifier.fillMaxSize(), verticalAlignment = Alignment.CenterVertically) {
+          Text(
+              modifier = Modifier.weight(1f).testTag(userName + expense.expenseId),
+              text = userName,
+              style = MaterialTheme.typography.bodyLarge,
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis)
+          Text(
+              text = String.format("%.2f CHF", expense.amount / expense.participantsIds.size),
+              style = MaterialTheme.typography.bodyLarge)
         }
+      }
+      HorizontalDivider(color = Color.Gray, thickness = 1.dp, modifier = Modifier.fillMaxWidth())
     }
+  }
 }
-
-

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
@@ -6,13 +6,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -102,8 +100,8 @@ fun Finance(financeViewModel: FinanceViewModel, navigationActions: NavigationAct
                 expenseList = expenseList,
                 onRefresh = { financeViewModel.updateStateLists() },
                 onExpenseItemClick = {
-                    navigationActions.setVariablesExpense(it)
-                    navigationActions.navigateTo(Route.EXPENSE_INFO)
+                  navigationActions.setVariablesExpense(it)
+                  navigationActions.navigateTo(Route.EXPENSE_INFO)
                 })
           }
           FinanceOption.CATEGORIES -> {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
@@ -104,7 +104,10 @@ fun Finance(financeViewModel: FinanceViewModel, navigationActions: NavigationAct
                 innerPadding = innerPadding,
                 expenseList = expenseList,
                 onRefresh = { financeViewModel.updateStateLists() },
-                onExpenseItemClick = { financeViewModel.showDeleteDialog(it) })
+                onExpenseItemClick = {
+                    navigationActions.setVariablesExpense(it)
+                    navigationActions.navigateTo(Route.EXPENSE_INFO)
+                })
           }
           FinanceOption.CATEGORIES -> {
             CategoryContent(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
@@ -63,9 +63,6 @@ fun Finance(financeViewModel: FinanceViewModel, navigationActions: NavigationAct
 
   val expenseList by financeViewModel.expenseStateList.collectAsState()
 
-  val showDeleteDialog by financeViewModel.showDeleteDialog.collectAsState()
-  val selectedExpense by financeViewModel.selectedExpense.collectAsState()
-
   LaunchedEffect(Unit) { financeViewModel.updateStateLists() }
 
   Scaffold(
@@ -123,30 +120,6 @@ fun Finance(financeViewModel: FinanceViewModel, navigationActions: NavigationAct
               )
             }
           }
-        }
-
-        if (showDeleteDialog) {
-          AlertDialog(
-              onDismissRequest = { financeViewModel.hideDeleteDialog() },
-              title = { Text("Confirm Deletion") },
-              text = {
-                Text("Are you sure you want to delete this expense? \"${selectedExpense!!.title}\"")
-              },
-              confirmButton = {
-                TextButton(
-                    onClick = { financeViewModel.deleteExpense(selectedExpense!!) },
-                    modifier = Modifier.testTag("confirmDeleteExpenseButton")) {
-                      Text("Confirm", color = Color.Red)
-                    }
-              },
-              dismissButton = {
-                TextButton(
-                    onClick = { financeViewModel.hideDeleteDialog() },
-                    modifier = Modifier.testTag("cancelDeleteExpenseButton")) {
-                      Text("Cancel")
-                    }
-              },
-              modifier = Modifier.testTag("deleteExpenseDialog"))
         }
       }
 }


### PR DESCRIPTION
In this PR, the following have been done :
User can now click on an expense in the expense option view in finance screen, displaying detailed information about an expense, including : 
 - title,cost,date and participants related to this expense.
 -  If user has permission higher than viewer, the user can delete the expense. directly in the expense info view.
 
 N.B : initally, deleting action was done  when clicking on an expense item (PR #314) since expense info feature was not available at this print. Now delete action is available in the expense info view. 