### PR TITLE
Add expense notification and update stop notification

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/finance/CreateExpenseTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/finance/CreateExpenseTest.kt
@@ -430,27 +430,6 @@ class CreateExpenseTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
   }
 
   @Test
-  fun viewModelTest() // This test might pose problem later, concurrency issues. If this breaks,
-    // remove it.
-  {
-    val viewModel = FinanceViewModel(FakeExpenseTripRepository(), "")
-    viewModel.loadMembers("")
-    viewModel.addExpense("", mockExpense)
-    composeTestRule.setContent { CreateExpense("", viewModel, mockNavActions) }
-    composeTestRule.waitForIdle()
-
-    ComposeScreen.onComposeScreen<ExpenseScreen>(composeTestRule) {
-      userRow1 { assertExists() }
-      userRow2 { assertExists() }
-      userRow3 { assertExists() }
-      userRow4 { assertExists() }
-    }
-
-    val users = viewModel.users.value
-    assert(users == listOf(mockUser1, mockUser2, mockUser3, mockUser4))
-  }
-
-  @Test
   fun goBackButton() {
     val viewModel = FakeFinanceViewModel()
 

--- a/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
@@ -1,11 +1,7 @@
 package com.github.se.wanderpals.notifications
 
-import androidx.compose.ui.test.assertIsDisplayed
+
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollToIndex
-import androidx.compose.ui.test.printToLog
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.wanderpals.model.data.Announcement
 import com.github.se.wanderpals.model.data.Role
@@ -39,38 +35,31 @@ private val notification1 =
     TripNotification(
         title = "Username1 joined the trip",
         route = Route.ADMIN_PAGE,
-        timestamp = LocalDateTime.now()
-    )
+        timestamp = LocalDateTime.now())
 
 private val notification2 =
     TripNotification(
-        title = "A new suggestion has been created",
-        route = "",
-        timestamp = LocalDateTime.now()
-    )
+        title = "A new suggestion has been created", route = "", timestamp = LocalDateTime.now())
 
 private val notification3 =
     TripNotification(
         title = "A new stop has been added",
         route = Route.STOPS_LIST,
-        timestamp = LocalDateTime.now()
-    )
+        timestamp = LocalDateTime.now())
 
 private val notification4 =
     TripNotification(
         title = "A new suggestion has been created",
         route = Route.SUGGESTION_DETAIL,
         timestamp = LocalDateTime.now(),
-        "currentTrip: 1 |latitude: 0.0|longitude: 0.0|currentAddress: |suggestionId: |expenseId: 0"
-    )
+        "currentTrip: 1 |latitude: 0.0|longitude: 0.0|currentAddress: |suggestionId: |expenseId: 0")
 
 private val notification5 =
     TripNotification(
         title = "A new Expense has been created",
         route = Route.EXPENSE_INFO,
         timestamp = LocalDateTime.now(),
-        "currentTrip: 1 |latitude: 0.0|longitude: 0.0|currentAddress: |suggestionId: |expenseId: 1"
-    )
+        "currentTrip: 1 |latitude: 0.0|longitude: 0.0|currentAddress: |suggestionId: |expenseId: 1")
 
 private val announcement1 =
     Announcement(
@@ -80,7 +69,7 @@ private val announcement1 =
         userName = "John Doe", // Replace with actual user name
         description = "This is a new announcement!",
         timestamp = LocalDateTime.now() // Replace with actual timestamp
-    )
+        )
 private val announcement2 =
     Announcement(
         announcementId = "2", // Replace with actual announcement ID
@@ -89,189 +78,185 @@ private val announcement2 =
         userName = "Jane", // Replace with actual user name
         description = "This is a second announcement!",
         timestamp = LocalDateTime.now() // Replace with actual timestamp
-    )
+        )
 
 class NotificationsViewModelTest :
     NotificationsViewModel(TripsRepository("-1", dispatcher = Dispatchers.IO), "-1") {
 
-    private val _notifStateList =
-        MutableStateFlow(listOf(notification1, notification2, notification3, notification4))
-    override val notifStateList: StateFlow<List<TripNotification>> = _notifStateList
+  private val _notifStateList =
+      MutableStateFlow(listOf(notification1, notification2, notification3, notification4))
+  override val notifStateList: StateFlow<List<TripNotification>> = _notifStateList
 
-    private val _announcementStateList = MutableStateFlow(listOf(announcement1))
-    override val announcementStateList: StateFlow<List<Announcement>> = _announcementStateList
+  private val _announcementStateList = MutableStateFlow(listOf(announcement1))
+  override val announcementStateList: StateFlow<List<Announcement>> = _announcementStateList
 
-    private val _isLoading = MutableStateFlow(false)
-    override val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+  private val _isLoading = MutableStateFlow(false)
+  override val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
-    override fun getSuggestion(suggestionId: String) {
-        _isLoading.value = true
-    }
+  override fun getSuggestion(suggestionId: String) {
+    _isLoading.value = true
+  }
 
-    override fun getExpense(expenseID: String) {
-        _isLoading.value = true
-    }
+  override fun getExpense(expenseID: String) {
+    _isLoading.value = true
+  }
 
-    override fun updateStateLists() {
-        _notifStateList.value = listOf(notification1, notification2, notification3, notification4,
-            notification5)
-        _announcementStateList.value = listOf(announcement1)
-    }
+  override fun updateStateLists() {
+    _notifStateList.value =
+        listOf(notification1, notification2, notification3, notification4, notification5)
+    _announcementStateList.value = listOf(announcement1)
+  }
 
-    override fun addAnnouncement(announcement: Announcement) {
-        _announcementStateList.value =
-            _announcementStateList.value.toMutableList().apply { add(announcement2) }
-    }
+  override fun addAnnouncement(announcement: Announcement) {
+    _announcementStateList.value =
+        _announcementStateList.value.toMutableList().apply { add(announcement2) }
+  }
 
-    override fun removeAnnouncement(announcementId: String) {
-        _announcementStateList.value =
-            _announcementStateList.value.toMutableList().apply {
-                removeIf { it.announcementId == announcementId }
-            }
-    }
+  override fun removeAnnouncement(announcementId: String) {
+    _announcementStateList.value =
+        _announcementStateList.value.toMutableList().apply {
+          removeIf { it.announcementId == announcementId }
+        }
+  }
 }
 
 @RunWith(AndroidJUnit4::class)
 class NotificationsTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @get:Rule
-    val mockkRule = MockKRule(this)
+  @get:Rule val mockkRule = MockKRule(this)
 
-    @RelaxedMockK
-    lateinit var mockNavActions: NavigationActions
+  @RelaxedMockK lateinit var mockNavActions: NavigationActions
 
-    private val notificationsViewModelTest = NotificationsViewModelTest()
+  private val notificationsViewModelTest = NotificationsViewModelTest()
 
-    @Before
-    fun testSetup() {
-        SessionManager.setUserSession()
-        SessionManager.setRole(Role.OWNER)
-        composeTestRule.setContent {
-            Notification(
-                notificationsViewModel = notificationsViewModelTest,
-                navigationActions = mockNavActions
-            )
-        }
+  @Before
+  fun testSetup() {
+    SessionManager.setUserSession()
+    SessionManager.setRole(Role.OWNER)
+    composeTestRule.setContent {
+      Notification(
+          notificationsViewModel = notificationsViewModelTest, navigationActions = mockNavActions)
     }
+  }
 
-    @Test
-    fun notifJoinTripNavigatesToAdmin() = run {
-        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-            notifJoinTripItemButton {
-                assertIsDisplayed()
-                performClick()
-            }
-            verify { mockNavActions.navigateTo(Route.ADMIN_PAGE) }
-            confirmVerified(mockNavActions)
-        }
+  @Test
+  fun notifJoinTripNavigatesToAdmin() = run {
+    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+      notifJoinTripItemButton {
+        assertIsDisplayed()
+        performClick()
+      }
+      verify { mockNavActions.navigateTo(Route.ADMIN_PAGE) }
+      confirmVerified(mockNavActions)
     }
+  }
 
-    @Test
-    fun notifStopNavigatesToStopList() = run {
-        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-            notifStopItemButton {
-                assertIsDisplayed()
-                performClick()
-            }
-            verify { mockNavActions.navigateTo(Route.STOPS_LIST) }
-            confirmVerified(mockNavActions)
-        }
+  @Test
+  fun notifStopNavigatesToStopList() = run {
+    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+      notifStopItemButton {
+        assertIsDisplayed()
+        performClick()
+      }
+      verify { mockNavActions.navigateTo(Route.STOPS_LIST) }
+      confirmVerified(mockNavActions)
     }
-    @Test
-    fun notifSuggestionNavigatesToSuggestionDetail() = run {
-        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-            notifSuggestionItemButton{
-                assertIsDisplayed()
-                performClick()
-            }
-            assert(notificationsViewModelTest.isLoading.value)
-        }
-    }
-    @Test
-    fun notifSuggestionNavigatesToExpenseInfo() = run {
-        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-            notifExpenseItemButton {
-                assertIsDisplayed()
-                performClick()
-            }
-            assert(notificationsViewModelTest.isLoading.value)
-        }
-    }
+  }
 
-
-    @Test
-    fun notifItemWithNoPathDoesNothing() = run {
-        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-            notifItemButtonWithoutPath {
-                assertIsDisplayed()
-                performClick()
-            }
-            verify(exactly = 0) { mockNavActions.navigateTo(any()) }
-            confirmVerified(mockNavActions)
-        }
+  @Test
+  fun notifSuggestionNavigatesToSuggestionDetail() = run {
+    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+      notifSuggestionItemButton {
+        assertIsDisplayed()
+        performClick()
+      }
+      assert(notificationsViewModelTest.isLoading.value)
     }
+  }
 
-    @Test
-    fun createAnnouncementButtonIsNotDisplayedIfUserHasNotPermission() = run {
-        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-            notificationButton { assertIsDisplayed() }
-            announcementButton { assertIsDisplayed() }
-            announcementButton { performClick() }
-            SessionManager.setRole(Role.VIEWER)
-            createAnnouncementButton { assertIsNotDisplayed() }
-            SessionManager.setRole(Role.MEMBER)
-            createAnnouncementButton { assertIsNotDisplayed() }
-        }
+  @Test
+  fun notifSuggestionNavigatesToExpenseInfo() = run {
+    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+      notifExpenseItemButton {
+        assertIsDisplayed()
+        performClick()
+      }
+      assert(notificationsViewModelTest.isLoading.value)
     }
+  }
 
-    @Test
-    fun viewerOrMemberCanReadAnnouncementInfoOnClick() = run {
-        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-            SessionManager.setRole(Role.VIEWER)
-            notificationButton { assertIsDisplayed() }
-            announcementButton { assertIsDisplayed() }
-            announcementButton { performClick() }
-            announcementItemButton1 { performClick() }
-            announcementDialog { assertIsDisplayed() }
-            deleteAnnouncementButton { assertIsNotDisplayed() }
-            deleteAnnouncementButton { assertIsNotDisplayed() }
-        }
-        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-            SessionManager.setRole(Role.MEMBER)
-            notificationButton { assertIsDisplayed() }
-            announcementButton { assertIsDisplayed() }
-            announcementButton { performClick() }
-            announcementItemButton1 { performClick() }
-            announcementDialog { assertIsDisplayed() }
-            deleteAnnouncementButton { assertIsNotDisplayed() }
-            deleteAnnouncementButton { assertIsNotDisplayed() }
-        }
+  @Test
+  fun notifItemWithNoPathDoesNothing() = run {
+    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+      notifItemButtonWithoutPath {
+        assertIsDisplayed()
+        performClick()
+      }
+      verify(exactly = 0) { mockNavActions.navigateTo(any()) }
+      confirmVerified(mockNavActions)
     }
+  }
 
-    @Test
-    fun emptyTextIsDisplayedIfNoAnnouncementAreThere() = run {
-        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-            notificationsViewModelTest.removeAnnouncement("1")
-            notificationButton { assertIsDisplayed() }
-            announcementButton { assertIsDisplayed() }
-            announcementButton { performClick() }
-            noItemsText { assertIsDisplayed() }
-        }
+  @Test
+  fun createAnnouncementButtonIsNotDisplayedIfUserHasNotPermission() = run {
+    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+      notificationButton { assertIsDisplayed() }
+      announcementButton { assertIsDisplayed() }
+      announcementButton { performClick() }
+      SessionManager.setRole(Role.VIEWER)
+      createAnnouncementButton { assertIsNotDisplayed() }
+      SessionManager.setRole(Role.MEMBER)
+      createAnnouncementButton { assertIsNotDisplayed() }
     }
+  }
 
-    @Test
-    fun userWithPermissionsCanDeleteAnnouncement() = run {
-        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-            announcementButton { performClick() }
-            announcementItemButton1 { performClick() }
-            announcementDialog { assertIsDisplayed() }
-            deleteAnnouncementButton { performClick() }
-            deleteAnnouncementDialog { assertIsDisplayed() }
-            confirmDeleteAnnouncementButton { performClick() }
-            noItemsText { assertIsDisplayed() }
-        }
+  @Test
+  fun viewerOrMemberCanReadAnnouncementInfoOnClick() = run {
+    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+      SessionManager.setRole(Role.VIEWER)
+      notificationButton { assertIsDisplayed() }
+      announcementButton { assertIsDisplayed() }
+      announcementButton { performClick() }
+      announcementItemButton1 { performClick() }
+      announcementDialog { assertIsDisplayed() }
+      deleteAnnouncementButton { assertIsNotDisplayed() }
+      deleteAnnouncementButton { assertIsNotDisplayed() }
     }
+    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+      SessionManager.setRole(Role.MEMBER)
+      notificationButton { assertIsDisplayed() }
+      announcementButton { assertIsDisplayed() }
+      announcementButton { performClick() }
+      announcementItemButton1 { performClick() }
+      announcementDialog { assertIsDisplayed() }
+      deleteAnnouncementButton { assertIsNotDisplayed() }
+      deleteAnnouncementButton { assertIsNotDisplayed() }
+    }
+  }
+
+  @Test
+  fun emptyTextIsDisplayedIfNoAnnouncementAreThere() = run {
+    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+      notificationsViewModelTest.removeAnnouncement("1")
+      notificationButton { assertIsDisplayed() }
+      announcementButton { assertIsDisplayed() }
+      announcementButton { performClick() }
+      noItemsText { assertIsDisplayed() }
+    }
+  }
+
+  @Test
+  fun userWithPermissionsCanDeleteAnnouncement() = run {
+    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+      announcementButton { performClick() }
+      announcementItemButton1 { performClick() }
+      announcementDialog { assertIsDisplayed() }
+      deleteAnnouncementButton { performClick() }
+      deleteAnnouncementDialog { assertIsDisplayed() }
+      confirmDeleteAnnouncementButton { performClick() }
+      noItemsText { assertIsDisplayed() }
+    }
+  }
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
@@ -1,6 +1,11 @@
 package com.github.se.wanderpals.notifications
 
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.test.printToLog
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.wanderpals.model.data.Announcement
 import com.github.se.wanderpals.model.data.Role
@@ -30,31 +35,44 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-val notification1 =
+private val notification1 =
     TripNotification(
         title = "Username1 joined the trip",
         route = Route.ADMIN_PAGE,
-        timestamp = LocalDateTime.now())
+        timestamp = LocalDateTime.now()
+    )
 
-val notification2 =
+private val notification2 =
     TripNotification(
         title = "A new suggestion has been created",
         route = "",
-        timestamp = LocalDateTime.now())
+        timestamp = LocalDateTime.now()
+    )
 
-val notification3 =
+private val notification3 =
     TripNotification(
         title = "A new stop has been added",
         route = Route.STOPS_LIST,
-        timestamp = LocalDateTime.now())
+        timestamp = LocalDateTime.now()
+    )
 
-val notification4 =
+private val notification4 =
     TripNotification(
         title = "A new suggestion has been created",
-        route = Route.STOPS_LIST,
-        timestamp = LocalDateTime.now())
+        route = Route.SUGGESTION_DETAIL,
+        timestamp = LocalDateTime.now(),
+        "currentTrip: 1 |latitude: 0.0|longitude: 0.0|currentAddress: |suggestionId: |expenseId: 0"
+    )
 
-val announcement1 =
+private val notification5 =
+    TripNotification(
+        title = "A new Expense has been created",
+        route = Route.EXPENSE_INFO,
+        timestamp = LocalDateTime.now(),
+        "currentTrip: 1 |latitude: 0.0|longitude: 0.0|currentAddress: |suggestionId: |expenseId: 1"
+    )
+
+private val announcement1 =
     Announcement(
         announcementId = "1", // Replace with actual announcement ID
         userId = "1", // Replace with actual user ID
@@ -62,8 +80,8 @@ val announcement1 =
         userName = "John Doe", // Replace with actual user name
         description = "This is a new announcement!",
         timestamp = LocalDateTime.now() // Replace with actual timestamp
-        )
-val announcement2 =
+    )
+private val announcement2 =
     Announcement(
         announcementId = "2", // Replace with actual announcement ID
         userId = "2", // Replace with actual user ID
@@ -71,141 +89,189 @@ val announcement2 =
         userName = "Jane", // Replace with actual user name
         description = "This is a second announcement!",
         timestamp = LocalDateTime.now() // Replace with actual timestamp
-        )
+    )
 
 class NotificationsViewModelTest :
     NotificationsViewModel(TripsRepository("-1", dispatcher = Dispatchers.IO), "-1") {
 
-  private val _notifStateList = MutableStateFlow(listOf(notification1, notification2,notification3,notification4))
-  override val notifStateList: StateFlow<List<TripNotification>> = _notifStateList
+    private val _notifStateList =
+        MutableStateFlow(listOf(notification1, notification2, notification3, notification4))
+    override val notifStateList: StateFlow<List<TripNotification>> = _notifStateList
 
-  private val _announcementStateList = MutableStateFlow(listOf(announcement1))
-  override val announcementStateList: StateFlow<List<Announcement>> = _announcementStateList
+    private val _announcementStateList = MutableStateFlow(listOf(announcement1))
+    override val announcementStateList: StateFlow<List<Announcement>> = _announcementStateList
 
-  private val _isLoading = MutableStateFlow(false)
-  override val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+    private val _isLoading = MutableStateFlow(false)
+    override val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
-  override fun updateStateLists() {
-    _notifStateList.value = listOf(notification1, notification2)
-    _announcementStateList.value = listOf(announcement1)
-  }
+    override fun getSuggestion(suggestionId: String) {
+        _isLoading.value = true
+    }
 
-  override fun addAnnouncement(announcement: Announcement) {
-    _announcementStateList.value =
-        _announcementStateList.value.toMutableList().apply { add(announcement2) }
-  }
+    override fun getExpense(expenseID: String) {
+        _isLoading.value = true
+    }
 
-  override fun removeAnnouncement(announcementId: String) {
-    _announcementStateList.value =
-        _announcementStateList.value.toMutableList().apply {
-          removeIf { it.announcementId == announcementId }
-        }
-  }
+    override fun updateStateLists() {
+        _notifStateList.value = listOf(notification1, notification2, notification3, notification4,
+            notification5)
+        _announcementStateList.value = listOf(announcement1)
+    }
+
+    override fun addAnnouncement(announcement: Announcement) {
+        _announcementStateList.value =
+            _announcementStateList.value.toMutableList().apply { add(announcement2) }
+    }
+
+    override fun removeAnnouncement(announcementId: String) {
+        _announcementStateList.value =
+            _announcementStateList.value.toMutableList().apply {
+                removeIf { it.announcementId == announcementId }
+            }
+    }
 }
 
 @RunWith(AndroidJUnit4::class)
 class NotificationsTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
 
-  @get:Rule val composeTestRule = createComposeRule()
+    @get:Rule
+    val composeTestRule = createComposeRule()
 
-  @get:Rule val mockkRule = MockKRule(this)
+    @get:Rule
+    val mockkRule = MockKRule(this)
 
-  @RelaxedMockK lateinit var mockNavActions: NavigationActions
+    @RelaxedMockK
+    lateinit var mockNavActions: NavigationActions
 
-  private val notificationsViewModelTest = NotificationsViewModelTest()
+    private val notificationsViewModelTest = NotificationsViewModelTest()
 
-  @Before
-  fun testSetup() {
-    SessionManager.setUserSession()
-    SessionManager.setRole(Role.OWNER)
-    composeTestRule.setContent {
-      Notification(
-          notificationsViewModel = notificationsViewModelTest, navigationActions = mockNavActions)
+    @Before
+    fun testSetup() {
+        SessionManager.setUserSession()
+        SessionManager.setRole(Role.OWNER)
+        composeTestRule.setContent {
+            Notification(
+                notificationsViewModel = notificationsViewModelTest,
+                navigationActions = mockNavActions
+            )
+        }
     }
-  }
 
-  @Test
-  fun notifJoinTripNavigatesToAdmin() = run {
-    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-      notifItemButtonWithPath {
-        assertIsDisplayed()
-        performClick()
-      }
-      verify { mockNavActions.navigateTo(Route.ADMIN_PAGE) }
-      confirmVerified(mockNavActions)
+    @Test
+    fun notifJoinTripNavigatesToAdmin() = run {
+        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+            notifJoinTripItemButton {
+                assertIsDisplayed()
+                performClick()
+            }
+            verify { mockNavActions.navigateTo(Route.ADMIN_PAGE) }
+            confirmVerified(mockNavActions)
+        }
     }
-  }
 
-  @Test
-  fun notifItemWithNoPathDoesNothing() = run {
-    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-      notifItemButtonWithoutPath {
-        assertIsDisplayed()
-        performClick()
-      }
-      verify(exactly = 0) { mockNavActions.navigateTo(any()) }
-      confirmVerified(mockNavActions)
+    @Test
+    fun notifStopNavigatesToStopList() = run {
+        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+            notifStopItemButton {
+                assertIsDisplayed()
+                performClick()
+            }
+            verify { mockNavActions.navigateTo(Route.STOPS_LIST) }
+            confirmVerified(mockNavActions)
+        }
     }
-  }
+    @Test
+    fun notifSuggestionNavigatesToSuggestionDetail() = run {
+        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+            notifSuggestionItemButton{
+                assertIsDisplayed()
+                performClick()
+            }
+            assert(notificationsViewModelTest.isLoading.value)
+        }
+    }
+    @Test
+    fun notifSuggestionNavigatesToExpenseInfo() = run {
+        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+            notifExpenseItemButton {
+                assertIsDisplayed()
+                performClick()
+            }
+            assert(notificationsViewModelTest.isLoading.value)
+        }
+    }
 
-  @Test
-  fun createAnnouncementButtonIsNotDisplayedIfUserHasNotPermission() = run {
-    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-      notificationButton { assertIsDisplayed() }
-      announcementButton { assertIsDisplayed() }
-      announcementButton { performClick() }
-      SessionManager.setRole(Role.VIEWER)
-      createAnnouncementButton { assertIsNotDisplayed() }
-      SessionManager.setRole(Role.MEMBER)
-      createAnnouncementButton { assertIsNotDisplayed() }
-    }
-  }
 
-  @Test
-  fun viewerOrMemberCanReadAnnouncementInfoOnClick() = run {
-    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-      SessionManager.setRole(Role.VIEWER)
-      notificationButton { assertIsDisplayed() }
-      announcementButton { assertIsDisplayed() }
-      announcementButton { performClick() }
-      announcementItemButton1 { performClick() }
-      announcementDialog { assertIsDisplayed() }
-      deleteAnnouncementButton { assertIsNotDisplayed() }
-      deleteAnnouncementButton { assertIsNotDisplayed() }
+    @Test
+    fun notifItemWithNoPathDoesNothing() = run {
+        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+            notifItemButtonWithoutPath {
+                assertIsDisplayed()
+                performClick()
+            }
+            verify(exactly = 0) { mockNavActions.navigateTo(any()) }
+            confirmVerified(mockNavActions)
+        }
     }
-    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-      SessionManager.setRole(Role.MEMBER)
-      notificationButton { assertIsDisplayed() }
-      announcementButton { assertIsDisplayed() }
-      announcementButton { performClick() }
-      announcementItemButton1 { performClick() }
-      announcementDialog { assertIsDisplayed() }
-      deleteAnnouncementButton { assertIsNotDisplayed() }
-      deleteAnnouncementButton { assertIsNotDisplayed() }
-    }
-  }
 
-  @Test
-  fun emptyTextIsDisplayedIfNoAnnouncementAreThere() = run {
-    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-      notificationsViewModelTest.removeAnnouncement("1")
-      notificationButton { assertIsDisplayed() }
-      announcementButton { assertIsDisplayed() }
-      announcementButton { performClick() }
-      noItemsText { assertIsDisplayed() }
+    @Test
+    fun createAnnouncementButtonIsNotDisplayedIfUserHasNotPermission() = run {
+        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+            notificationButton { assertIsDisplayed() }
+            announcementButton { assertIsDisplayed() }
+            announcementButton { performClick() }
+            SessionManager.setRole(Role.VIEWER)
+            createAnnouncementButton { assertIsNotDisplayed() }
+            SessionManager.setRole(Role.MEMBER)
+            createAnnouncementButton { assertIsNotDisplayed() }
+        }
     }
-  }
 
-  @Test
-  fun userWithPermissionsCanDeleteAnnouncement() = run {
-    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
-      announcementButton { performClick() }
-      announcementItemButton1 { performClick() }
-      announcementDialog { assertIsDisplayed() }
-      deleteAnnouncementButton { performClick() }
-      deleteAnnouncementDialog { assertIsDisplayed() }
-      confirmDeleteAnnouncementButton { performClick() }
-      noItemsText { assertIsDisplayed() }
+    @Test
+    fun viewerOrMemberCanReadAnnouncementInfoOnClick() = run {
+        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+            SessionManager.setRole(Role.VIEWER)
+            notificationButton { assertIsDisplayed() }
+            announcementButton { assertIsDisplayed() }
+            announcementButton { performClick() }
+            announcementItemButton1 { performClick() }
+            announcementDialog { assertIsDisplayed() }
+            deleteAnnouncementButton { assertIsNotDisplayed() }
+            deleteAnnouncementButton { assertIsNotDisplayed() }
+        }
+        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+            SessionManager.setRole(Role.MEMBER)
+            notificationButton { assertIsDisplayed() }
+            announcementButton { assertIsDisplayed() }
+            announcementButton { performClick() }
+            announcementItemButton1 { performClick() }
+            announcementDialog { assertIsDisplayed() }
+            deleteAnnouncementButton { assertIsNotDisplayed() }
+            deleteAnnouncementButton { assertIsNotDisplayed() }
+        }
     }
-  }
+
+    @Test
+    fun emptyTextIsDisplayedIfNoAnnouncementAreThere() = run {
+        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+            notificationsViewModelTest.removeAnnouncement("1")
+            notificationButton { assertIsDisplayed() }
+            announcementButton { assertIsDisplayed() }
+            announcementButton { performClick() }
+            noItemsText { assertIsDisplayed() }
+        }
+    }
+
+    @Test
+    fun userWithPermissionsCanDeleteAnnouncement() = run {
+        ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+            announcementButton { performClick() }
+            announcementItemButton1 { performClick() }
+            announcementDialog { assertIsDisplayed() }
+            deleteAnnouncementButton { performClick() }
+            deleteAnnouncementDialog { assertIsDisplayed() }
+            confirmDeleteAnnouncementButton { performClick() }
+            noItemsText { assertIsDisplayed() }
+        }
+    }
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
@@ -38,9 +38,22 @@ val notification1 =
 
 val notification2 =
     TripNotification(
-        title = "Username1 joined the trip",
+        title = "A new suggestion has been created",
         route = "",
-        timestamp = LocalDateTime.now().minusDays(1))
+        timestamp = LocalDateTime.now())
+
+val notification3 =
+    TripNotification(
+        title = "A new stop has been added",
+        route = Route.STOPS_LIST,
+        timestamp = LocalDateTime.now())
+
+val notification4 =
+    TripNotification(
+        title = "A new suggestion has been created",
+        route = Route.STOPS_LIST,
+        timestamp = LocalDateTime.now())
+
 val announcement1 =
     Announcement(
         announcementId = "1", // Replace with actual announcement ID
@@ -63,7 +76,7 @@ val announcement2 =
 class NotificationsViewModelTest :
     NotificationsViewModel(TripsRepository("-1", dispatcher = Dispatchers.IO), "-1") {
 
-  private val _notifStateList = MutableStateFlow(listOf(notification1, notification2))
+  private val _notifStateList = MutableStateFlow(listOf(notification1, notification2,notification3,notification4))
   override val notifStateList: StateFlow<List<TripNotification>> = _notifStateList
 
   private val _announcementStateList = MutableStateFlow(listOf(announcement1))
@@ -112,7 +125,7 @@ class NotificationsTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
   }
 
   @Test
-  fun notifItemWithPathNavigatesOnClick() = run {
+  fun notifJoinTripNavigatesToAdmin() = run {
     ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
       notifItemButtonWithPath {
         assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
@@ -1,6 +1,5 @@
 package com.github.se.wanderpals.notifications
 
-
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.wanderpals.model.data.Announcement

--- a/app/src/androidTest/java/com/github/se/wanderpals/screens/NotificationScreen.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/screens/NotificationScreen.kt
@@ -25,8 +25,13 @@ class NotificationScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   }
   val deleteAnnouncementButton: KNode = onNode { hasTestTag("deleteAnnouncementButton") }
 
-  val notifItemButtonWithPath: KNode = onNode { hasTestTag("notifItemButton" + Route.ADMIN_PAGE) }
+  val notifJoinTripItemButton: KNode = onNode { hasTestTag("notifItemButton" + Route.ADMIN_PAGE) }
 
+  val notifStopItemButton: KNode = onNode { hasTestTag("notifItemButton" + Route.STOPS_LIST) }
+
+  val notifSuggestionItemButton: KNode = onNode { hasTestTag("notifItemButton" + Route.SUGGESTION_DETAIL) }
+
+  val notifExpenseItemButton: KNode = onNode { hasTestTag("notifItemButton" + Route.EXPENSE_INFO) }
   val notifItemButtonWithoutPath: KNode = onNode { hasTestTag("notifItemButton") }
 
   val announcementItemButton1: KNode = onNode { hasTestTag("announcementItemButton1") }

--- a/app/src/androidTest/java/com/github/se/wanderpals/screens/NotificationScreen.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/screens/NotificationScreen.kt
@@ -29,7 +29,9 @@ class NotificationScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
 
   val notifStopItemButton: KNode = onNode { hasTestTag("notifItemButton" + Route.STOPS_LIST) }
 
-  val notifSuggestionItemButton: KNode = onNode { hasTestTag("notifItemButton" + Route.SUGGESTION_DETAIL) }
+  val notifSuggestionItemButton: KNode = onNode {
+    hasTestTag("notifItemButton" + Route.SUGGESTION_DETAIL)
+  }
 
   val notifExpenseItemButton: KNode = onNode { hasTestTag("notifItemButton" + Route.EXPENSE_INFO) }
   val notifItemButtonWithoutPath: KNode = onNode { hasTestTag("notifItemButton") }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
@@ -48,7 +48,12 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
     viewModelScope.launch { _users.value = tripsRepository.getAllUsersFromTrip(tripId) }
   }
 
-  /** Adds an expense to the trip. */
+  /**
+   * Adds an expense to a specified trip.
+   *
+   * @param tripId The ID of the trip to which to add the expense.
+   * @param expense The Expense object to add.
+   */
   open fun addExpense(tripId: String, expense: Expense) {
     runBlocking {
       tripsRepository.addExpenseToTrip(tripId, expense)}
@@ -59,7 +64,11 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
         }
   }
 
-
+  /**
+   * Deletes a specific expense from a trip.
+   *
+   * @param expense The Expense object to delete.
+   */
   open fun deleteExpense(expense: Expense) {
     runBlocking { tripsRepository.removeExpenseFromTrip(tripId, expense.expenseId) }
     viewModelScope.launch {
@@ -68,6 +77,8 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
     setShowDeleteDialogState(false)
   }
 
+
+  /** Setter functions*/
   open fun setShowDeleteDialogState(value: Boolean) {
     _showDeleteDialog.value = value
   }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
@@ -55,13 +55,12 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
    * @param expense The Expense object to add.
    */
   open fun addExpense(tripId: String, expense: Expense) {
-    runBlocking {
-      tripsRepository.addExpenseToTrip(tripId, expense)}
-        viewModelScope.launch {
-          val newExpense = tripsRepository.getAllExpensesFromTrip(tripId).last()
-          NotificationsManager.addExpenseNotification(tripId,newExpense)
-          updateStateLists()
-        }
+    runBlocking { tripsRepository.addExpenseToTrip(tripId, expense) }
+    viewModelScope.launch {
+      val newExpense = tripsRepository.getAllExpensesFromTrip(tripId).last()
+      NotificationsManager.addExpenseNotification(tripId, newExpense)
+      updateStateLists()
+    }
   }
 
   /**
@@ -72,13 +71,13 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
   open fun deleteExpense(expense: Expense) {
     runBlocking { tripsRepository.removeExpenseFromTrip(tripId, expense.expenseId) }
     viewModelScope.launch {
-      NotificationsManager.removeExpensePath(tripId,expense.expenseId)
-      updateStateLists() }
+      NotificationsManager.removeExpensePath(tripId, expense.expenseId)
+      updateStateLists()
+    }
     setShowDeleteDialogState(false)
   }
 
-
-  /** Setter functions*/
+  /** Setter functions */
   open fun setShowDeleteDialogState(value: Boolean) {
     _showDeleteDialog.value = value
   }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.github.se.wanderpals.model.data.Expense
 import com.github.se.wanderpals.model.data.User
 import com.github.se.wanderpals.model.repository.TripsRepository
+import com.github.se.wanderpals.service.NotificationsManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -49,9 +50,15 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
 
   /** Adds an expense to the trip. */
   open fun addExpense(tripId: String, expense: Expense) {
-    runBlocking { tripsRepository.addExpenseToTrip(tripId, expense) }
-    viewModelScope.launch { updateStateLists() }
+    runBlocking {
+      tripsRepository.addExpenseToTrip(tripId, expense)}
+        viewModelScope.launch {
+          val newExpense = tripsRepository.getAllExpensesFromTrip(tripId).last()
+          NotificationsManager.addExpenseNotification(tripId,newExpense)
+          updateStateLists()
+        }
   }
+
 
   open fun deleteExpense(expense: Expense) {
     runBlocking { tripsRepository.removeExpenseFromTrip(tripId, expense.expenseId) }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
@@ -62,7 +62,9 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
 
   open fun deleteExpense(expense: Expense) {
     runBlocking { tripsRepository.removeExpenseFromTrip(tripId, expense.expenseId) }
-    viewModelScope.launch { updateStateLists() }
+    viewModelScope.launch {
+      NotificationsManager.removeExpensePath(tripId,expense.expenseId)
+      updateStateLists() }
     setShowDeleteDialogState(false)
   }
 

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/NotificationsViewModel.kt
@@ -70,6 +70,11 @@ open class NotificationsViewModel(val tripsRepository: TripsRepository, val trip
     }
   }
 
+  /**
+   * Retrieves a suggestion for the specified suggestion ID from the trip's repository.
+   *
+   * @param suggestionId The ID of the suggestion to retrieve.
+   */
   open fun getSuggestion(suggestionId: String) {
     viewModelScope.launch {
       val suggestion = tripsRepository.getSuggestionFromTrip(tripId, suggestionId)
@@ -78,11 +83,11 @@ open class NotificationsViewModel(val tripsRepository: TripsRepository, val trip
     }
   }
 
-  open fun resetIsLoadingSuggestion() {
-    _isSuggestionReady.value = false
-  }
-
-
+  /**
+   * Retrieves an expense for the specified expense ID from the trip's repository.
+   *
+   * @param expenseID The ID of the expense to retrieve.
+   */
   open fun getExpense(expenseID : String) {
     viewModelScope.launch {
       val expense= tripsRepository.getExpenseFromTrip(tripId,expenseID)
@@ -91,6 +96,10 @@ open class NotificationsViewModel(val tripsRepository: TripsRepository, val trip
     }
   }
 
+  /** Methods for reset the loading state for suggestion or expense retrieval*/
+  open fun resetIsLoadingSuggestion() {
+    _isSuggestionReady.value = false
+  }
   open fun resetIsLoadingExpense() {
     _isExpenseReady.value = false
   }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/NotificationsViewModel.kt
@@ -88,23 +88,22 @@ open class NotificationsViewModel(val tripsRepository: TripsRepository, val trip
    *
    * @param expenseID The ID of the expense to retrieve.
    */
-  open fun getExpense(expenseID : String) {
+  open fun getExpense(expenseID: String) {
     viewModelScope.launch {
-      val expense= tripsRepository.getExpenseFromTrip(tripId,expenseID)
+      val expense = tripsRepository.getExpenseFromTrip(tripId, expenseID)
       _currentExpense.value = expense
       _isExpenseReady.value = true
     }
   }
 
-  /** Methods for reset the loading state for suggestion or expense retrieval*/
+  /** Methods for reset the loading state for suggestion or expense retrieval */
   open fun resetIsLoadingSuggestion() {
     _isSuggestionReady.value = false
   }
+
   open fun resetIsLoadingExpense() {
     _isExpenseReady.value = false
   }
-
-
 
   /**
    * Adds a Announcement by the administrator to a trip.

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/NotificationsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.github.se.wanderpals.model.data.Announcement
+import com.github.se.wanderpals.model.data.Expense
 import com.github.se.wanderpals.model.data.Suggestion
 import com.github.se.wanderpals.model.data.TripNotification
 import com.github.se.wanderpals.model.repository.TripsRepository
@@ -46,6 +47,13 @@ open class NotificationsViewModel(val tripsRepository: TripsRepository, val trip
 
   private val _isSuggestionReady = MutableStateFlow(false)
   val isSuggestionReady: StateFlow<Boolean> = _isSuggestionReady.asStateFlow()
+
+  private val _currentExpense = MutableStateFlow<Expense?>(null)
+  val currentExpense: StateFlow<Expense?> = _currentExpense.asStateFlow()
+
+  private val _isExpenseReady = MutableStateFlow(false)
+  val isExpenseReady: StateFlow<Boolean> = _isExpenseReady.asStateFlow()
+
   /**
    * Updates the state lists of notifications and announcements by launching a coroutine within the
    * viewModel scope.
@@ -73,6 +81,21 @@ open class NotificationsViewModel(val tripsRepository: TripsRepository, val trip
   open fun resetIsLoadingSuggestion() {
     _isSuggestionReady.value = false
   }
+
+
+  open fun getExpense(expenseID : String) {
+    viewModelScope.launch {
+      val expense= tripsRepository.getExpenseFromTrip(tripId,expenseID)
+      _currentExpense.value = expense
+      _isExpenseReady.value = true
+    }
+  }
+
+  open fun resetIsLoadingExpense() {
+    _isExpenseReady.value = false
+  }
+
+
 
   /**
    * Adds a Announcement by the administrator to a trip.

--- a/app/src/main/java/com/github/se/wanderpals/service/NotificationsManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/NotificationsManager.kt
@@ -1,5 +1,6 @@
 package com.github.se.wanderpals.service
 
+import com.github.se.wanderpals.model.data.Expense
 import com.github.se.wanderpals.model.data.Stop
 import com.github.se.wanderpals.model.data.TripNotification
 import com.github.se.wanderpals.model.repository.TripsRepository
@@ -115,6 +116,29 @@ object NotificationsManager {
         TripNotification(
             "A new stop has been added ", route, LocalDateTime.now(), navActionVariables)
     addNewNotification(notifList, newNotif)
+    tripsRepository.setNotificationList(tripId, notifList.toList())
+  }
+
+  /**
+   * Adds a notification for a new expense to the notification list of a trip.
+   *
+   * @param tripId The ID of the trip to which to add the notification.
+   * @param expense The added expense  for which to create the notification.
+   */
+  suspend fun addExpenseNotification(tripId: String, expense: Expense) {
+    val notifList = tripsRepository.getNotificationList(tripId).toMutableList()
+    val navActions = navigationActions.copy()
+    var route = Route.EXPENSE_INFO
+
+    navActions.setVariablesExpense(expense)
+
+    var navActionVariables = navActions.serializeNavigationVariable()
+
+    val newNotif =
+      TripNotification(
+        "A new expense has been created", route, LocalDateTime.now(), navActionVariables)
+    addNewNotification(notifList, newNotif)
+
     tripsRepository.setNotificationList(tripId, notifList.toList())
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/service/NotificationsManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/NotificationsManager.kt
@@ -7,6 +7,8 @@ import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.navigationActions
 import com.github.se.wanderpals.ui.navigation.Route
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 /** Singleton object responsible for managing trip notifications. */
 object NotificationsManager {
@@ -126,14 +128,13 @@ object NotificationsManager {
     val navActions = navigationActions.copy()
     var route = ""
     var navActionVariables = ""
-    if (stop.address.isNotEmpty()) {
-      navActions.setVariablesLocation(geoCords = stop.geoCords, address = stop.address)
-      route = Route.MAP
-      navActionVariables = navActions.serializeNavigationVariable()
-    }
+    route = Route.STOPS_LIST
+
     val newNotif =
         TripNotification(
-            "A new stop has been added ", route, LocalDateTime.now(), navActionVariables)
+            "A new stop has been added for ${stop.date.format(
+              DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy").withLocale(
+                Locale.getDefault()))}", route, LocalDateTime.now(), navActionVariables)
     addNewNotification(notifList, newNotif)
     tripsRepository.setNotificationList(tripId, notifList.toList())
   }

--- a/app/src/main/java/com/github/se/wanderpals/service/NotificationsManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/NotificationsManager.kt
@@ -127,7 +127,6 @@ object NotificationsManager {
     val notifList = tripsRepository.getNotificationList(tripId).toMutableList()
     val navActionVariables = ""
     val route = Route.STOPS_LIST
-
     val newNotif =
         TripNotification(
             "A new stop has been added for ${stop.date.format(

--- a/app/src/main/java/com/github/se/wanderpals/service/NotificationsManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/NotificationsManager.kt
@@ -60,6 +60,25 @@ object NotificationsManager {
   }
 
   /**
+   * Removes the path from a notification containing the provided expense ID.
+   *
+   * @param tripId The ID of the trip containing the notification.
+   * @param expenseId The expense for which the notification path should be removed.
+   */
+  suspend fun removeExpensePath(tripId: String, expenseId: String) {
+    val notifList = tripsRepository.getNotificationList(tripId).toMutableList()
+
+    notifList.replaceAll {
+      if (it.navActionVariables.contains("expenseId: $expenseId")) {
+        it.copy(route = "", navActionVariables = "")
+      } else {
+        it
+      }
+    }
+    tripsRepository.setNotificationList(tripId, notifList.toList())
+  }
+
+  /**
    * Adds a notification indicating that a user has joined a trip.
    *
    * @param tripId The ID of the trip for which the notification is added.

--- a/app/src/main/java/com/github/se/wanderpals/service/NotificationsManager.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/NotificationsManager.kt
@@ -125,16 +125,17 @@ object NotificationsManager {
    */
   suspend fun addStopNotification(tripId: String, stop: Stop) {
     val notifList = tripsRepository.getNotificationList(tripId).toMutableList()
-    val navActions = navigationActions.copy()
-    var route = ""
-    var navActionVariables = ""
-    route = Route.STOPS_LIST
+    val navActionVariables = ""
+    val route = Route.STOPS_LIST
 
     val newNotif =
         TripNotification(
             "A new stop has been added for ${stop.date.format(
               DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy").withLocale(
-                Locale.getDefault()))}", route, LocalDateTime.now(), navActionVariables)
+                Locale.getDefault()))}",
+            route,
+            LocalDateTime.now(),
+            navActionVariables)
     addNewNotification(notifList, newNotif)
     tripsRepository.setNotificationList(tripId, notifList.toList())
   }
@@ -143,20 +144,20 @@ object NotificationsManager {
    * Adds a notification for a new expense to the notification list of a trip.
    *
    * @param tripId The ID of the trip to which to add the notification.
-   * @param expense The added expense  for which to create the notification.
+   * @param expense The added expense for which to create the notification.
    */
   suspend fun addExpenseNotification(tripId: String, expense: Expense) {
     val notifList = tripsRepository.getNotificationList(tripId).toMutableList()
     val navActions = navigationActions.copy()
-    var route = Route.EXPENSE_INFO
+    val route = Route.EXPENSE_INFO
 
     navActions.setVariablesExpense(expense)
 
-    var navActionVariables = navActions.serializeNavigationVariable()
+    val navActionVariables = navActions.serializeNavigationVariable()
 
     val newNotif =
-      TripNotification(
-        "A new expense has been created", route, LocalDateTime.now(), navActionVariables)
+        TripNotification(
+            "A new expense has been created", route, LocalDateTime.now(), navActionVariables)
     addNewNotification(notifList, newNotif)
 
     tripsRepository.setNotificationList(tripId, notifList.toList())

--- a/app/src/main/java/com/github/se/wanderpals/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/navigation/NavigationActions.kt
@@ -213,7 +213,8 @@ data class NavigationActions(
             "latitude: ${variables.currentGeoCords.latitude}",
             "longitude: ${variables.currentGeoCords.longitude}",
             "currentAddress: ${variables.currentAddress}",
-            "suggestionId: ${variables.suggestionId}")
+            "suggestionId: ${variables.suggestionId}",
+            "expenseId: ${variables.expense.expenseId}")
 
     return navActionsVariablesToString.joinToString("|")
   }
@@ -237,6 +238,7 @@ data class NavigationActions(
                 variables.currentGeoCords.copy(longitude = argVal.toDouble())
         "currentAddress" -> variables.currentAddress = argVal
         "suggestionId" -> variables.suggestionId = argVal
+        "expenseId" -> variables.expense = Expense(expenseId = argVal)
       }
     }
     this.variables = variables

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/MessageItem.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/MessageItem.kt
@@ -51,7 +51,6 @@ fun NotificationItem(notification: TripNotification, onNotificationItemClick: ()
                 textAlign = TextAlign.Start,
                 maxLines = 2)
 
-
             // Spacer
             Spacer(modifier = Modifier.width(16.dp))
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/MessageItem.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/MessageItem.kt
@@ -48,7 +48,9 @@ fun NotificationItem(notification: TripNotification, onNotificationItemClick: ()
                 style = TextStyle(fontSize = 16.sp),
                 color = if (notification.route.isNotEmpty()) Color.Black else Color.Gray,
                 modifier = Modifier.weight(1f).fillMaxWidth().align(Alignment.CenterVertically),
-                textAlign = TextAlign.Start)
+                textAlign = TextAlign.Start,
+                maxLines = 2)
+
 
             // Spacer
             Spacer(modifier = Modifier.width(16.dp))

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/Notification.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/Notification.kt
@@ -88,7 +88,7 @@ fun Notification(
   val expense by notificationsViewModel.currentExpense.collectAsState()
   val isLoadingExpense by notificationsViewModel.isExpenseReady.collectAsState()
 
-  // navigation to suggestion fix
+
   LaunchedEffect(isLoadingSuggestion,isLoadingExpense) {
     if (isLoadingSuggestion) {
       navigationActions.variables.currentSuggestion = suggestion as Suggestion

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/Notification.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/Notification.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.model.data.Announcement
+import com.github.se.wanderpals.model.data.Expense
 import com.github.se.wanderpals.model.data.Suggestion
 import com.github.se.wanderpals.model.data.TripNotification
 import com.github.se.wanderpals.model.viewmodel.NotificationsViewModel
@@ -84,13 +85,21 @@ fun Notification(
   val suggestion by notificationsViewModel.currentSuggestion.collectAsState()
   val isLoadingSuggestion by notificationsViewModel.isSuggestionReady.collectAsState()
 
+  val expense by notificationsViewModel.currentExpense.collectAsState()
+  val isLoadingExpense by notificationsViewModel.isExpenseReady.collectAsState()
+
   // navigation to suggestion fix
-  LaunchedEffect(isLoadingSuggestion) {
+  LaunchedEffect(isLoadingSuggestion,isLoadingExpense) {
     if (isLoadingSuggestion) {
       navigationActions.variables.currentSuggestion = suggestion as Suggestion
       navigationActions.navigateTo(Route.SUGGESTION_DETAIL)
       notificationsViewModel.resetIsLoadingSuggestion()
     }
+    if (isLoadingExpense) {
+          navigationActions.variables.expense = expense as Expense
+          navigationActions.navigateTo(Route.EXPENSE_INFO)
+          notificationsViewModel.resetIsLoadingExpense()
+      }
   }
 
   Column(modifier = Modifier.testTag("notificationScreen")) {
@@ -194,7 +203,12 @@ fun Notification(
                                   notificationsViewModel.getSuggestion(
                                       navigationActions.variables.suggestionId)
                                 }
-                              } else if (item.route != Route.SUGGESTION_DETAIL) {
+                                if(item.route == Route.EXPENSE_INFO){
+                                    notificationsViewModel.getExpense(
+                                        navigationActions.variables.expense.expenseId)
+                                }
+                              }
+                              else if (item.route != Route.SUGGESTION_DETAIL && item.route != Route.EXPENSE_INFO) {
                                 navigationActions.navigateTo(item.route)
                               }
                             }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/Notification.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/Notification.kt
@@ -88,18 +88,17 @@ fun Notification(
   val expense by notificationsViewModel.currentExpense.collectAsState()
   val isLoadingExpense by notificationsViewModel.isExpenseReady.collectAsState()
 
-
-  LaunchedEffect(isLoadingSuggestion,isLoadingExpense) {
+  LaunchedEffect(isLoadingSuggestion, isLoadingExpense) {
     if (isLoadingSuggestion) {
       navigationActions.variables.currentSuggestion = suggestion as Suggestion
       navigationActions.navigateTo(Route.SUGGESTION_DETAIL)
       notificationsViewModel.resetIsLoadingSuggestion()
     }
     if (isLoadingExpense) {
-          navigationActions.variables.expense = expense as Expense
-          navigationActions.navigateTo(Route.EXPENSE_INFO)
-          notificationsViewModel.resetIsLoadingExpense()
-      }
+      navigationActions.variables.expense = expense as Expense
+      navigationActions.navigateTo(Route.EXPENSE_INFO)
+      notificationsViewModel.resetIsLoadingExpense()
+    }
   }
 
   Column(modifier = Modifier.testTag("notificationScreen")) {
@@ -195,21 +194,20 @@ fun Notification(
                           notification = item,
                           onNotificationItemClick = {
                             if (item.route.isNotEmpty()) {
-                                if (item.navActionVariables.isNotEmpty()) {
-                                    navigationActions.deserializeNavigationVariables(
-                                        item.navActionVariables)
-                                    when (item.route) {
-                                        Route.SUGGESTION_DETAIL -> notificationsViewModel.getSuggestion(
-                                            navigationActions.variables.suggestionId
-                                        )
-
-                                        Route.EXPENSE_INFO -> notificationsViewModel.getExpense(
-                                            navigationActions.variables.expense.expenseId
-                                        )
-                                    }
-                                }else{
-                                    navigationActions.navigateTo(item.route)
+                              if (item.navActionVariables.isNotEmpty()) {
+                                navigationActions.deserializeNavigationVariables(
+                                    item.navActionVariables)
+                                when (item.route) {
+                                  Route.SUGGESTION_DETAIL ->
+                                      notificationsViewModel.getSuggestion(
+                                          navigationActions.variables.suggestionId)
+                                  Route.EXPENSE_INFO ->
+                                      notificationsViewModel.getExpense(
+                                          navigationActions.variables.expense.expenseId)
                                 }
+                              } else {
+                                navigationActions.navigateTo(item.route)
+                              }
                             }
                           })
                     }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/Notification.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/Notification.kt
@@ -195,22 +195,21 @@ fun Notification(
                           notification = item,
                           onNotificationItemClick = {
                             if (item.route.isNotEmpty()) {
-                              if (item.navActionVariables.isNotEmpty()) {
-                                navigationActions.deserializeNavigationVariables(
-                                    item.navActionVariables)
-                                if (item.route == Route.SUGGESTION_DETAIL) {
-                                  // Load suggestion for navigation
-                                  notificationsViewModel.getSuggestion(
-                                      navigationActions.variables.suggestionId)
+                                if (item.navActionVariables.isNotEmpty()) {
+                                    navigationActions.deserializeNavigationVariables(
+                                        item.navActionVariables)
+                                    when (item.route) {
+                                        Route.SUGGESTION_DETAIL -> notificationsViewModel.getSuggestion(
+                                            navigationActions.variables.suggestionId
+                                        )
+
+                                        Route.EXPENSE_INFO -> notificationsViewModel.getExpense(
+                                            navigationActions.variables.expense.expenseId
+                                        )
+                                    }
+                                }else{
+                                    navigationActions.navigateTo(item.route)
                                 }
-                                if(item.route == Route.EXPENSE_INFO){
-                                    notificationsViewModel.getExpense(
-                                        navigationActions.variables.expense.expenseId)
-                                }
-                              }
-                              else if (item.route != Route.SUGGESTION_DETAIL && item.route != Route.EXPENSE_INFO) {
-                                navigationActions.navigateTo(item.route)
-                              }
                             }
                           })
                     }

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/FinanceViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/FinanceViewModelTest.kt
@@ -7,7 +7,6 @@ import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.FinanceViewModel
 import com.github.se.wanderpals.navigationActions
 import com.github.se.wanderpals.service.NotificationsManager
-import com.github.se.wanderpals.ui.navigation.NavigationActions
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -31,7 +30,6 @@ class FinanceViewModelTest {
   private lateinit var mockTripsRepository: TripsRepository
   private val testDispatcher = StandardTestDispatcher()
   private val tripId = "tripId"
-
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Before

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/FinanceViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/FinanceViewModelTest.kt
@@ -5,8 +5,14 @@ import com.github.se.wanderpals.model.data.Expense
 import com.github.se.wanderpals.model.data.User
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.FinanceViewModel
+import com.github.se.wanderpals.navigationActions
+import com.github.se.wanderpals.service.NotificationsManager
+import com.github.se.wanderpals.ui.navigation.NavigationActions
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import java.time.LocalDate
 import kotlinx.coroutines.Dispatchers
@@ -26,12 +32,17 @@ class FinanceViewModelTest {
   private val testDispatcher = StandardTestDispatcher()
   private val tripId = "tripId"
 
+
   @OptIn(ExperimentalCoroutinesApi::class)
   @Before
   fun setup() {
     Dispatchers.setMain(testDispatcher)
 
     mockTripsRepository = mockk(relaxed = true)
+    NotificationsManager.initNotificationsManager(mockTripsRepository)
+    navigationActions = mockk(relaxed = true)
+
+    every { navigationActions.goBack() } just Runs
     setupMockResponses()
 
     viewModel = FinanceViewModel(mockTripsRepository, tripId)


### PR DESCRIPTION
In this review, the following things have been done : 
- When an expense is created an expense notification is created. When clicking, it displays the information of the expense and if the expense is deleted, we can't click on it anymore
- Since there is a stop list implemented now, every stop notification is clickable and navigates to the stop list. The notification text indicates the starting date of the stop so that user can find easier which stops it corresponds to in the notification List
- Tests have been modified and updated to reflect all of these changes