### PR TITLE
Fix in Trip Creation

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
@@ -87,6 +87,9 @@ class OverviewViewModelTest :
   private val _isLoading = MutableStateFlow(false)
   override val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
+  private val _createTripFinished = MutableStateFlow(false)
+  override val createTripFinished: StateFlow<Boolean> = _createTripFinished.asStateFlow()
+
   fun deleteTrips() {
     _state.value = listOf()
   }
@@ -94,6 +97,7 @@ class OverviewViewModelTest :
   override fun createTrip(trip: Trip) {
     val newTrip = trip.copy(users = listOf("user1"))
     _state.value = _state.value.toMutableList().apply { add(newTrip) }
+    _createTripFinished.value = true
   }
 
   override fun getAllTrips() {}

--- a/app/src/androidTest/java/com/github/se/wanderpals/trip/CreateTripTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/trip/CreateTripTest.kt
@@ -425,80 +425,9 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
     }
   }
 
-  @Test
-  fun saveTripWorks() = run {
-    ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
-      val vm = CreateTripViewModelTest(TripsRepository("testUser123", Dispatchers.IO))
-      composeTestRule.setContent { CreateTrip(vm, mockNavActions) }
-      step("Open trip screen") {
-        inputTitle {
-          assertIsDisplayed()
-          performClick()
-
-          assertTextContains("Title")
-          assertTextContains("Name the trip")
-
-          performTextClearance()
-          performTextInput("My trip")
-        }
-        titleLengthText {
-          assertIsDisplayed()
-          assertTextEquals("7/35")
-        }
-
-        inputBudget {
-          assertIsDisplayed()
-          performClick()
-
-          assertTextContains("Budget")
-
-          performTextClearance()
-          performTextInput("500")
-        }
-
-        inputDescription {
-          assertIsDisplayed()
-          performClick()
-
-          assertTextContains("Describe")
-          assertTextContains("Describe the trip")
-
-          performTextClearance()
-          performTextInput("My description")
-        }
-
-        inputStartDate {
-          assertIsDisplayed()
-
-          assertTextContains("dd/mm/yyyy")
-          performTextClearance()
-
-          performTextInput("05/03/2024")
-        }
-
-        inputEndDate {
-          assertIsDisplayed()
-
-          assertTextContains("dd/mm/yyyy")
-          performTextClearance()
-
-          performTextInput("10/03/2024")
-        }
-
-        saveButton {
-          assertIsDisplayed()
-          performClick()
-        }
-
-        verify { mockNavActions.navigateTo(Route.OVERVIEW) }
-        confirmVerified(mockNavActions)
-      }
-    }
-  }
-
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
-  fun SaveTripWorks() = runBlockingTest {
+  fun saveTripWorks() = runBlockingTest {
 
     // Spy on the actual ViewModel rather than completely mocking it
     val overviewViewModel =

--- a/app/src/androidTest/java/com/github/se/wanderpals/trip/CreateTripTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/trip/CreateTripTest.kt
@@ -1,6 +1,8 @@
 package com.github.se.wanderpals.trip
 
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.repository.TripsRepository
@@ -14,13 +16,16 @@ import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.mockk.Called
+import io.mockk.coEvery
 import io.mockk.confirmVerified
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
+import io.mockk.spyk
 import io.mockk.verify
 import java.time.LocalDate
 import kotlinx.coroutines.Dispatchers
-import org.junit.Before
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -54,14 +59,10 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
 
   @RelaxedMockK lateinit var mockNavActions: NavigationActions
 
-  @Before
-  fun testSetup() {
-    val vm = CreateTripViewModelTest(TripsRepository("testUser123", Dispatchers.IO))
-    composeTestRule.setContent { CreateTrip(vm, mockNavActions) }
-  }
-
   @Test
   fun goBackButtonTriggersBackNavigation() = run {
+    val vm = CreateTripViewModelTest(TripsRepository("testUser123", Dispatchers.IO))
+    composeTestRule.setContent { CreateTrip(vm, mockNavActions) }
     ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
       goBackButton {
         assertIsDisplayed()
@@ -76,6 +77,8 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
 
   @Test
   fun saveTripDoesNotWorkWithEmptyTitle() = run {
+    val vm = CreateTripViewModelTest(TripsRepository("testUser123", Dispatchers.IO))
+    composeTestRule.setContent { CreateTrip(vm, mockNavActions) }
     ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
       step("Open trip screen") {
         inputTitle {
@@ -145,6 +148,8 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
 
   @Test
   fun saveTripDoesNotWorkWithEmptyDescription() = run {
+    val vm = CreateTripViewModelTest(TripsRepository("testUser123", Dispatchers.IO))
+    composeTestRule.setContent { CreateTrip(vm, mockNavActions) }
     ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
       step("Open trip screen") {
         inputTitle {
@@ -212,6 +217,8 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
   }
 
   fun saveTripDoesNotWorkWithEmptyDates() = run {
+    val vm = CreateTripViewModelTest(TripsRepository("testUser123", Dispatchers.IO))
+    composeTestRule.setContent { CreateTrip(vm, mockNavActions) }
     ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
       step("Open trip screen") {
         inputTitle {
@@ -278,6 +285,8 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
   }
 
   fun saveTripDoesNotWorkWithNotLogicalDates() = run {
+    val vm = CreateTripViewModelTest(TripsRepository("testUser123", Dispatchers.IO))
+    composeTestRule.setContent { CreateTrip(vm, mockNavActions) }
     ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
       step("Open trip screen") {
         inputTitle {
@@ -348,6 +357,8 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
   @Test
   fun saveDoesNotWorkWithNegativeBudget() = run {
     ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
+      val vm = CreateTripViewModelTest(TripsRepository("testUser123", Dispatchers.IO))
+      composeTestRule.setContent { CreateTrip(vm, mockNavActions) }
       step("Open trip screen") {
         inputTitle {
           assertIsDisplayed()
@@ -417,6 +428,8 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
   @Test
   fun saveTripWorks() = run {
     ComposeScreen.onComposeScreen<CreateTripoScreen>(composeTestRule) {
+      val vm = CreateTripViewModelTest(TripsRepository("testUser123", Dispatchers.IO))
+      composeTestRule.setContent { CreateTrip(vm, mockNavActions) }
       step("Open trip screen") {
         inputTitle {
           assertIsDisplayed()
@@ -481,5 +494,49 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
         confirmVerified(mockNavActions)
       }
     }
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun SaveTripWorks() = runBlockingTest {
+
+    // Spy on the actual ViewModel rather than completely mocking it
+    val overviewViewModel =
+        spyk(
+            OverviewViewModel(tripsRepository = TripsRepository("-1", Dispatchers.IO)),
+            recordPrivateCalls = true)
+
+    // Mock the createTrip function to only modify certain properties
+    coEvery { overviewViewModel.createTrip(any()) } coAnswers
+        {
+          overviewViewModel.apply {
+            this.setCreateTripFinished(true)
+            // this.setProperty("_createTripFinished", true)
+          }
+        }
+
+    // Set the content of the test
+    composeTestRule.setContent {
+      CreateTrip(overviewViewModel = overviewViewModel, nav = mockNavActions)
+    }
+
+    // Access the UI controls using your custom screen class
+    val screen = CreateTripoScreen(composeTestRule)
+
+    // Simulate user inputs and interactions
+    screen.inputTitle.performTextInput("My Trip")
+    screen.inputBudget.performTextInput("500")
+    screen.inputDescription.performTextInput("An exciting journey")
+    screen.inputStartDate.performTextInput("05/03/2024")
+    screen.inputEndDate.performTextInput("10/03/2024")
+
+    // Simulate clicking the save button
+    screen.saveButton.performClick()
+
+    // Wait for Compose to process potential recompositions due to state changes
+    composeTestRule.waitForIdle()
+
+    // Verify that the navigation has been triggered as expected due to the ViewModel's state change
+    verify { mockNavActions.navigateTo(Route.OVERVIEW) }
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/OverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/OverviewViewModel.kt
@@ -44,11 +44,11 @@ open class OverviewViewModel(private val tripsRepository: TripsRepository) : Vie
 
   // signal that the trip was added successfully
   private val _createTripFinished = MutableStateFlow(false)
-  val createTripFinished: StateFlow<Boolean> = _createTripFinished.asStateFlow()
+  open val createTripFinished: StateFlow<Boolean> = _createTripFinished.asStateFlow()
 
   // don't add a trip twice
   private val _isAddingTrip = MutableStateFlow(false)
-  val isAddingTrip: StateFlow<Boolean> = _isAddingTrip.asStateFlow()
+  open val isAddingTrip: StateFlow<Boolean> = _isAddingTrip.asStateFlow()
 
   /** Fetches all trips from the repository and updates the state flow accordingly. */
   open fun getAllTrips() {
@@ -84,8 +84,8 @@ open class OverviewViewModel(private val tripsRepository: TripsRepository) : Vie
   }
 
   /** Resets the CreateTripFinished flag */
-  fun resetCreateTripFinished() {
-    _createTripFinished.value = false
+  fun setCreateTripFinished(value: Boolean) {
+    _createTripFinished.value = value
   }
 
   /**

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/CreateTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/CreateTrip.kt
@@ -99,7 +99,7 @@ fun CreateTrip(overviewViewModel: OverviewViewModel, nav: NavigationActions) {
   LaunchedEffect(createTripFinished) {
     if (createTripFinished) {
       nav.navigateTo(Route.OVERVIEW) // navigate to overview, after add trip is done
-      overviewViewModel.resetCreateTripFinished() // Reset the flag after handling it
+      overviewViewModel.setCreateTripFinished(false) // Reset the flag after handling it
     }
   }
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/CreateTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/CreateTrip.kt
@@ -27,6 +27,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -90,6 +92,16 @@ class DateInteractionSource(val onClick: () -> Unit) : MutableInteractionSource 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun CreateTrip(overviewViewModel: OverviewViewModel, nav: NavigationActions) {
+
+  val createTripFinished by overviewViewModel.createTripFinished.collectAsState()
+
+  // Effect to react to the createTripFinished state change
+  LaunchedEffect(createTripFinished) {
+    if (createTripFinished) {
+      nav.navigateTo(Route.OVERVIEW) // navigate to overview, after add trip is done
+      overviewViewModel.resetCreateTripFinished() // Reset the flag after handling it
+    }
+  }
 
   val MAX_TITLE_LENGTH = 35
 
@@ -238,7 +250,7 @@ fun CreateTrip(overviewViewModel: OverviewViewModel, nav: NavigationActions) {
                               users = emptyList(),
                               suggestions = emptyList())
                       overviewViewModel.createTrip(trip)
-                      nav.navigateTo(Route.OVERVIEW)
+                      // navigation handled by the launched effects
                     }
                   },
               ) {


### PR DESCRIPTION
Refactored the CreateTrip function to create only a single trip instance, improving efficiency. Transitioned the implementation to use Coroutine scope in the ViewModel, replacing runBlocking to prevent main thread blockage. Updated the OverviewModel to have a stateflow variable tracking the end of the TripCreate operation. Adjusted and fixed unit tests to align with these changes.