### PR TITLE
Delete stops

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/agenda/AgendaTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/agenda/AgendaTest.kt
@@ -111,7 +111,12 @@ class AgendaTest {
     val testYearMonth = YearMonth.now()
     val fakeViewModel = FakeAgendaViewModel(testYearMonth, emptyList())
 
-    composeTestRule.setContent { Agenda(agendaViewModel = fakeViewModel) }
+    composeTestRule.setContent {
+      Agenda(
+          agendaViewModel = fakeViewModel,
+          tripId = "",
+          tripsRepository = TripsRepository("", Dispatchers.IO))
+    }
 
     composeTestRule.waitForIdle()
 
@@ -127,7 +132,14 @@ class AgendaTest {
     val initialMonth = YearMonth.now()
     val fakeViewModel = FakeAgendaViewModel(initialMonth, emptyList())
 
-    composeTestRule.setContent { WanderPalsTheme { Agenda(agendaViewModel = fakeViewModel) } }
+    composeTestRule.setContent {
+      WanderPalsTheme {
+        Agenda(
+            agendaViewModel = fakeViewModel,
+            tripId = "",
+            tripsRepository = TripsRepository("", Dispatchers.IO))
+      }
+    }
 
     // Click on the banner to make the calendar appear
     composeTestRule.onNodeWithTag("Banner").performClick()
@@ -144,7 +156,14 @@ class AgendaTest {
     val initialMonth = YearMonth.now()
     val fakeViewModel = FakeAgendaViewModel(initialMonth, emptyList())
 
-    composeTestRule.setContent { WanderPalsTheme { Agenda(agendaViewModel = fakeViewModel) } }
+    composeTestRule.setContent {
+      WanderPalsTheme {
+        Agenda(
+            agendaViewModel = fakeViewModel,
+            tripId = "",
+            tripsRepository = TripsRepository("", Dispatchers.IO))
+      }
+    }
 
     // Click on the banner to make the calendar appear
     composeTestRule.onNodeWithTag("Banner").performClick()
@@ -165,7 +184,14 @@ class AgendaTest {
           // Initial state setup to ensure "15" is present and not selected.
         }
 
-    composeTestRule.setContent { WanderPalsTheme { Agenda(agendaViewModel = fakeViewModel) } }
+    composeTestRule.setContent {
+      WanderPalsTheme {
+        Agenda(
+            agendaViewModel = fakeViewModel,
+            tripId = "",
+            tripsRepository = TripsRepository("", Dispatchers.IO))
+      }
+    }
 
     // Click on the banner to make the calendar appear
     composeTestRule.onNodeWithTag("Banner").performClick()
@@ -186,7 +212,12 @@ class AgendaTest {
   fun checkBannerIsDisplayed() {
     val testViewModel = AgendaViewModel("", TripsRepository("", Dispatchers.Main))
 
-    composeTestRule.setContent { Agenda(agendaViewModel = testViewModel) }
+    composeTestRule.setContent {
+      Agenda(
+          agendaViewModel = testViewModel,
+          tripId = "",
+          tripsRepository = TripsRepository("", Dispatchers.IO))
+    }
 
     composeTestRule.waitForIdle()
 

--- a/app/src/androidTest/java/com/github/se/wanderpals/agenda/AgendaTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/agenda/AgendaTest.kt
@@ -2,6 +2,7 @@ package com.github.se.wanderpals.agenda
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -14,6 +15,7 @@ import com.github.se.wanderpals.model.viewmodel.AgendaViewModel
 import com.github.se.wanderpals.ui.screens.trip.agenda.Agenda
 import com.github.se.wanderpals.ui.screens.trip.agenda.Banner
 import com.github.se.wanderpals.ui.screens.trip.agenda.CalendarUiState
+import com.github.se.wanderpals.ui.screens.trip.agenda.CalendarWidget
 import com.github.se.wanderpals.ui.screens.trip.agenda.getDisplayName
 import com.github.se.wanderpals.ui.theme.WanderPalsTheme
 import java.time.LocalDate
@@ -27,8 +29,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-class FakeAgendaViewModel(initialYearMonth: YearMonth, testActivities: List<Stop>) :
-    AgendaViewModel("", TripsRepository("", Dispatchers.IO)) {
+class FakeAgendaViewModel(
+    initialYearMonth: YearMonth,
+    testActivities: List<Stop>,
+    private val initialStopsInfo: MutableStateFlow<Map<LocalDate, CalendarUiState.StopStatus>> =
+        MutableStateFlow(emptyMap())
+) : AgendaViewModel("", TripsRepository("", Dispatchers.IO)) {
   private val _uiState =
       MutableStateFlow(
           CalendarUiState(
@@ -39,9 +45,18 @@ class FakeAgendaViewModel(initialYearMonth: YearMonth, testActivities: List<Stop
                         dayOfMonth = (day + 1).toString(),
                         yearMonth = initialYearMonth,
                         year = Year.now(),
-                        isSelected = false)
+                        isSelected = false,
+                        stopStatus =
+                            initialStopsInfo.value.getOrDefault(
+                                LocalDate.now().withDayOfMonth(day + 1),
+                                CalendarUiState.StopStatus.NONE))
                   },
               selectedDate = null))
+
+  /** Mutable state flow for the stops info. */
+  init {
+    _stopsInfo.value = initialStopsInfo.value
+  }
 
   override var uiState: StateFlow<CalendarUiState> = _uiState
   override var dailyActivities: StateFlow<List<Stop>> = MutableStateFlow(testActivities)
@@ -64,6 +79,25 @@ class FakeAgendaViewModel(initialYearMonth: YearMonth, testActivities: List<Stop
     _uiState.value =
         _uiState.value.copy(
             dates = newDates, selectedDate = if (date.isSelected) null else LocalDate.now())
+  }
+
+  /**
+   * Simulates a change in the stop status for a given date.
+   *
+   * @param date The date to update.
+   * @param status The new status to assign to the date.
+   */
+  fun simulateStopStatusChange(date: LocalDate, status: CalendarUiState.StopStatus) {
+    initialStopsInfo.value = initialStopsInfo.value.plus(date to status)
+    _stopsInfo.value = initialStopsInfo.value
+    _uiState.value =
+        _uiState.value.copy(
+            dates =
+                _uiState.value.dates.map {
+                  if (it.dayOfMonth.toInt() == date.dayOfMonth) {
+                    it.copy(stopStatus = status)
+                  } else it
+                })
   }
 }
 
@@ -191,5 +225,78 @@ class AgendaTest {
     composeTestRule.waitForIdle() // Wait for UI to update
 
     composeTestRule.onNodeWithTag("displayDateText", useUnmergedTree = true).assertIsDisplayed()
+  }
+
+  /** Test to verify that the marker with "ADDED" stop status exists and is displayed. */
+  @Test
+  fun calendarDateWithAddedStatusShowsMarker() {
+    val testYearMonth = YearMonth.of(2024, 5)
+    val testDate = LocalDate.of(2024, 5, 5)
+    val fakeViewModel = FakeAgendaViewModel(testYearMonth, emptyList())
+
+    // Simulate adding a stop with ADDED status on May 5, 2024
+    fakeViewModel.simulateStopStatusChange(testDate, CalendarUiState.StopStatus.ADDED)
+
+    // Set up the environment for the test
+    composeTestRule.setContent {
+      WanderPalsTheme {
+        CalendarWidget(
+            days = arrayOf("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"),
+            yearMonth = testYearMonth,
+            dates =
+                listOf(
+                    CalendarUiState.Date(
+                        "5",
+                        testYearMonth.withMonth(5),
+                        year = Year.of(2024),
+                        isSelected = false,
+                        stopStatus = CalendarUiState.StopStatus.ADDED)),
+            onPreviousMonthButtonClicked = {},
+            onNextMonthButtonClicked = {},
+            onDateClickListener = {},
+        )
+      }
+    }
+
+    // Find the marker and assert it's displayed on the screen because the stop status is "ADDED"
+    composeTestRule.onNodeWithTag("MarkerADDED", useUnmergedTree = true).assertExists()
+    composeTestRule.onNodeWithTag("MarkerADDED", useUnmergedTree = true).assertIsDisplayed()
+  }
+
+  /**
+   * Test to verify that the marker with "ADDED" stop status does not exist and is not displayed.
+   */
+  @Test
+  fun calendarDateWithNoAddedStatusShowsNoMarker() {
+    val testYearMonth = YearMonth.of(2024, 5)
+    val testDate = LocalDate.of(2024, 5, 6)
+    val fakeViewModel = FakeAgendaViewModel(testYearMonth, emptyList())
+
+    // Ensure the status is NONE for the test date
+    fakeViewModel.simulateStopStatusChange(testDate, CalendarUiState.StopStatus.NONE)
+
+    // Set up the environment for the test
+    composeTestRule.setContent {
+      WanderPalsTheme {
+        CalendarWidget(
+            days = arrayOf("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"),
+            yearMonth = testYearMonth,
+            dates =
+                listOf(
+                    CalendarUiState.Date(
+                        "6",
+                        testYearMonth.withMonth(5),
+                        year = Year.of(2024),
+                        isSelected = false,
+                        stopStatus = CalendarUiState.StopStatus.NONE)),
+            onPreviousMonthButtonClicked = {},
+            onNextMonthButtonClicked = {},
+            onDateClickListener = {})
+      }
+    }
+
+    // Assert that the marker with "ADDED" status is not displayed because the stop status is "NONE"
+    composeTestRule.onNodeWithTag("MarkerADDED", useUnmergedTree = true).assertDoesNotExist()
+    composeTestRule.onNodeWithTag("MarkerADDED", useUnmergedTree = true).isNotDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/agenda/DailyActivitiesTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/agenda/DailyActivitiesTest.kt
@@ -15,13 +15,15 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.wanderpals.model.data.GeoCords
 import com.github.se.wanderpals.model.data.Stop
-import com.github.se.wanderpals.ui.screens.trip.agenda.StopItem
+import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.ui.screens.trip.agenda.DailyActivities
 import com.github.se.wanderpals.ui.screens.trip.agenda.StopInfoDialog
+import com.github.se.wanderpals.ui.screens.trip.stops.StopItem
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.Dispatchers
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -80,7 +82,11 @@ class DailyActivitiesTest {
   fun checkDailyActivitiesAreDisplayed() {
 
     composeTestRule.setContent {
-      DailyActivities(agendaViewModel = testViewModel, onActivityItemClick = {})
+      DailyActivities(
+          agendaViewModel = testViewModel,
+          onActivityItemClick = {},
+          tripId = "1",
+          tripsRepository = TripsRepository(uid = "1", Dispatchers.IO))
     }
 
     composeTestRule.waitForIdle()
@@ -101,7 +107,16 @@ class DailyActivitiesTest {
   fun verifyActivityItemsContent() {
     // Set the content once with a composable that includes all test items
     composeTestRule.setContent {
-      Column { testActivities.forEach { stop -> StopItem(stop = stop, onActivityClick = {}) } }
+      Column {
+        testActivities.forEach { stop ->
+          StopItem(
+              stop = stop,
+              onActivityClick = {},
+              tripId = "1",
+              tripsRepository = TripsRepository(uid = "1", Dispatchers.IO),
+              onRefresh = {})
+        }
+      }
     }
 
     // Loop through each test activity and assert its details
@@ -142,7 +157,11 @@ class DailyActivitiesTest {
   fun checkNoActivitiesMessageIsDisplayed() {
 
     composeTestRule.setContent {
-      DailyActivities(agendaViewModel = emptyTestViewModel, onActivityItemClick = {})
+      DailyActivities(
+          agendaViewModel = emptyTestViewModel,
+          onActivityItemClick = {},
+          tripId = "1",
+          tripsRepository = TripsRepository(uid = "1", Dispatchers.IO))
     }
 
     composeTestRule.waitForIdle()
@@ -163,7 +182,10 @@ class DailyActivitiesTest {
               onActivityClick = { stopId ->
                 isStopPressed = true
                 selectedStopId = stopId
-              })
+              },
+              tripId = "1",
+              tripsRepository = TripsRepository(uid = "1", Dispatchers.IO),
+              onRefresh = {})
         }
         if (isStopPressed) {
           val selectedStop = testActivities.find { stop -> stop.stopId == selectedStopId }!!

--- a/app/src/androidTest/java/com/github/se/wanderpals/agenda/DailyActivitiesTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/agenda/DailyActivitiesTest.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.wanderpals.model.data.GeoCords
 import com.github.se.wanderpals.model.data.Stop
-import com.github.se.wanderpals.ui.screens.trip.agenda.ActivityItem
+import com.github.se.wanderpals.ui.screens.trip.agenda.StopItem
 import com.github.se.wanderpals.ui.screens.trip.agenda.DailyActivities
 import com.github.se.wanderpals.ui.screens.trip.agenda.StopInfoDialog
 import java.time.LocalDate
@@ -101,7 +101,7 @@ class DailyActivitiesTest {
   fun verifyActivityItemsContent() {
     // Set the content once with a composable that includes all test items
     composeTestRule.setContent {
-      Column { testActivities.forEach { stop -> ActivityItem(stop = stop, onActivityClick = {}) } }
+      Column { testActivities.forEach { stop -> StopItem(stop = stop, onActivityClick = {}) } }
     }
 
     // Loop through each test activity and assert its details
@@ -158,7 +158,7 @@ class DailyActivitiesTest {
         var selectedStopId by remember { mutableStateOf("") }
 
         testActivities.forEach { stop ->
-          ActivityItem(
+          StopItem(
               stop = stop,
               onActivityClick = { stopId ->
                 isStopPressed = true

--- a/app/src/androidTest/java/com/github/se/wanderpals/stops/StopItemTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/stops/StopItemTest.kt
@@ -1,0 +1,37 @@
+package com.github.se.wanderpals.stops
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.wanderpals.model.viewmodel.StopItemViewModel
+import com.kaspersky.components.composesupport.config.withComposeSupport
+import com.kaspersky.kaspresso.kaspresso.Kaspresso
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+class FakeStopItemViewModel() : StopItemViewModel(mockk(relaxed = true), tripId = "1") {
+  private val _isDeleted = MutableStateFlow(false)
+  override val isDeleted: StateFlow<Boolean> = _isDeleted
+
+  override fun deleteStop(stopId: String) {
+    _isDeleted.value = true
+  }
+}
+
+@RunWith(AndroidJUnit4::class)
+class StopListTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setup() {
+    // Set up the test
+
+  }
+
+  @Test fun testDeleteStop() {}
+}

--- a/app/src/androidTest/java/com/github/se/wanderpals/stops/StopsListTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/stops/StopsListTest.kt
@@ -38,7 +38,7 @@ val stop3 = Stop("stopId3", "stop3", "stop3 address", LocalDate.of(2024, 5, 12))
 val stop4 = Stop("stopId4", "stop4", "stop4 address", LocalDate.of(2024, 5, 13))
 
 // Fake ViewModel for testing
-class FakeStopsListViewModel : StopsListViewModel(mockk(relaxed = true)) {
+class FakeStopsListViewModel : StopsListViewModel(mockk(relaxed = true), tripId = "tripId") {
   private val _stops = MutableStateFlow(emptyList<Stop>())
   override var stops: StateFlow<List<Stop>> = _stops.asStateFlow()
 
@@ -47,7 +47,7 @@ class FakeStopsListViewModel : StopsListViewModel(mockk(relaxed = true)) {
 
   var allowDataLoading = true
 
-  override fun loadStops(tripId: String) {
+  override fun loadStops() {
     if (allowDataLoading) {
       viewModelScope.launch {
         _isLoading.value = true
@@ -88,11 +88,13 @@ class StopsListTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeS
     // Load stops accordingly
     if (!useEmptyList) {
       (stopsListViewModel as FakeStopsListViewModel).allowDataLoading = true
-      stopsListViewModel.loadStops("tripId")
+      stopsListViewModel.loadStops()
     }
 
     // Set up Compose UI content
-    composeTestRule.setContent { StopsList(stopsListViewModel, "tripId") }
+    composeTestRule.setContent {
+      StopsList(stopsListViewModel, tripId = "tripId", mockk(relaxed = true))
+    }
   }
 
   @Test

--- a/app/src/main/java/com/github/se/wanderpals/model/data/Stop.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/data/Stop.kt
@@ -1,5 +1,6 @@
 package com.github.se.wanderpals.model.data
 
+import com.github.se.wanderpals.ui.screens.trip.agenda.CalendarUiState
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -22,6 +23,8 @@ import java.time.LocalTime
  * @param website Optional. A URL to a website providing additional information about the stop.
  *   Empty by default.
  * @param imageUrl URL for an image of the stop, optional.
+ * @param stopStatus The status of the stop, indicating whether it has been added to the trip or
+ *   not.
  */
 data class Stop(
     val stopId: String = "",
@@ -35,4 +38,5 @@ data class Stop(
     val geoCords: GeoCords = GeoCords(),
     val website: String = "",
     val imageUrl: String = "",
+    val stopStatus: CalendarUiState.StopStatus = CalendarUiState.StopStatus.NONE // Default value
 )

--- a/app/src/main/java/com/github/se/wanderpals/model/data/Suggestion.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/data/Suggestion.kt
@@ -35,5 +35,5 @@ data class Suggestion(
     val createdAtTime: LocalTime = LocalTime.of(0, 0), // Time of creation
     val stop: Stop = Stop(), // Embed the Stop object directly
     val comments: List<Comment> = emptyList(),
-    val userLikes: List<String> = emptyList()
+    val userLikes: List<String> = emptyList(),
 )

--- a/app/src/main/java/com/github/se/wanderpals/model/firestoreData/FirestoreStop.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/firestoreData/FirestoreStop.kt
@@ -2,6 +2,7 @@ package com.github.se.wanderpals.model.firestoreData
 
 import com.github.se.wanderpals.model.data.GeoCords
 import com.github.se.wanderpals.model.data.Stop
+import com.github.se.wanderpals.ui.screens.trip.agenda.CalendarUiState
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
@@ -22,6 +23,7 @@ import java.time.format.DateTimeFormatter
  * @property geoCords Coordinates pinpointing the stop's location.
  * @property website Optional URL for more information about the stop.
  * @property imageUrl Optional URL for an image of the stop.
+ * @property stopStatus Status of the stop addition, converted to String for Firestore.
  */
 data class FirestoreStop(
     val stopId: String = "",
@@ -34,7 +36,9 @@ data class FirestoreStop(
     val description: String = "",
     val geoCords: GeoCords = GeoCords(0.0, 0.0), // Assuming GeoCords is Firestore compatible
     val website: String = "",
-    val imageUrl: String = ""
+    val imageUrl: String = "",
+    val stopStatus: String =
+        CalendarUiState.StopStatus.NONE.name // Convert enum to string for Firestore
 ) {
   companion object {
     /**
@@ -58,7 +62,9 @@ data class FirestoreStop(
           description = stop.description,
           geoCords = stop.geoCords,
           website = stop.website,
-          imageUrl = stop.imageUrl)
+          imageUrl = stop.imageUrl,
+          stopStatus = stop.stopStatus.name // Convert enum to string for Firestore
+          )
     }
   }
 
@@ -82,6 +88,8 @@ data class FirestoreStop(
         description = description,
         geoCords = geoCords,
         website = website,
-        imageUrl = imageUrl)
+        imageUrl = imageUrl,
+        stopStatus = CalendarUiState.StopStatus.valueOf(stopStatus) // Convert string back to enum
+        )
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopItemViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopItemViewModel.kt
@@ -8,6 +8,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
+/**
+    * ViewModel for a stop item in a trip.
+    * @param stopId the id of the stop
+    * @param tripsRepository the repository for trips
+    * @param tripId the id of the trip
+ */
 class StopItemViewModel(
     private val stopId: String,
     private val tripsRepository: TripsRepository,

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopItemViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopItemViewModel.kt
@@ -11,20 +11,22 @@ import kotlinx.coroutines.launch
 /**
  * ViewModel for a stop item in a trip.
  *
- * @param stopId the id of the stop
  * @param tripsRepository the repository for trips
  * @param tripId the id of the trip
  */
-class StopItemViewModel(
-    private val stopId: String,
+open class StopItemViewModel(
     private val tripsRepository: TripsRepository,
     private val tripId: String
 ) : ViewModel() {
 
   private val _isDeleted = MutableStateFlow(false)
-  val isDeleted: StateFlow<Boolean> = _isDeleted
+  open val isDeleted: StateFlow<Boolean> = _isDeleted
 
-  fun deleteStop() {
+  fun resetDeleteState() {
+    _isDeleted.value = false
+  }
+
+  open fun deleteStop(stopId: String) {
     viewModelScope.launch {
       tripsRepository.removeStopFromTrip(tripId, stopId)
       _isDeleted.value = true
@@ -35,12 +37,11 @@ class StopItemViewModel(
   class StopItemViewModelFactory(
       private val tripsRepository: TripsRepository,
       private val tripId: String,
-      private val stopId: String
   ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
       if (modelClass.isAssignableFrom(StopItemViewModel::class.java)) {
-        @Suppress("UNCHECKED_CAST") return StopItemViewModel(stopId, tripsRepository, tripId) as T
+        @Suppress("UNCHECKED_CAST") return StopItemViewModel(tripsRepository, tripId) as T
       }
       throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopItemViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopItemViewModel.kt
@@ -9,10 +9,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 /**
-    * ViewModel for a stop item in a trip.
-    * @param stopId the id of the stop
-    * @param tripsRepository the repository for trips
-    * @param tripId the id of the trip
+ * ViewModel for a stop item in a trip.
+ *
+ * @param stopId the id of the stop
+ * @param tripsRepository the repository for trips
+ * @param tripId the id of the trip
  */
 class StopItemViewModel(
     private val stopId: String,

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopItemViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopItemViewModel.kt
@@ -1,7 +1,5 @@
 package com.github.se.wanderpals.model.viewmodel
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -10,31 +8,34 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-class StopItemViewModel(private val stopId: String, private val tripsRepository: TripsRepository, private val tripId: String) : ViewModel() {
+class StopItemViewModel(
+    private val stopId: String,
+    private val tripsRepository: TripsRepository,
+    private val tripId: String
+) : ViewModel() {
 
-    private val _isDeleted = MutableStateFlow(false)
-    val isDeleted: StateFlow<Boolean> = _isDeleted
+  private val _isDeleted = MutableStateFlow(false)
+  val isDeleted: StateFlow<Boolean> = _isDeleted
 
-    fun deleteStop() {
-        viewModelScope.launch {
-            tripsRepository.removeStopFromTrip(tripId, stopId)
-            _isDeleted.value = true
-        }
+  fun deleteStop() {
+    viewModelScope.launch {
+      tripsRepository.removeStopFromTrip(tripId, stopId)
+      _isDeleted.value = true
     }
+  }
 
-    /** Factory for creating StopViewModel instances. */
-    class StopItemViewModelFactory(
-        private val tripsRepository: TripsRepository,
-        private val tripId: String,
-        private val stopId: String
-    ) : ViewModelProvider.Factory {
+  /** Factory for creating StopViewModel instances. */
+  class StopItemViewModelFactory(
+      private val tripsRepository: TripsRepository,
+      private val tripId: String,
+      private val stopId: String
+  ) : ViewModelProvider.Factory {
 
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            if (modelClass.isAssignableFrom(StopItemViewModel::class.java)) {
-                @Suppress("UNCHECKED_CAST")
-                return StopItemViewModel(stopId, tripsRepository, tripId) as T
-            }
-            throw IllegalArgumentException("Unknown ViewModel class")
-        }
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(StopItemViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST") return StopItemViewModel(stopId, tripsRepository, tripId) as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
     }
+  }
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopItemViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopItemViewModel.kt
@@ -1,0 +1,40 @@
+package com.github.se.wanderpals.model.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.github.se.wanderpals.model.repository.TripsRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class StopItemViewModel(private val stopId: String, private val tripsRepository: TripsRepository, private val tripId: String) : ViewModel() {
+
+    private val _isDeleted = MutableStateFlow(false)
+    val isDeleted: StateFlow<Boolean> = _isDeleted
+
+    fun deleteStop() {
+        viewModelScope.launch {
+            tripsRepository.removeStopFromTrip(tripId, stopId)
+            _isDeleted.value = true
+        }
+    }
+
+    /** Factory for creating StopViewModel instances. */
+    class StopItemViewModelFactory(
+        private val tripsRepository: TripsRepository,
+        private val tripId: String,
+        private val stopId: String
+    ) : ViewModelProvider.Factory {
+
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(StopItemViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return StopItemViewModel(stopId, tripsRepository, tripId) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
+}

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopsListViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopsListViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 
 open class StopsListViewModel(
     private val tripsRepository: TripsRepository,
+  private val tripId: String,
 ) : ViewModel() {
 
   private val _stops = MutableStateFlow(emptyList<Stop>())
@@ -21,7 +22,7 @@ open class StopsListViewModel(
   open val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
   /** Fetches all stops from the trip and updates the state flow accordingly. */
-  open fun loadStops(tripId: String) {
+  open fun loadStops() {
     viewModelScope.launch {
       _isLoading.value = true
       _stops.value = tripsRepository.getAllStopsFromTrip(tripId)
@@ -32,11 +33,12 @@ open class StopsListViewModel(
   /** Factory for creating StopsListViewModel instances. */
   class StopsListViewModelFactory(
       private val tripsRepository: TripsRepository,
+    private val tripId: String,
   ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
       if (modelClass.isAssignableFrom(StopsListViewModel::class.java)) {
-        @Suppress("UNCHECKED_CAST") return StopsListViewModel(tripsRepository) as T
+        @Suppress("UNCHECKED_CAST") return StopsListViewModel(tripsRepository, tripId) as T
       }
       throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopsListViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/StopsListViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.launch
 
 open class StopsListViewModel(
     private val tripsRepository: TripsRepository,
-  private val tripId: String,
+    private val tripId: String,
 ) : ViewModel() {
 
   private val _stops = MutableStateFlow(emptyList<Stop>())
@@ -33,7 +33,7 @@ open class StopsListViewModel(
   /** Factory for creating StopsListViewModel instances. */
   class StopsListViewModelFactory(
       private val tripsRepository: TripsRepository,
-    private val tripId: String,
+      private val tripId: String,
   ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CommentOptionsBottomSheet.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CommentOptionsBottomSheet.kt
@@ -115,7 +115,7 @@ fun CommentBottomSheet(
           TextButton(
               onClick = { viewModel.confirmDeleteComment(suggestion) },
               modifier = Modifier.testTag("confirmDeleteCommentButton")) {
-                Text("Confirm")
+                Text("Confirm", color = MaterialTheme.colorScheme.error)
               }
         },
         dismissButton = {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
@@ -137,7 +137,7 @@ fun SuggestionBottomSheet(
           TextButton(
               onClick = { viewModel.confirmDeleteSuggestion(selectedSuggestion!!) },
               modifier = Modifier.testTag("confirmDeleteSuggestionButton")) {
-                Text("Confirm", color = Color.Red)
+                Text("Confirm", color = MaterialTheme.colorScheme.error)
               }
         },
         dismissButton = {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.se.wanderpals.model.data.Suggestion

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
@@ -100,7 +100,7 @@ fun Trip(
                               factory =
                                   AgendaViewModel.AgendaViewModelFactory(tripId, tripsRepository),
                               key = "Agenda")
-                      Agenda(agendaViewModel)
+                      Agenda(agendaViewModel, tripId, tripsRepository)
                     }
                     composable(Route.SUGGESTION) {
                       oldNavActions.updateCurrentRouteOfTrip(Route.SUGGESTION)
@@ -221,9 +221,9 @@ fun Trip(
                       val viewModel: StopsListViewModel =
                           viewModel(
                               factory =
-                                  StopsListViewModel.StopsListViewModelFactory(tripsRepository),
+                                  StopsListViewModel.StopsListViewModelFactory(tripsRepository, tripId),
                               key = "StopsListViewModel")
-                      StopsList(viewModel, tripId)
+                      StopsList(viewModel, tripId, tripsRepository)
                     }
                   }
             }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Trip.kt
@@ -221,7 +221,8 @@ fun Trip(
                       val viewModel: StopsListViewModel =
                           viewModel(
                               factory =
-                                  StopsListViewModel.StopsListViewModelFactory(tripsRepository, tripId),
+                                  StopsListViewModel.StopsListViewModelFactory(
+                                      tripsRepository, tripId),
                               key = "StopsListViewModel")
                       StopsList(viewModel, tripId, tripsRepository)
                     }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
@@ -63,12 +63,8 @@ private const val MAX_ROWS_CALENDAR = 6
 @Composable
 fun Agenda(agendaViewModel: AgendaViewModel, tripId: String, tripsRepository: TripsRepository) {
   val uiState by agendaViewModel.uiState.collectAsState()
-  val dailyActivities by agendaViewModel.dailyActivities.collectAsState()
 
   var isDrawerExpanded by remember { mutableStateOf(false) }
-
-  var isStopPressed by remember { mutableStateOf(false) }
-  var selectedStopId by remember { mutableStateOf("") }
 
   Scaffold(
       topBar = {
@@ -107,19 +103,8 @@ fun Agenda(agendaViewModel: AgendaViewModel, tripId: String, tripsRepository: Tr
       }
       // Daily agenda implementation
       DailyActivities(
-          agendaViewModel = agendaViewModel,
-          onActivityItemClick = { stopId ->
-            isStopPressed = true
-            selectedStopId = stopId
-          },
-          tripId = tripId,
-          tripsRepository = tripsRepository)
+          agendaViewModel = agendaViewModel, tripId = tripId, tripsRepository = tripsRepository)
     }
-  }
-
-  if (isStopPressed) {
-    val selectedStop = dailyActivities.find { stop -> stop.stopId == selectedStopId }!!
-    StopInfoDialog(stop = selectedStop, closeDialogueAction = { isStopPressed = false })
   }
 }
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
@@ -40,24 +40,16 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.se.wanderpals.R
 import com.github.se.wanderpals.model.viewmodel.AgendaViewModel
 import com.github.se.wanderpals.navigationActions
 import com.github.se.wanderpals.ui.navigation.Route
-import com.github.se.wanderpals.ui.theme.WanderPalsTheme
 import java.time.LocalDate
 import java.time.YearMonth
 
 private const val DAYS_IN_A_WEEK = 7
 private const val MAX_ROWS_CALENDAR = 6
-
-@Preview(showSystemUi = true)
-@Composable
-fun AgendaPreview() {
-  WanderPalsTheme { Agenda(AgendaViewModel("", null)) }
-}
 
 /**
  * The main entry point Composable for the Agenda screen. It displays a calendar view that allows

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.github.se.wanderpals.R
+import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.AgendaViewModel
 import com.github.se.wanderpals.navigationActions
 import com.github.se.wanderpals.ui.navigation.Route
@@ -60,7 +61,7 @@ private const val MAX_ROWS_CALENDAR = 6
  *   screen. It defaults to a ViewModel instance provided by the `viewModel()` function.
  */
 @Composable
-fun Agenda(agendaViewModel: AgendaViewModel) {
+fun Agenda(agendaViewModel: AgendaViewModel, tripId: String, tripsRepository: TripsRepository) {
   val uiState by agendaViewModel.uiState.collectAsState()
   val dailyActivities by agendaViewModel.dailyActivities.collectAsState()
 
@@ -110,7 +111,10 @@ fun Agenda(agendaViewModel: AgendaViewModel) {
           onActivityItemClick = { stopId ->
             isStopPressed = true
             selectedStopId = stopId
-          })
+          },
+          tripId = tripId,
+          tripsRepository = tripsRepository
+          )
     }
   }
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
@@ -113,8 +113,7 @@ fun Agenda(agendaViewModel: AgendaViewModel, tripId: String, tripsRepository: Tr
             selectedStopId = stopId
           },
           tripId = tripId,
-          tripsRepository = tripsRepository
-          )
+          tripsRepository = tripsRepository)
     }
   }
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
@@ -148,7 +149,7 @@ fun CalendarWidget(
     dates: List<CalendarUiState.Date>,
     onPreviousMonthButtonClicked: (YearMonth) -> Unit,
     onNextMonthButtonClicked: (YearMonth) -> Unit,
-    onDateClickListener: (CalendarUiState.Date) -> Unit,
+    onDateClickListener: (CalendarUiState.Date) -> Unit
 ) {
   Column(modifier = Modifier.padding(16.dp).background(MaterialTheme.colorScheme.surface)) {
     Row {
@@ -308,6 +309,13 @@ fun ContentItem(
   // Assuming dayOfMonth is an empty string for empty dates, or add a specific check if possible.
   val isEmptyDate = date.dayOfMonth.isEmpty()
 
+  // Set the marker color based on the stop status
+  val markerColor =
+      when (date.stopStatus) {
+        CalendarUiState.StopStatus.ADDED -> Color.Blue // Stop added
+        else -> Color.Transparent // No stop
+      }
+
   val baseModifier =
       modifier
           .aspectRatio(1f)
@@ -324,16 +332,32 @@ fun ContentItem(
 
   // Apply clickable only if the date is not empty.
   val finalModifier =
-      if (!isEmptyDate) {
-        baseModifier.clickable { onClickListener(date) }
-      } else baseModifier
+      (if (!isEmptyDate) {
+        baseModifier.clickable { onClickListener(date) }.padding(10.dp)
+      } else baseModifier)
 
   Box(modifier = finalModifier) {
     if (!isEmptyDate) {
       Text(
           text = date.dayOfMonth,
           style = MaterialTheme.typography.bodyMedium,
-          modifier = Modifier.align(Alignment.Center).padding(10.dp))
+          modifier = Modifier.align(Alignment.TopCenter))
+      // Displaying the status dot below the date
+      if (date.stopStatus !=
+          CalendarUiState.StopStatus
+              .NONE) { // I use "not equal to the NONE status" here, because we might have more
+        // statuses in the future
+        Box(
+            modifier =
+                Modifier.align(
+                        Alignment.BottomCenter) // Center the dot at the bottom of the date cell
+                    .size(8.dp) // Size of the dot
+                    .clip(CircleShape) // Make it circular
+                    .background(markerColor) // Set the appropriate color
+                    .padding(bottom = 4.dp) // Add some padding to the bottom
+                    .testTag("MarkerADDED") // Add test tag here
+            )
+      }
     }
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
@@ -25,15 +25,13 @@ import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
 import com.github.se.wanderpals.ui.screens.trip.stops.StopItem
 
 /**
- * Composable function that displays the daily activities for a selected date.
+ * Composable function that displays the daily activities for a trip.
  *
- * @param agendaViewModel The view model for managing the agenda of a trip.
- * @param onActivityItemClick Callback function triggered when an activity item is clicked,
+ * @param agendaViewModel The view model that provides the data for the daily activities.
  */
 @Composable
 fun DailyActivities(
     agendaViewModel: AgendaViewModel,
-    onActivityItemClick: (String) -> Unit,
     tripId: String,
     tripsRepository: TripsRepository
 ) {
@@ -69,8 +67,7 @@ fun DailyActivities(
           LazyColumn(
               content = {
                 items(dailyActivities.sortedBy { it.startTime }) { stop ->
-                  StopItem(
-                      stop, onActivityItemClick, tripId, tripsRepository, { refreshFunction() })
+                  StopItem(stop, tripId, tripsRepository) { refreshFunction() }
                 }
               })
         }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.AgendaViewModel
 import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
 import com.github.se.wanderpals.ui.screens.trip.stops.StopItem
@@ -31,7 +32,7 @@ import com.github.se.wanderpals.ui.screens.trip.stops.StopItem
  * @param onActivityItemClick Callback function triggered when an activity item is clicked,
  */
 @Composable
-fun DailyActivities(agendaViewModel: AgendaViewModel, onActivityItemClick: (String) -> Unit) {
+fun DailyActivities(agendaViewModel: AgendaViewModel, onActivityItemClick: (String) -> Unit, tripId: String, tripsRepository: TripsRepository) {
   val uiState by agendaViewModel.uiState.collectAsState()
   val selectedDate = uiState.selectedDate
 
@@ -64,7 +65,7 @@ fun DailyActivities(agendaViewModel: AgendaViewModel, onActivityItemClick: (Stri
           LazyColumn(
               content = {
                 items(dailyActivities.sortedBy { it.startTime }) { stop ->
-                  StopItem(stop, onActivityItemClick)
+                  StopItem(stop, onActivityItemClick, tripId, tripsRepository,{refreshFunction()})
                 }
               })
         }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
@@ -24,7 +24,6 @@ import com.github.se.wanderpals.model.viewmodel.AgendaViewModel
 import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
 import com.github.se.wanderpals.ui.screens.trip.stops.StopItem
 
-
 /**
  * Composable function that displays the daily activities for a selected date.
  *
@@ -32,7 +31,12 @@ import com.github.se.wanderpals.ui.screens.trip.stops.StopItem
  * @param onActivityItemClick Callback function triggered when an activity item is clicked,
  */
 @Composable
-fun DailyActivities(agendaViewModel: AgendaViewModel, onActivityItemClick: (String) -> Unit, tripId: String, tripsRepository: TripsRepository) {
+fun DailyActivities(
+    agendaViewModel: AgendaViewModel,
+    onActivityItemClick: (String) -> Unit,
+    tripId: String,
+    tripsRepository: TripsRepository
+) {
   val uiState by agendaViewModel.uiState.collectAsState()
   val selectedDate = uiState.selectedDate
 
@@ -65,7 +69,8 @@ fun DailyActivities(agendaViewModel: AgendaViewModel, onActivityItemClick: (Stri
           LazyColumn(
               content = {
                 items(dailyActivities.sortedBy { it.startTime }) { stop ->
-                  StopItem(stop, onActivityItemClick, tripId, tripsRepository,{refreshFunction()})
+                  StopItem(
+                      stop, onActivityItemClick, tripId, tripsRepository, { refreshFunction() })
                 }
               })
         }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
@@ -1,64 +1,28 @@
 package com.github.se.wanderpals.ui.screens.trip.agenda
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.github.se.wanderpals.model.data.Stop
-import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.AgendaViewModel
-import com.github.se.wanderpals.navigationActions
 import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
-import com.github.se.wanderpals.ui.navigation.Route
-import com.github.se.wanderpals.ui.theme.WanderPalsTheme
-import com.github.se.wanderpals.ui.theme.outlineVariantLight
-import kotlinx.coroutines.Dispatchers
+import com.github.se.wanderpals.ui.screens.trip.stops.StopItem
 
-@Preview(showBackground = true)
-@Composable
-fun DailyActivitiesPreview() {
-  WanderPalsTheme { DailyActivities(AgendaViewModel("", TripsRepository("", Dispatchers.IO))) {} }
-}
 
 /**
  * Composable function that displays the daily activities for a selected date.
@@ -106,163 +70,4 @@ fun DailyActivities(agendaViewModel: AgendaViewModel, onActivityItemClick: (Stri
         }
     PullToRefreshLazyColumn(lazyColumn, { refreshFunction() })
   }
-}
-
-/**
- * Composable function that displays an activity item.
- *
- * @param stop The stop to display.
- * @param onActivityClick Callback function triggered when the activity item is clicked,
- */
-@Composable
-fun StopItem(stop: Stop, onActivityClick: (String) -> Unit) {
-
-    // State to handle the visibility of the confirmation dialog
-    var showDeleteConfirmDialog by remember { mutableStateOf(false) }
-
-  val stopHasLocation = stop.geoCords.latitude != 0.0 || stop.geoCords.longitude != 0.0
-  Box(modifier = Modifier.testTag(stop.stopId).fillMaxWidth()) {
-    Button(
-        onClick = { onActivityClick(stop.stopId) },
-        shape = RectangleShape,
-        modifier =
-            Modifier.height(100.dp).fillMaxWidth().testTag("activityItemButton" + stop.stopId),
-        colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)) {
-          Row(modifier = Modifier.fillMaxSize()) {
-            // Texts Column
-            Column(
-                modifier =
-                    Modifier.weight(
-                            1f) // Takes up all available space, pushing the IconButton to the right
-                        .align(Alignment.CenterVertically) // Vertically center the column content
-                        .fillMaxSize(), // Fill the available space
-                verticalArrangement = Arrangement.SpaceEvenly) {
-                  Text(
-                      text = stop.title,
-                      style =
-                          TextStyle(
-                              fontSize = 16.sp,
-                              lineHeight = 20.sp,
-                              fontWeight = FontWeight(500),
-                              letterSpacing = 0.16.sp),
-                      color = MaterialTheme.colorScheme.primary,
-                      modifier =
-                          Modifier.wrapContentWidth(Alignment.Start)
-                              .testTag("ActivityTitle" + stop.stopId))
-                  Text(
-                      text =
-                          "${stop.startTime} - ${stop.startTime.plusMinutes(stop.duration.toLong())}",
-                      style =
-                          TextStyle(
-                              fontSize = 16.sp,
-                              lineHeight = 20.sp,
-                              fontWeight = FontWeight(500),
-                              letterSpacing = 0.16.sp,
-                          ),
-                      color = MaterialTheme.colorScheme.secondary,
-                      modifier =
-                          Modifier.wrapContentWidth(Alignment.Start)
-                              .testTag("ActivityTime" + stop.stopId))
-                  if (stopHasLocation) {
-                    Text(
-                        text = stop.address,
-                        style =
-                            TextStyle(
-                                fontSize = 16.sp,
-                                lineHeight = 20.sp,
-                                fontWeight = FontWeight(500),
-                                letterSpacing = 0.16.sp),
-                        color = MaterialTheme.colorScheme.secondary,
-                        modifier =
-                            Modifier.wrapContentWidth(Alignment.Start)
-                                .testTag("ActivityAddress" + stop.stopId))
-                  }
-                }
-
-              // Map Navigation Button
-            // Icon Button at the far right, centered vertically
-            IconButton(
-                onClick = {
-                  if (stopHasLocation) {
-                    navigationActions.setVariablesLocation(stop.geoCords, stop.address)
-                    navigationActions.navigateTo(Route.MAP)
-                  }
-                },
-                modifier =
-                    Modifier.size(24.dp) // Adjust the size of the IconButton as needed
-                        .align(Alignment.CenterVertically)
-                        .testTag(
-                            "navigationToMapButton" +
-                                stop.stopId), // Center the IconButton vertically within the
-                enabled = stopHasLocation
-                // Row
-                ) {
-                  Icon(
-                      imageVector = Icons.Default.LocationOn,
-                      tint =
-                          if (stopHasLocation) MaterialTheme.colorScheme.primary
-                          else MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
-                      contentDescription = null // Provide an appropriate content description
-                      )
-                }
-
-              // Add spacing between the map icon and delete icon
-                Spacer(modifier = Modifier.width(16.dp))
-
-              // Delete Icon
-              IconButton(
-                  onClick = { showDeleteConfirmDialog = true },
-                  modifier = Modifier
-                      .size(24.dp)
-                      .align(Alignment.CenterVertically)
-                      .testTag("deleteButton" + stop.stopId),
-                  content = {
-                        Icon(
-                            imageVector = Icons.Default.Delete,
-                            tint = MaterialTheme.colorScheme.error,
-                            contentDescription = "Delete Stop"
-                        )
-                  }
-              )
-          }
-        }
-  }
-
-    // Confirmation Dialog for Deletion
-    if (showDeleteConfirmDialog) {
-        AlertDialog(
-            onDismissRequest = { showDeleteConfirmDialog = false },
-            title = { Text("Confirm Deletion") },
-            text = { Text("Are you sure you want to delete this stop?") },
-            confirmButton = {
-                TextButton(
-                    modifier = Modifier.testTag("confirmDeleteButton" + stop.stopId),
-                    onClick = {
-                        showDeleteConfirmDialog = false
-                    }
-                ) {
-                    Text("Confirm", color = MaterialTheme.colorScheme.error)
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    modifier = Modifier.testTag("cancelDeleteButton" + stop.stopId),
-                    onClick = { showDeleteConfirmDialog = false }) {
-                    Text("Cancel")
-                }
-            }
-        )
-    }
-
-  // the horizontal divider
-  Box(
-      modifier =
-          Modifier.fillMaxWidth(), // This ensures the box takes the full width of its container
-      contentAlignment = Alignment.Center // This will center the content inside the box
-      ) {
-        HorizontalDivider(
-            modifier = Modifier.fillMaxWidth(), // Customize this width as needed
-            thickness = 1.dp,
-            color = outlineVariantLight)
-      }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
@@ -4,17 +4,21 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -22,10 +26,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -92,7 +100,7 @@ fun DailyActivities(agendaViewModel: AgendaViewModel, onActivityItemClick: (Stri
           LazyColumn(
               content = {
                 items(dailyActivities.sortedBy { it.startTime }) { stop ->
-                  ActivityItem(stop, onActivityItemClick)
+                  StopItem(stop, onActivityItemClick)
                 }
               })
         }
@@ -107,7 +115,11 @@ fun DailyActivities(agendaViewModel: AgendaViewModel, onActivityItemClick: (Stri
  * @param onActivityClick Callback function triggered when the activity item is clicked,
  */
 @Composable
-fun ActivityItem(stop: Stop, onActivityClick: (String) -> Unit) {
+fun StopItem(stop: Stop, onActivityClick: (String) -> Unit) {
+
+    // State to handle the visibility of the confirmation dialog
+    var showDeleteConfirmDialog by remember { mutableStateOf(false) }
+
   val stopHasLocation = stop.geoCords.latitude != 0.0 || stop.geoCords.longitude != 0.0
   Box(modifier = Modifier.testTag(stop.stopId).fillMaxWidth()) {
     Button(
@@ -167,6 +179,7 @@ fun ActivityItem(stop: Stop, onActivityClick: (String) -> Unit) {
                   }
                 }
 
+              // Map Navigation Button
             // Icon Button at the far right, centered vertically
             IconButton(
                 onClick = {
@@ -192,9 +205,54 @@ fun ActivityItem(stop: Stop, onActivityClick: (String) -> Unit) {
                       contentDescription = null // Provide an appropriate content description
                       )
                 }
+
+              // Add spacing between the map icon and delete icon
+                Spacer(modifier = Modifier.width(16.dp))
+
+              // Delete Icon
+              IconButton(
+                  onClick = { showDeleteConfirmDialog = true },
+                  modifier = Modifier
+                      .size(24.dp)
+                      .align(Alignment.CenterVertically)
+                      .testTag("deleteButton" + stop.stopId),
+                  content = {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            tint = MaterialTheme.colorScheme.error,
+                            contentDescription = "Delete Stop"
+                        )
+                  }
+              )
           }
         }
   }
+
+    // Confirmation Dialog for Deletion
+    if (showDeleteConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirmDialog = false },
+            title = { Text("Confirm Deletion") },
+            text = { Text("Are you sure you want to delete this stop?") },
+            confirmButton = {
+                TextButton(
+                    modifier = Modifier.testTag("confirmDeleteButton" + stop.stopId),
+                    onClick = {
+                        showDeleteConfirmDialog = false
+                    }
+                ) {
+                    Text("Confirm", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    modifier = Modifier.testTag("cancelDeleteButton" + stop.stopId),
+                    onClick = { showDeleteConfirmDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
 
   // the horizontal divider
   Box(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
@@ -36,6 +36,17 @@ data class CalendarUiState(
   }
 
   /**
+   * Enum class representing the status of the stop addition.
+   *
+   * @property ADDED Stop was added to the trip.
+   * @property NONE Stop was not added, it is still a suggestion of the trip.
+   */
+  enum class StopStatus {
+    ADDED,
+    NONE
+  }
+
+  /**
    * Data class representing a single date in the calendar. Includes information about the day of
    * the month, the corresponding year and month, and whether the date is selected.
    *
@@ -48,11 +59,12 @@ data class CalendarUiState(
       val dayOfMonth: String,
       val yearMonth: YearMonth,
       val year: Year,
-      val isSelected: Boolean
+      val isSelected: Boolean,
+      val stopStatus: StopStatus = StopStatus.NONE
   ) {
     companion object {
       // Represents an empty date, used as a placeholder in the calendar grid
-      val Empty = Date("", YearMonth.now(), Year.now(), false)
+      val Empty = Date("", YearMonth.now(), Year.now(), false, StopStatus.NONE)
     }
   }
 }
@@ -69,16 +81,23 @@ class CalendarDataSource {
    *
    * @param yearMonth The year and month for which to generate the date list.
    * @param selectedDate An optional `LocalDate` representing the currently selected date.
+   * @param stopsInfo A map of `LocalDate` to `CalendarUiState.StopStatus` representing the status
+   *   of stops.
    * @return A list of `CalendarUiState.Date` objects representing the dates of the specified month.
    */
-  fun getDates(yearMonth: YearMonth, selectedDate: LocalDate?): List<CalendarUiState.Date> {
+  fun getDates(
+      yearMonth: YearMonth,
+      selectedDate: LocalDate?,
+      stopsInfo: Map<LocalDate, CalendarUiState.StopStatus>
+  ): List<CalendarUiState.Date> {
     return yearMonth.getDayOfMonthStartingFromMonday().map { date ->
       val isSelected = date == selectedDate && date.monthValue == yearMonth.monthValue
       CalendarUiState.Date(
           dayOfMonth = if (date.monthValue == yearMonth.monthValue) "${date.dayOfMonth}" else "",
           yearMonth = yearMonth,
           year = Year.of(date.year),
-          isSelected = isSelected)
+          isSelected = isSelected,
+          stopStatus = stopsInfo[date] ?: CalendarUiState.StopStatus.NONE)
     }
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopItem.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopItem.kt
@@ -1,0 +1,228 @@
+package com.github.se.wanderpals.ui.screens.trip.stops
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.wanderpals.model.data.Stop
+import com.github.se.wanderpals.navigationActions
+import com.github.se.wanderpals.service.SessionManager
+import com.github.se.wanderpals.ui.navigation.Route
+import com.github.se.wanderpals.ui.theme.outlineVariantLight
+
+/**
+ * Composable function that displays an activity item.
+ *
+ * @param stop The stop to display.
+ * @param onActivityClick Callback function triggered when the activity item is clicked,
+ */
+@Composable
+fun StopItem(stop: Stop, onActivityClick: (String) -> Unit) {
+
+    // State to handle the visibility of the confirmation dialog
+    var showDeleteConfirmDialog by remember { mutableStateOf(false) }
+    var showNoRightsToast by remember { mutableStateOf(false) }
+
+    if (showNoRightsToast) {
+        ShowToast("You do not have the rights to delete this stop")
+        showNoRightsToast = false
+    }
+
+    val stopHasLocation = stop.geoCords.latitude != 0.0 || stop.geoCords.longitude != 0.0
+    Box(modifier = Modifier.testTag(stop.stopId).fillMaxWidth()) {
+        Button(
+            onClick = { onActivityClick(stop.stopId) },
+            shape = RectangleShape,
+            modifier =
+            Modifier.height(100.dp).fillMaxWidth().testTag("activityItemButton" + stop.stopId),
+            colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)) {
+            Row(modifier = Modifier.fillMaxSize()) {
+                // Texts Column
+                Column(
+                    modifier =
+                    Modifier.weight(
+                        1f) // Takes up all available space, pushing the IconButton to the right
+                        .align(Alignment.CenterVertically) // Vertically center the column content
+                        .fillMaxSize(), // Fill the available space
+                    verticalArrangement = Arrangement.SpaceEvenly) {
+                    Text(
+                        text = stop.title,
+                        style =
+                        TextStyle(
+                            fontSize = 16.sp,
+                            lineHeight = 20.sp,
+                            fontWeight = FontWeight(500),
+                            letterSpacing = 0.16.sp),
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier =
+                        Modifier.wrapContentWidth(Alignment.Start)
+                            .testTag("ActivityTitle" + stop.stopId))
+                    Text(
+                        text =
+                        "${stop.startTime} - ${stop.startTime.plusMinutes(stop.duration.toLong())}",
+                        style =
+                        TextStyle(
+                            fontSize = 16.sp,
+                            lineHeight = 20.sp,
+                            fontWeight = FontWeight(500),
+                            letterSpacing = 0.16.sp,
+                        ),
+                        color = MaterialTheme.colorScheme.secondary,
+                        modifier =
+                        Modifier.wrapContentWidth(Alignment.Start)
+                            .testTag("ActivityTime" + stop.stopId))
+                    if (stopHasLocation) {
+                        Text(
+                            text = stop.address,
+                            style =
+                            TextStyle(
+                                fontSize = 16.sp,
+                                lineHeight = 20.sp,
+                                fontWeight = FontWeight(500),
+                                letterSpacing = 0.16.sp),
+                            color = MaterialTheme.colorScheme.secondary,
+                            modifier =
+                            Modifier.wrapContentWidth(Alignment.Start)
+                                .testTag("ActivityAddress" + stop.stopId))
+                    }
+                }
+
+                // Map Navigation Button
+                // Icon Button at the far right, centered vertically
+                IconButton(
+                    onClick = {
+                        if (stopHasLocation) {
+                            navigationActions.setVariablesLocation(stop.geoCords, stop.address)
+                            navigationActions.navigateTo(Route.MAP)
+                        }
+                    },
+                    modifier =
+                    Modifier.size(24.dp) // Adjust the size of the IconButton as needed
+                        .align(Alignment.CenterVertically)
+                        .testTag(
+                            "navigationToMapButton" +
+                                    stop.stopId), // Center the IconButton vertically within the
+                    enabled = stopHasLocation
+                    // Row
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.LocationOn,
+                        tint =
+                        if (stopHasLocation) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
+                        contentDescription = null // Provide an appropriate content description
+                    )
+                }
+
+                // Add spacing between the map icon and delete icon
+                Spacer(modifier = Modifier.width(16.dp))
+
+                // Delete Icon
+                IconButton(
+                    onClick = {
+                        if(SessionManager.isAdmin()) {
+                            showDeleteConfirmDialog = true
+                        } else {
+                            showNoRightsToast = true
+                        }
+                    },
+                    modifier = Modifier
+                        .size(24.dp)
+                        .align(Alignment.CenterVertically)
+                        .testTag("deleteButton" + stop.stopId),
+                    content = {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            tint = if(SessionManager.isAdmin()) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                            contentDescription = "Delete Stop"
+                        )
+                    }
+                )
+            }
+        }
+    }
+
+    // Confirmation Dialog for Deletion
+    if (showDeleteConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirmDialog = false },
+            title = { Text("Confirm Deletion") },
+            text = { Text("Are you sure you want to delete this stop?") },
+            confirmButton = {
+                TextButton(
+                    modifier = Modifier.testTag("confirmDeleteButton" + stop.stopId),
+                    onClick = {
+
+                        showDeleteConfirmDialog = false
+                    }
+                ) {
+                    Text("Confirm", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    modifier = Modifier.testTag("cancelDeleteButton" + stop.stopId),
+                    onClick = { showDeleteConfirmDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    // the horizontal divider
+    Box(
+        modifier =
+        Modifier.fillMaxWidth(), // This ensures the box takes the full width of its container
+        contentAlignment = Alignment.Center // This will center the content inside the box
+    ) {
+        HorizontalDivider(
+            modifier = Modifier.fillMaxWidth(), // Customize this width as needed
+            thickness = 1.dp,
+            color = outlineVariantLight
+        )
+    }
+}
+
+@Composable
+fun ShowToast(message: String) {
+    val context = LocalContext.current
+    LaunchedEffect(message) {
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopItem.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopItem.kt
@@ -57,192 +57,191 @@ import com.github.se.wanderpals.ui.theme.outlineVariantLight
  * @param onActivityClick Callback function triggered when the activity item is clicked,
  */
 @Composable
-fun StopItem(stop: Stop, onActivityClick: (String) -> Unit, tripId: String, tripsRepository: TripsRepository, onRefresh: () -> Unit) {
+fun StopItem(
+    stop: Stop,
+    onActivityClick: (String) -> Unit,
+    tripId: String,
+    tripsRepository: TripsRepository,
+    onRefresh: () -> Unit
+) {
 
-    val stopItemViewModel: StopItemViewModel = viewModel(
-        factory = StopItemViewModel.StopItemViewModelFactory(
-            stopId = stop.stopId,
-            tripsRepository = tripsRepository,
-            tripId = tripId
-        )
-    )
+  val stopItemViewModel: StopItemViewModel =
+      viewModel(
+          factory =
+              StopItemViewModel.StopItemViewModelFactory(
+                  stopId = stop.stopId, tripsRepository = tripsRepository, tripId = tripId))
 
-    // State to handle the visibility of the confirmation dialog
-    var showDeleteConfirmDialog by remember { mutableStateOf(false) }
-    var showNoRightsToast by remember { mutableStateOf(false) }
+  // State to handle the visibility of the confirmation dialog
+  var showDeleteConfirmDialog by remember { mutableStateOf(false) }
+  var showNoRightsToast by remember { mutableStateOf(false) }
 
-    if (showNoRightsToast) {
-        ShowToast("You do not have the rights to delete this stop")
-        showNoRightsToast = false
+  if (showNoRightsToast) {
+    ShowToast("You do not have the rights to delete this stop")
+    showNoRightsToast = false
+  }
+
+  val isDeleted by stopItemViewModel.isDeleted.collectAsState()
+
+  LaunchedEffect(isDeleted) {
+    if (isDeleted) {
+      onRefresh()
     }
+  }
 
-    val isDeleted by stopItemViewModel.isDeleted.collectAsState()
-
-    LaunchedEffect(isDeleted) {
-        if (isDeleted) {
-            onRefresh()
-        }
-    }
-
-    val stopHasLocation = stop.geoCords.latitude != 0.0 || stop.geoCords.longitude != 0.0
-    Box(modifier = Modifier.testTag(stop.stopId).fillMaxWidth()) {
-        Button(
-            onClick = { onActivityClick(stop.stopId) },
-            shape = RectangleShape,
-            modifier =
+  val stopHasLocation = stop.geoCords.latitude != 0.0 || stop.geoCords.longitude != 0.0
+  Box(modifier = Modifier.testTag(stop.stopId).fillMaxWidth()) {
+    Button(
+        onClick = { onActivityClick(stop.stopId) },
+        shape = RectangleShape,
+        modifier =
             Modifier.height(100.dp).fillMaxWidth().testTag("activityItemButton" + stop.stopId),
-            colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)) {
-            Row(modifier = Modifier.fillMaxSize()) {
-                // Texts Column
-                Column(
-                    modifier =
+        colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)) {
+          Row(modifier = Modifier.fillMaxSize()) {
+            // Texts Column
+            Column(
+                modifier =
                     Modifier.weight(
-                        1f) // Takes up all available space, pushing the IconButton to the right
+                            1f) // Takes up all available space, pushing the IconButton to the right
                         .align(Alignment.CenterVertically) // Vertically center the column content
                         .fillMaxSize(), // Fill the available space
-                    verticalArrangement = Arrangement.SpaceEvenly) {
+                verticalArrangement = Arrangement.SpaceEvenly) {
+                  Text(
+                      text = stop.title,
+                      style =
+                          TextStyle(
+                              fontSize = 16.sp,
+                              lineHeight = 20.sp,
+                              fontWeight = FontWeight(500),
+                              letterSpacing = 0.16.sp),
+                      color = MaterialTheme.colorScheme.primary,
+                      modifier =
+                          Modifier.wrapContentWidth(Alignment.Start)
+                              .testTag("ActivityTitle" + stop.stopId))
+                  Text(
+                      text =
+                          "${stop.startTime} - ${stop.startTime.plusMinutes(stop.duration.toLong())}",
+                      style =
+                          TextStyle(
+                              fontSize = 16.sp,
+                              lineHeight = 20.sp,
+                              fontWeight = FontWeight(500),
+                              letterSpacing = 0.16.sp,
+                          ),
+                      color = MaterialTheme.colorScheme.secondary,
+                      modifier =
+                          Modifier.wrapContentWidth(Alignment.Start)
+                              .testTag("ActivityTime" + stop.stopId))
+                  if (stopHasLocation) {
                     Text(
-                        text = stop.title,
+                        text = stop.address,
                         style =
-                        TextStyle(
-                            fontSize = 16.sp,
-                            lineHeight = 20.sp,
-                            fontWeight = FontWeight(500),
-                            letterSpacing = 0.16.sp),
-                        color = MaterialTheme.colorScheme.primary,
-                        modifier =
-                        Modifier.wrapContentWidth(Alignment.Start)
-                            .testTag("ActivityTitle" + stop.stopId))
-                    Text(
-                        text =
-                        "${stop.startTime} - ${stop.startTime.plusMinutes(stop.duration.toLong())}",
-                        style =
-                        TextStyle(
-                            fontSize = 16.sp,
-                            lineHeight = 20.sp,
-                            fontWeight = FontWeight(500),
-                            letterSpacing = 0.16.sp,
-                        ),
-                        color = MaterialTheme.colorScheme.secondary,
-                        modifier =
-                        Modifier.wrapContentWidth(Alignment.Start)
-                            .testTag("ActivityTime" + stop.stopId))
-                    if (stopHasLocation) {
-                        Text(
-                            text = stop.address,
-                            style =
                             TextStyle(
                                 fontSize = 16.sp,
                                 lineHeight = 20.sp,
                                 fontWeight = FontWeight(500),
                                 letterSpacing = 0.16.sp),
-                            color = MaterialTheme.colorScheme.secondary,
-                            modifier =
+                        color = MaterialTheme.colorScheme.secondary,
+                        modifier =
                             Modifier.wrapContentWidth(Alignment.Start)
                                 .testTag("ActivityAddress" + stop.stopId))
-                    }
+                  }
                 }
 
-                // Map Navigation Button
-                // Icon Button at the far right, centered vertically
-                IconButton(
-                    onClick = {
-                        if (stopHasLocation) {
-                            navigationActions.setVariablesLocation(stop.geoCords, stop.address)
-                            navigationActions.navigateTo(Route.MAP)
-                        }
-                    },
-                    modifier =
+            // Map Navigation Button
+            // Icon Button at the far right, centered vertically
+            IconButton(
+                onClick = {
+                  if (stopHasLocation) {
+                    navigationActions.setVariablesLocation(stop.geoCords, stop.address)
+                    navigationActions.navigateTo(Route.MAP)
+                  }
+                },
+                modifier =
                     Modifier.size(24.dp) // Adjust the size of the IconButton as needed
                         .align(Alignment.CenterVertically)
                         .testTag(
                             "navigationToMapButton" +
-                                    stop.stopId), // Center the IconButton vertically within the
-                    enabled = stopHasLocation
-                    // Row
+                                stop.stopId), // Center the IconButton vertically within the
+                enabled = stopHasLocation
+                // Row
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.LocationOn,
-                        tint =
-                        if (stopHasLocation) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
-                        contentDescription = null // Provide an appropriate content description
-                    )
+                  Icon(
+                      imageVector = Icons.Default.LocationOn,
+                      tint =
+                          if (stopHasLocation) MaterialTheme.colorScheme.primary
+                          else MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
+                      contentDescription = null // Provide an appropriate content description
+                      )
                 }
 
-                // Add spacing between the map icon and delete icon
-                Spacer(modifier = Modifier.width(16.dp))
+            // Add spacing between the map icon and delete icon
+            Spacer(modifier = Modifier.width(16.dp))
 
-                // Delete Icon
-                IconButton(
-                    onClick = {
-                        if(SessionManager.isAdmin()) {
-                            showDeleteConfirmDialog = true
-                        } else {
-                            showNoRightsToast = true
-                        }
-                    },
-                    modifier = Modifier
-                        .size(24.dp)
+            // Delete Icon
+            IconButton(
+                onClick = {
+                  if (SessionManager.isAdmin()) {
+                    showDeleteConfirmDialog = true
+                  } else {
+                    showNoRightsToast = true
+                  }
+                },
+                modifier =
+                    Modifier.size(24.dp)
                         .align(Alignment.CenterVertically)
                         .testTag("deleteButton" + stop.stopId),
-                    content = {
-                        Icon(
-                            imageVector = Icons.Default.Delete,
-                            tint = if(SessionManager.isAdmin()) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
-                            contentDescription = "Delete Stop"
-                        )
-                    }
-                )
-            }
+                content = {
+                  Icon(
+                      imageVector = Icons.Default.Delete,
+                      tint =
+                          if (SessionManager.isAdmin()) MaterialTheme.colorScheme.error
+                          else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                      contentDescription = "Delete Stop")
+                })
+          }
         }
-    }
+  }
 
-    // Confirmation Dialog for Deletion
-    if (showDeleteConfirmDialog) {
-        AlertDialog(
-            onDismissRequest = { showDeleteConfirmDialog = false },
-            title = { Text("Confirm Deletion") },
-            text = { Text("Are you sure you want to delete this stop?") },
-            confirmButton = {
-                TextButton(
-                    modifier = Modifier.testTag("confirmDeleteButton" + stop.stopId),
-                    onClick = {
-                        stopItemViewModel.deleteStop()
-                        showDeleteConfirmDialog = false
-                    }
-                ) {
-                    Text("Confirm", color = MaterialTheme.colorScheme.error)
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    modifier = Modifier.testTag("cancelDeleteButton" + stop.stopId),
-                    onClick = { showDeleteConfirmDialog = false }) {
-                    Text("Cancel")
-                }
-            }
-        )
-    }
+  // Confirmation Dialog for Deletion
+  if (showDeleteConfirmDialog) {
+    AlertDialog(
+        onDismissRequest = { showDeleteConfirmDialog = false },
+        title = { Text("Confirm Deletion") },
+        text = { Text("Are you sure you want to delete this stop?") },
+        confirmButton = {
+          TextButton(
+              modifier = Modifier.testTag("confirmDeleteButton" + stop.stopId),
+              onClick = {
+                stopItemViewModel.deleteStop()
+                showDeleteConfirmDialog = false
+              }) {
+                Text("Confirm", color = MaterialTheme.colorScheme.error)
+              }
+        },
+        dismissButton = {
+          TextButton(
+              modifier = Modifier.testTag("cancelDeleteButton" + stop.stopId),
+              onClick = { showDeleteConfirmDialog = false }) {
+                Text("Cancel")
+              }
+        })
+  }
 
-    // the horizontal divider
-    Box(
-        modifier =
-        Modifier.fillMaxWidth(), // This ensures the box takes the full width of its container
-        contentAlignment = Alignment.Center // This will center the content inside the box
-    ) {
+  // the horizontal divider
+  Box(
+      modifier =
+          Modifier.fillMaxWidth(), // This ensures the box takes the full width of its container
+      contentAlignment = Alignment.Center // This will center the content inside the box
+      ) {
         HorizontalDivider(
             modifier = Modifier.fillMaxWidth(), // Customize this width as needed
             thickness = 1.dp,
-            color = outlineVariantLight
-        )
-    }
+            color = outlineVariantLight)
+      }
 }
 
 @Composable
 fun ShowToast(message: String) {
-    val context = LocalContext.current
-    LaunchedEffect(message) {
-        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
-    }
+  val context = LocalContext.current
+  LaunchedEffect(message) { Toast.makeText(context, message, Toast.LENGTH_SHORT).show() }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopsList.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopsList.kt
@@ -54,7 +54,11 @@ import java.time.LocalDate
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter", "WeekBasedYear")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun StopsList(stopsListViewModel: StopsListViewModel, tripId: String, tripsRepository: TripsRepository) {
+fun StopsList(
+    stopsListViewModel: StopsListViewModel,
+    tripId: String,
+    tripsRepository: TripsRepository
+) {
 
   var isStopPressed by remember { mutableStateOf(false) }
   var selectedStopId by remember { mutableStateOf("") }
@@ -69,7 +73,7 @@ fun StopsList(stopsListViewModel: StopsListViewModel, tripId: String, tripsRepos
 
   val stops by stopsListViewModel.stops.collectAsState()
 
-  val  refreshFunction = { stopsListViewModel.loadStops() }
+  val refreshFunction = { stopsListViewModel.loadStops() }
 
   LaunchedEffect(Unit) { refreshFunction() }
 
@@ -142,14 +146,18 @@ fun StopsList(stopsListViewModel: StopsListViewModel, tripId: String, tripsRepos
                                 stops
                                     .filter { stop -> stop.date == date }
                                     .sortedBy { it.startTime }) { stop ->
-                                  StopItem(stop, onActivityItemClick, tripId, tripsRepository, refreshFunction)
+                                  StopItem(
+                                      stop,
+                                      onActivityItemClick,
+                                      tripId,
+                                      tripsRepository,
+                                      refreshFunction)
                                 }
                           }
                         })
                   }
               PullToRefreshLazyColumn(
-                  inputLazyColumn = stopsLazyColumn,
-                  onRefresh = { stopsListViewModel.loadStops() })
+                  inputLazyColumn = stopsLazyColumn, onRefresh = { stopsListViewModel.loadStops() })
             } else { // Display a message if there are no stops
               Box(modifier = Modifier.fillMaxSize()) {
                 Text(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopsList.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopsList.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.model.viewmodel.StopsListViewModel
 import com.github.se.wanderpals.navigationActions
 import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
-import com.github.se.wanderpals.ui.screens.trip.agenda.ActivityItem
+import com.github.se.wanderpals.ui.screens.trip.agenda.StopItem
 import com.github.se.wanderpals.ui.screens.trip.agenda.DisplayDate
 import com.github.se.wanderpals.ui.screens.trip.agenda.StopInfoDialog
 import java.time.LocalDate
@@ -140,7 +140,7 @@ fun StopsList(stopsListViewModel: StopsListViewModel, tripId: String) {
                                 stops
                                     .filter { stop -> stop.date == date }
                                     .sortedBy { it.startTime }) { stop ->
-                                  ActivityItem(stop, onActivityItemClick)
+                                  StopItem(stop, onActivityItemClick)
                                 }
                           }
                         })

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopsList.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopsList.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.StopsListViewModel
 import com.github.se.wanderpals.navigationActions
 import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
@@ -53,7 +54,7 @@ import java.time.LocalDate
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter", "WeekBasedYear")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun StopsList(stopsListViewModel: StopsListViewModel, tripId: String) {
+fun StopsList(stopsListViewModel: StopsListViewModel, tripId: String, tripsRepository: TripsRepository) {
 
   var isStopPressed by remember { mutableStateOf(false) }
   var selectedStopId by remember { mutableStateOf("") }
@@ -68,7 +69,9 @@ fun StopsList(stopsListViewModel: StopsListViewModel, tripId: String) {
 
   val stops by stopsListViewModel.stops.collectAsState()
 
-  LaunchedEffect(Unit) { stopsListViewModel.loadStops(tripId) }
+  val  refreshFunction = { stopsListViewModel.loadStops() }
+
+  LaunchedEffect(Unit) { refreshFunction() }
 
   Scaffold(
       topBar = {
@@ -139,14 +142,14 @@ fun StopsList(stopsListViewModel: StopsListViewModel, tripId: String) {
                                 stops
                                     .filter { stop -> stop.date == date }
                                     .sortedBy { it.startTime }) { stop ->
-                                  StopItem(stop, onActivityItemClick)
+                                  StopItem(stop, onActivityItemClick, tripId, tripsRepository, refreshFunction)
                                 }
                           }
                         })
                   }
               PullToRefreshLazyColumn(
                   inputLazyColumn = stopsLazyColumn,
-                  onRefresh = { stopsListViewModel.loadStops(tripId) })
+                  onRefresh = { stopsListViewModel.loadStops() })
             } else { // Display a message if there are no stops
               Box(modifier = Modifier.fillMaxSize()) {
                 Text(
@@ -158,7 +161,7 @@ fun StopsList(stopsListViewModel: StopsListViewModel, tripId: String) {
                             .testTag("NoActivitiesMessage")
                             .align(Alignment.Center))
                 IconButton(
-                    onClick = { stopsListViewModel.loadStops(tripId) },
+                    onClick = { stopsListViewModel.loadStops() },
                     modifier =
                         Modifier.align(Alignment.Center)
                             .padding(top = 60.dp)

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopsList.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopsList.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.model.viewmodel.StopsListViewModel
 import com.github.se.wanderpals.navigationActions
 import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
-import com.github.se.wanderpals.ui.screens.trip.agenda.StopItem
 import com.github.se.wanderpals.ui.screens.trip.agenda.DisplayDate
 import com.github.se.wanderpals.ui.screens.trip.agenda.StopInfoDialog
 import java.time.LocalDate

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/AgendaViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/AgendaViewModelTest.kt
@@ -1,0 +1,95 @@
+package com.github.se.wanderpals.viewmodel
+
+import com.github.se.wanderpals.model.data.GeoCords
+import com.github.se.wanderpals.model.data.Stop
+import com.github.se.wanderpals.model.repository.TripsRepository
+import com.github.se.wanderpals.model.viewmodel.AgendaViewModel
+import com.github.se.wanderpals.ui.screens.trip.agenda.CalendarUiState
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class AgendaViewModelTest {
+  private lateinit var viewModel: AgendaViewModel
+  private lateinit var mockTripsRepository: TripsRepository
+  private val testDispatcher = StandardTestDispatcher()
+
+  @Before
+  fun setup() {
+    // Set the main dispatcher to the test dispatcher
+    Dispatchers.setMain(testDispatcher)
+
+    // Mock the TripsRepository
+    mockTripsRepository = mockk(relaxed = true)
+
+    // Create the ViewModel
+    viewModel = AgendaViewModel("tripId", mockTripsRepository)
+  }
+
+  /**
+   * Test the loadStopsInfo method of the AgendaViewModel class to ensure that the stopsInfo state
+   * is updated correctly. The method should fetch the stops for the trip and update the stopsInfo.
+   */
+  @Test
+  fun `loadStopsInfo updates stopsInfo state`() = runBlockingTest {
+    // Prepare mock response
+    val mockStops =
+        listOf(
+            Stop(
+                stopId = "stop1",
+                title = "Location1",
+                address = "Address1",
+                date = LocalDate.of(2024, 5, 10), // Properly create LocalDate instances
+                startTime = LocalTime.of(10, 0), // Example start time
+                duration = 120, // Example duration in minutes
+                budget = 50.0, // Example budget
+                description = "Description of Location1",
+                geoCords =
+                    GeoCords(
+                        latitude = 40.712776,
+                        longitude = -74.005974), // Example coordinates, e.g., for New York City
+                website = "http://location1.com", // Example website
+                imageUrl = "http://example.com/location1.jpg" // Example image URL
+                ),
+            Stop(
+                stopId = "stop2",
+                title = "Location2",
+                address = "Address2",
+                date = LocalDate.of(2024, 5, 11),
+                startTime = LocalTime.of(15, 30), // Different example start time
+                duration = 90, // Different example duration
+                budget = 75.0, // Different budget
+                description = "Description of Location2",
+                geoCords =
+                    GeoCords(
+                        latitude = 34.052235,
+                        longitude = -118.243683), // Example coordinates, e.g., for Los Angeles
+                website = "http://location2.com",
+                imageUrl = "http://example.com/location2.jpg"))
+    coEvery { mockTripsRepository.getAllStopsFromTrip(any()) } returns mockStops
+
+    // Call the method to test
+    viewModel.loadStopsInfo() // Assuming this method is public or internal for testing
+    advanceUntilIdle() // Wait for all coroutines to complete
+
+    // Check the resulting state
+    assertEquals(2, viewModel._stopsInfo.value.size)
+    assertEquals(CalendarUiState.StopStatus.ADDED, viewModel._stopsInfo.value[mockStops[0].date])
+    assertEquals(CalendarUiState.StopStatus.ADDED, viewModel._stopsInfo.value[mockStops[1].date])
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain() // Reset the main dispatcher to the original Main dispatcher
+  }
+}

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/StopsListViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/StopsListViewModelTest.kt
@@ -53,7 +53,7 @@ class StopsListViewModelTest {
     SessionManager.setUserSession("user", "user@example.com", "token", Role.MEMBER)
 
     // Create the ViewModel using a factory with the mocked repository
-    val factory = StopsListViewModel.StopsListViewModelFactory(mockTripsRepository)
+    val factory = StopsListViewModel.StopsListViewModelFactory(mockTripsRepository, tripId)
     viewModel = factory.create(StopsListViewModel::class.java)
   }
 
@@ -67,7 +67,7 @@ class StopsListViewModelTest {
   @Test
   fun `loadStops fetches stops successfully and updates state`() =
       runTest(testDispatcher) {
-        viewModel.loadStops(tripId)
+        viewModel.loadStops()
 
         // Wait for all coroutines started during the test to complete
         advanceUntilIdle()


### PR DESCRIPTION
In this PR : 

The ability to delete stops was added. 
The user now sees a delete icon on the Stop item in agenda and the stops list. 
When clicking on this icon, if the user has the rights it asks for confirmation to delete the stop else the icon is greyed out and a toast informing the user they don't have the necessary permissions is displayed. 
