### PR TITLE
Visual cues for offline mode

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/dashboard/DashboardTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/dashboard/DashboardTest.kt
@@ -22,6 +22,7 @@ import com.github.se.wanderpals.ui.screens.trip.Dashboard
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.mockk.Called
 import io.mockk.confirmVerified
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
@@ -729,6 +730,23 @@ class DashboardTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeS
     composeTestRule.onNodeWithTag("confirmDeleteTripButton", useUnmergedTree = true).performClick()
 
     verify { mockNavActions.navigateTo(Route.OVERVIEW) }
+    confirmVerified(mockNavActions)
+  }
+
+  @Test
+  fun deleteTripDoesntWorkOffline() = run {
+    val viewModel = DashboardViewModelTest(emptyList())
+    viewModel.setLoading(false)
+    SessionManager.setIsNetworkAvailable(false)
+    SessionManager.setUserSession(role = Role.OWNER)
+    composeTestRule.setContent {
+      Dashboard(tripId = "", dashboardViewModel = viewModel, navActions = mockNavActions)
+    }
+
+    composeTestRule.onNodeWithTag("menuButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("deleteTripButton", useUnmergedTree = true).assertIsNotDisplayed()
+
+    verify { mockNavActions wasNot Called }
     confirmVerified(mockNavActions)
   }
 

--- a/app/src/androidTest/java/com/github/se/wanderpals/dashboard/DashboardTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/dashboard/DashboardTest.kt
@@ -748,6 +748,7 @@ class DashboardTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeS
 
     verify { mockNavActions wasNot Called }
     confirmVerified(mockNavActions)
+    SessionManager.setIsNetworkAvailable(true)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/wanderpals/finance/FinanceTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/finance/FinanceTest.kt
@@ -204,6 +204,7 @@ class FinanceTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSup
     ComposeScreen.onComposeScreen<FinanceScreen>(composeTestRule) {
       financeFloatingActionButton { assertIsNotDisplayed() }
     }
+    SessionManager.setIsNetworkAvailable(true)
   }
 
   @Test
@@ -388,6 +389,7 @@ class FinanceTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSup
       composeTestRule.onNodeWithTag("deleteExpenseDialog").assertIsNotDisplayed()
       assert(financeViewModelTest.expenseStateList.value.size == 3)
     }
+    SessionManager.setIsNetworkAvailable(true)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/wanderpals/notifications/CreateAnnouncementTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/notifications/CreateAnnouncementTest.kt
@@ -225,5 +225,6 @@ class CreateAnnouncementTest : TestCase(kaspressoBuilder = Kaspresso.Builder.wit
         confirmVerified(mockNavActions)
       }
     }
+    SessionManager.setIsNetworkAvailable(true)
   }
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/notifications/CreateAnnouncementTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/notifications/CreateAnnouncementTest.kt
@@ -195,4 +195,35 @@ class CreateAnnouncementTest : TestCase(kaspressoBuilder = Kaspresso.Builder.wit
       }
     }
   }
+
+  @Test
+  fun createAnnouncementOffline() = run {
+    ComposeScreen.onComposeScreen<CreateAnnouncementScreen>(composeTestRule) {
+      val vm = NotificationsViewModelTest()
+      SessionManager.setIsNetworkAvailable(false)
+      composeTestRule.setContent {
+        CreateAnnouncement(
+            vm,
+            onNavigationBack = { mockNavActions.navigateTo(Route.NOTIFICATION) },
+        )
+      }
+
+      step("Open create tripAnnouncement screen") {
+        inputAnnouncementTitle {
+          assertIsDisplayed()
+          performClick()
+
+          assertTextContains("Trip Announcement Title*")
+
+          performTextClearance()
+          performTextInput("Title1")
+        }
+
+        createAnnouncementButton { assertIsNotEnabled() }
+
+        verify { mockNavActions wasNot Called }
+        confirmVerified(mockNavActions)
+      }
+    }
+  }
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
@@ -235,6 +235,7 @@ class NotificationsTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
       createAnnouncementButton { assertIsNotEnabled() }
     }
     notificationsViewModelTest.addAnnouncement(announcement1)
+    SessionManager.setIsNetworkAvailable(true)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
@@ -212,6 +212,32 @@ class NotificationsTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
   }
 
   @Test
+  fun createAnnoucementButtonOnline() = run {
+    notificationsViewModelTest.removeAnnouncement("1")
+    SessionManager.setIsNetworkAvailable(true)
+    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+      notificationButton { assertIsDisplayed() }
+      announcementButton { assertIsDisplayed() }
+      announcementButton { performClick() }
+      createAnnouncementButton { assertIsEnabled() }
+    }
+    notificationsViewModelTest.addAnnouncement(announcement1)
+  }
+
+  @Test
+  fun createAnnoucementButtonOffline() = run {
+    notificationsViewModelTest.removeAnnouncement("1")
+    SessionManager.setIsNetworkAvailable(false)
+    ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
+      notificationButton { assertIsDisplayed() }
+      announcementButton { assertIsDisplayed() }
+      announcementButton { performClick() }
+      createAnnouncementButton { assertIsNotEnabled() }
+    }
+    notificationsViewModelTest.addAnnouncement(announcement1)
+  }
+
+  @Test
   fun viewerOrMemberCanReadAnnouncementInfoOnClick() = run {
     ComposeScreen.onComposeScreen<NotificationScreen>(composeTestRule) {
       SessionManager.setRole(Role.VIEWER)

--- a/app/src/androidTest/java/com/github/se/wanderpals/stops/StopItemTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/stops/StopItemTest.kt
@@ -85,6 +85,34 @@ class StopItemTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
   }
 
   @Test
+  fun testDeleteButtonFunctionalityNotWorkingOffline() = run {
+    // Set the user as an admin
+    SessionManager.setIsNetworkAvailable(false)
+    SessionManager.setUserSession(role = Role.ADMIN)
+    var deleteClicked = false
+    composeTestRule.setContent {
+      StopItem(
+          stop = stop,
+          tripId = "trip1",
+          tripsRepository = tripsRepository,
+          onDelete = { deleteClicked = true })
+    }
+
+    composeTestRule.onNodeWithTag("deleteButton1", useUnmergedTree = true).performClick()
+    // Wait for the dialog to be displayed
+    composeTestRule.waitForIdle()
+    // Assuming SessionManager.isAdmin() returns true for testing purpose
+    composeTestRule
+        .onNodeWithTag("confirmDeleteButton1", useUnmergedTree = true)
+        .assertExists()
+        .performClick()
+
+    composeTestRule.mainClock.advanceTimeBy(500) // Wait for the delete action to complete
+
+    assert(!deleteClicked) { "Delete callback was triggered" }
+  }
+
+  @Test
   fun testDeleteCancelFunctionality() = run {
     // Set the user as an admin
     SessionManager.setUserSession(role = Role.ADMIN)

--- a/app/src/androidTest/java/com/github/se/wanderpals/stops/StopItemTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/stops/StopItemTest.kt
@@ -110,6 +110,7 @@ class StopItemTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
     composeTestRule.mainClock.advanceTimeBy(500) // Wait for the delete action to complete
 
     assert(!deleteClicked) { "Delete callback was triggered" }
+    SessionManager.setIsNetworkAvailable(true)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/wanderpals/suggestion/CommentOptionsBottomSheetTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/suggestion/CommentOptionsBottomSheetTest.kt
@@ -271,6 +271,7 @@ class CommentOptionsBottomSheetTest {
 
     // Check if the comment is deleted
     composeTestRule.onNodeWithTag("comment1").assertExists()
+    SessionManager.setIsNetworkAvailable(true)
   }
 
   // Add a test that checks the bottom sheet is hidden when the delete comment option is clicked
@@ -501,6 +502,7 @@ class CommentOptionsBottomSheetTest {
 
     // Check if the edit comment option is displayed
     composeTestRule.onNodeWithTag("editCommentOption").assertIsNotDisplayed()
+    SessionManager.setIsNetworkAvailable(true)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/wanderpals/suggestion/CommentOptionsBottomSheetTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/suggestion/CommentOptionsBottomSheetTest.kt
@@ -481,32 +481,6 @@ class CommentOptionsBottomSheetTest {
   }
 
   @Test
-  fun testEditCommentOptionNotVisibleOffline() {
-    SessionManager.setUserSession(
-        // use the same user id as the comment owner
-        userId = "user1",
-        // must not be an admin
-        role = Role.MEMBER)
-    SessionManager.setIsNetworkAvailable(false)
-
-    composeTestRule.setContent {
-      SuggestionDetail(
-          suggestionId = mockSuggestion.suggestionId,
-          viewModel = FakeViewModelBottomSheetOptions(listOf(mockSuggestion)),
-          navActions = mockNavActions)
-    }
-
-    // Click on the comment 3 dot option icon
-    composeTestRule
-        .onNodeWithTag("commentOptionsIconcomment1", useUnmergedTree = true)
-        .performClick()
-
-    // Check if the edit comment option is displayed
-    composeTestRule.onNodeWithTag("editCommentOption").assertIsNotDisplayed()
-    SessionManager.setIsNetworkAvailable(true)
-  }
-
-  @Test
   fun testEditCommentOptionVisibleForOwner() {
     SessionManager.setUserSession(
         // use the same user id as the comment owner

--- a/app/src/androidTest/java/com/github/se/wanderpals/suggestion/CommentOptionsBottomSheetTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/suggestion/CommentOptionsBottomSheetTest.kt
@@ -1,7 +1,6 @@
 package com.github.se.wanderpals.suggestion
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule

--- a/app/src/androidTest/java/com/github/se/wanderpals/suggestion/CommentOptionsBottomSheetTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/suggestion/CommentOptionsBottomSheetTest.kt
@@ -2,6 +2,7 @@ package com.github.se.wanderpals.suggestion
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -527,6 +528,32 @@ class CommentOptionsBottomSheetTest {
 
     // Check if the edit comment option is displayed
     composeTestRule.onNodeWithTag("editCommentOption").assertIsDisplayed()
+  }
+
+  @Test
+  fun testEditCommentOptionVisibleForOwnerAndDisabledOffline() {
+    SessionManager.setIsNetworkAvailable(false)
+    SessionManager.setUserSession(
+        // use the same user id as the comment owner
+        userId = "user1",
+        // must not be an admin
+        role = Role.MEMBER)
+
+    composeTestRule.setContent {
+      SuggestionDetail(
+          suggestionId = mockSuggestion.suggestionId,
+          viewModel = FakeViewModelBottomSheetOptions(listOf(mockSuggestion)),
+          navActions = mockNavActions)
+    }
+
+    // Click on the comment 3 dot option icon
+    composeTestRule
+        .onNodeWithTag("commentOptionsIconcomment1", useUnmergedTree = true)
+        .performClick()
+
+    // Check if the edit comment option is displayed
+    composeTestRule.onNodeWithTag("editCommentOption").assertIsNotEnabled()
+    SessionManager.setIsNetworkAvailable(true)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/wanderpals/suggestion/CommentOptionsBottomSheetTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/suggestion/CommentOptionsBottomSheetTest.kt
@@ -1,6 +1,7 @@
 package com.github.se.wanderpals.suggestion
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -246,6 +247,32 @@ class CommentOptionsBottomSheetTest {
     composeTestRule.onNodeWithTag("comment1").assertDoesNotExist()
   }
 
+  // Add a test that checks the delete comment option deletes the comment when clicked
+  @Test
+  fun testDeleteCommentOptionDeletesCommentNotInOffline() {
+    SessionManager.setIsNetworkAvailable(false)
+    composeTestRule.setContent {
+      SuggestionDetail(
+          suggestionId = mockSuggestion.suggestionId,
+          viewModel = FakeViewModelBottomSheetOptions(listOf(mockSuggestion)),
+          navActions = mockNavActions)
+    }
+
+    // Click on the comment 3 dot option icon
+    composeTestRule
+        .onNodeWithTag("commentOptionsIconcomment1", useUnmergedTree = true)
+        .performClick()
+
+    // Click on the delete comment option
+    composeTestRule.onNodeWithTag("deleteCommentOption").performClick()
+
+    // Click on the confirm delete comment button
+    composeTestRule.onNodeWithTag("confirmDeleteCommentButton").performClick()
+
+    // Check if the comment is deleted
+    composeTestRule.onNodeWithTag("comment1").assertExists()
+  }
+
   // Add a test that checks the bottom sheet is hidden when the delete comment option is clicked
   @Test
   fun testDeleteCommentOptionHidesBottomSheet() {
@@ -449,6 +476,31 @@ class CommentOptionsBottomSheetTest {
 
     // Check if the delete comment option is displayed
     composeTestRule.onNodeWithTag("deleteCommentOption").assertIsDisplayed()
+  }
+
+  @Test
+  fun testEditCommentOptionNotVisibleOffline() {
+    SessionManager.setUserSession(
+        // use the same user id as the comment owner
+        userId = "user1",
+        // must not be an admin
+        role = Role.MEMBER)
+    SessionManager.setIsNetworkAvailable(false)
+
+    composeTestRule.setContent {
+      SuggestionDetail(
+          suggestionId = mockSuggestion.suggestionId,
+          viewModel = FakeViewModelBottomSheetOptions(listOf(mockSuggestion)),
+          navActions = mockNavActions)
+    }
+
+    // Click on the comment 3 dot option icon
+    composeTestRule
+        .onNodeWithTag("commentOptionsIconcomment1", useUnmergedTree = true)
+        .performClick()
+
+    // Check if the edit comment option is displayed
+    composeTestRule.onNodeWithTag("editCommentOption").assertIsNotDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/wanderpals/suggestion/SuggestionBottomSheetTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/suggestion/SuggestionBottomSheetTest.kt
@@ -1,6 +1,7 @@
 package com.github.se.wanderpals.suggestion
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -261,5 +262,22 @@ class SuggestionBottomSheetTest {
     composeTestRule
         .onNodeWithTag("suggestionBottomSheet", useUnmergedTree = true)
         .assertDoesNotExist()
+  }
+
+  @Test
+  fun testSuggestionBottomSheetTransformOffline() {
+    val viewModel = SuggestionsViewModelSheetTest(listOf(mockSuggestion))
+    SessionManager.setIsNetworkAvailable(false)
+
+    // Launch the composable with the view model
+    composeTestRule.setContent { SuggestionBottomSheet(viewModel) }
+
+    viewModel.showSuggestionBottomSheet(mockSuggestion)
+
+    composeTestRule
+        .onNodeWithTag("transformSuggestionOption", useUnmergedTree = true)
+        .assertIsNotEnabled()
+
+    SessionManager.setIsNetworkAvailable(true)
   }
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/trip/CreateTripTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/trip/CreateTripTest.kt
@@ -507,5 +507,6 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
 
     // Check that the save button is disabled
     screen.saveButton.assertIsNotEnabled()
+    SessionManager.setIsNetworkAvailable(true)
   }
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/trip/CreateTripTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/trip/CreateTripTest.kt
@@ -8,6 +8,7 @@ import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.OverviewViewModel
 import com.github.se.wanderpals.screens.CreateTripoScreen
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
 import com.github.se.wanderpals.ui.screens.CreateTrip
@@ -467,5 +468,44 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
 
     // Verify that the navigation has been triggered as expected due to the ViewModel's state change
     verify { mockNavActions.navigateTo(Route.OVERVIEW) }
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun saveTripDoesntWorkOffline() = runBlockingTest {
+
+    // Spy on the actual ViewModel rather than completely mocking it
+    val overviewViewModel =
+      spyk(
+        OverviewViewModel(tripsRepository = TripsRepository("-1", Dispatchers.IO)),
+        recordPrivateCalls = true)
+
+    // Mock the createTrip function to only modify certain properties
+    coEvery { overviewViewModel.createTrip(any()) } coAnswers
+            {
+              overviewViewModel.apply {
+                this.setCreateTripFinished(true)
+                // this.setProperty("_createTripFinished", true)
+              }
+            }
+    SessionManager.setIsNetworkAvailable(false)
+
+    // Set the content of the test
+    composeTestRule.setContent {
+      CreateTrip(overviewViewModel = overviewViewModel, nav = mockNavActions)
+    }
+
+    // Access the UI controls using your custom screen class
+    val screen = CreateTripoScreen(composeTestRule)
+
+    // Simulate user inputs and interactions
+    screen.inputTitle.performTextInput("My Trip")
+    screen.inputBudget.performTextInput("500")
+    screen.inputDescription.performTextInput("An exciting journey")
+    screen.inputStartDate.performTextInput("05/03/2024")
+    screen.inputEndDate.performTextInput("10/03/2024")
+
+    // Check that the save button is disabled
+    screen.saveButton.assertIsNotEnabled()
   }
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/trip/CreateTripTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/trip/CreateTripTest.kt
@@ -476,18 +476,18 @@ class CreateTripTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompose
 
     // Spy on the actual ViewModel rather than completely mocking it
     val overviewViewModel =
-      spyk(
-        OverviewViewModel(tripsRepository = TripsRepository("-1", Dispatchers.IO)),
-        recordPrivateCalls = true)
+        spyk(
+            OverviewViewModel(tripsRepository = TripsRepository("-1", Dispatchers.IO)),
+            recordPrivateCalls = true)
 
     // Mock the createTrip function to only modify certain properties
     coEvery { overviewViewModel.createTrip(any()) } coAnswers
-            {
-              overviewViewModel.apply {
-                this.setCreateTripFinished(true)
-                // this.setProperty("_createTripFinished", true)
-              }
-            }
+        {
+          overviewViewModel.apply {
+            this.setCreateTripFinished(true)
+            // this.setProperty("_createTripFinished", true)
+          }
+        }
     SessionManager.setIsNetworkAvailable(false)
 
     // Set the content of the test

--- a/app/src/main/java/com/github/se/wanderpals/service/NetworkHelper.kt
+++ b/app/src/main/java/com/github/se/wanderpals/service/NetworkHelper.kt
@@ -22,6 +22,7 @@ class NetworkHelper(context: Context, private val repository: TripsRepository) {
       context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
   init {
+    SessionManager.setIsNetworkAvailable(false)
     val networkCallback =
         object : ConnectivityManager.NetworkCallback() {
           override fun onAvailable(network: Network) {

--- a/app/src/main/java/com/github/se/wanderpals/ui/PullToRefreshLazyColumn.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/PullToRefreshLazyColumn.kt
@@ -40,7 +40,7 @@ fun PullToRefreshLazyColumn(
       LaunchedEffect(Unit) {
         scope.launch {
           isRefreshing = true
-          when (SessionManager.getIsNetworkAvailable()){
+          when (SessionManager.getIsNetworkAvailable()) {
             true -> onRefresh()
             false -> Toast.makeText(context, "No internet connection", Toast.LENGTH_SHORT).show()
           }

--- a/app/src/main/java/com/github/se/wanderpals/ui/PullToRefreshLazyColumn.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/PullToRefreshLazyColumn.kt
@@ -1,5 +1,6 @@
 package com.github.se.wanderpals.ui
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -16,6 +17,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
+import com.github.se.wanderpals.service.SessionManager
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -26,6 +29,7 @@ fun PullToRefreshLazyColumn(
     onRefresh: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+  val context = LocalContext.current
   var isRefreshing by remember { mutableStateOf(false) }
   val scope = rememberCoroutineScope()
   val pullToRefreshState = rememberPullToRefreshState()
@@ -36,7 +40,10 @@ fun PullToRefreshLazyColumn(
       LaunchedEffect(Unit) {
         scope.launch {
           isRefreshing = true
-          onRefresh()
+          when (SessionManager.getIsNetworkAvailable()){
+            true -> onRefresh()
+            false -> Toast.makeText(context, "No internet connection", Toast.LENGTH_SHORT).show()
+          }
           delay(1000)
           isRefreshing = false
         }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/CreateTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/CreateTrip.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.viewmodel.OverviewViewModel
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
 import java.text.SimpleDateFormat
@@ -219,6 +220,7 @@ fun CreateTrip(overviewViewModel: OverviewViewModel, nav: NavigationActions) {
               )
 
               Button(
+                  enabled = SessionManager.getIsNetworkAvailable(),
                   modifier = Modifier.testTag("tripSave").fillMaxWidth().padding(16.dp),
                   onClick = {
                     val error = validateInputs(name, budget, description, startDate, endDate)

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/Overview.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/Overview.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.window.Dialog
 import com.github.se.wanderpals.isMapManagerInitialized
 import com.github.se.wanderpals.mapManager
 import com.github.se.wanderpals.model.viewmodel.OverviewViewModel
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
 
@@ -169,6 +170,7 @@ fun DialogHandler(closeDialogueAction: () -> Unit, addTripCodeAction: (String) -
 
                     // Button to join with trip code
                     Button(
+                        enabled = SessionManager.getIsNetworkAvailable(),
                         onClick = {
                           val success = addTripCodeAction(tripCode)
                           if (success) {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewBottomBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewBottomBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.theme.onPrimaryContainerLight
 import com.github.se.wanderpals.ui.theme.primaryContainerLight
 
@@ -42,6 +43,7 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
     // Button to join a trip
     Box(modifier = Modifier.fillMaxWidth()) {
       Button(
+          enabled = SessionManager.getIsNetworkAvailable(),
           onClick = { onLinkClick() },
           modifier =
               Modifier.width(360.dp)
@@ -77,6 +79,7 @@ fun OverviewBottomBar(onCreateTripClick: () -> Unit, onLinkClick: () -> Unit) {
     // Button to create a new trip
     Box(modifier = Modifier.fillMaxWidth()) {
       Button(
+          enabled = SessionManager.getIsNetworkAvailable(),
           onClick = { onCreateTripClick() },
           modifier =
               Modifier.width(360.dp)

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
@@ -68,7 +68,7 @@ fun OverviewContent(
           text =
               when (SessionManager.getIsNetworkAvailable()) {
                 true -> "Looks like you have no travel plan yet. "
-                false -> "No internet connection."
+                false -> "It seems you're not connected to the Internet"
               },
           style =
               TextStyle(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.viewmodel.OverviewViewModel
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 
@@ -64,7 +65,11 @@ fun OverviewContent(
                   .width(260.dp)
                   .height(55.dp)
                   .testTag("noTripForUserText"),
-          text = "Looks like you have no travel plan yet. ",
+          text =
+              when (SessionManager.getIsNetworkAvailable()) {
+                true -> "Looks like you have no travel plan yet. "
+                false -> "No internet connection."
+              },
           style =
               TextStyle(
                   fontSize = 18.sp,
@@ -76,6 +81,7 @@ fun OverviewContent(
               ),
       )
       IconButton(
+          enabled = SessionManager.getIsNetworkAvailable(),
           onClick = { overviewViewModel.getAllTrips() },
           modifier = Modifier.align(Alignment.Center).padding(top = 60.dp),
           content = { Icon(Icons.Default.Refresh, contentDescription = "Refresh trips") })

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CommentOptionsBottomSheet.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CommentOptionsBottomSheet.kt
@@ -81,26 +81,28 @@ fun CommentBottomSheet(
                       }
                     }
 
-                Box(
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .clickable(
-                                onClick = {
-                                  viewModel.editCommentOption()
-                                  onEdit(selectedComment!!.text)
-                                })
-                            .padding(16.dp)
-                            .testTag("editCommentOption"),
-                    contentAlignment = Alignment.CenterStart) {
-                      Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            imageVector = Icons.Outlined.Create,
-                            contentDescription = "Edit",
-                            modifier = Modifier.size(24.dp))
-                        Spacer(modifier = Modifier.width(16.dp)) // Space between icon and text
-                        Text("Edit comment", style = MaterialTheme.typography.bodyLarge)
+                if (SessionManager.getIsNetworkAvailable()) {
+                  Box(
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .clickable(
+                                  onClick = {
+                                    viewModel.editCommentOption()
+                                    onEdit(selectedComment!!.text)
+                                  })
+                              .padding(16.dp)
+                              .testTag("editCommentOption"),
+                      contentAlignment = Alignment.CenterStart) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                          Icon(
+                              imageVector = Icons.Outlined.Create,
+                              contentDescription = "Edit",
+                              modifier = Modifier.size(24.dp))
+                          Spacer(modifier = Modifier.width(16.dp)) // Space between icon and text
+                          Text("Edit comment", style = MaterialTheme.typography.bodyLarge)
+                        }
                       }
-                    }
+                }
               }
             }
           }
@@ -110,12 +112,29 @@ fun CommentBottomSheet(
     AlertDialog(
         onDismissRequest = { viewModel.hideDeleteDialog() },
         title = { Text("Confirm Deletion") },
-        text = { Text("Are you sure you want to delete this comment?") },
+        text = {
+          Text(
+              when (SessionManager.getIsNetworkAvailable()) {
+                true -> "Are you sure you want to delete this comment?"
+                false -> "You are offline. You can't delete this comment."
+              })
+        },
         confirmButton = {
           TextButton(
-              onClick = { viewModel.confirmDeleteComment(suggestion) },
+              onClick = {
+                if (SessionManager.getIsNetworkAvailable()) {
+                  viewModel.confirmDeleteComment(suggestion)
+                } else {
+                  viewModel.hideDeleteDialog()
+                }
+              },
               modifier = Modifier.testTag("confirmDeleteCommentButton")) {
-                Text("Confirm", color = MaterialTheme.colorScheme.error)
+                Text(
+                    when (SessionManager.getIsNetworkAvailable()) {
+                      true -> "Confirm"
+                      false -> "Exit"
+                    },
+                    color = MaterialTheme.colorScheme.error)
               }
         },
         dismissButton = {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CommentOptionsBottomSheet.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CommentOptionsBottomSheet.kt
@@ -128,12 +128,7 @@ fun CommentBottomSheet(
                 }
               },
               modifier = Modifier.testTag("confirmDeleteCommentButton")) {
-                Text(
-                    when (SessionManager.getIsNetworkAvailable()) {
-                      true -> "Confirm"
-                      false -> "Exit"
-                    },
-                    color = MaterialTheme.colorScheme.error)
+                Text("Confirm", color = MaterialTheme.colorScheme.error)
               }
         },
         dismissButton = {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CommentOptionsBottomSheet.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CommentOptionsBottomSheet.kt
@@ -122,10 +122,9 @@ fun CommentBottomSheet(
         confirmButton = {
           TextButton(
               onClick = {
-                if (SessionManager.getIsNetworkAvailable()) {
-                  viewModel.confirmDeleteComment(suggestion)
-                } else {
-                  viewModel.hideDeleteDialog()
+                when (SessionManager.getIsNetworkAvailable()) {
+                  true -> viewModel.confirmDeleteComment(suggestion)
+                  false -> viewModel.hideDeleteDialog()
                 }
               },
               modifier = Modifier.testTag("confirmDeleteCommentButton")) {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CommentOptionsBottomSheet.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CommentOptionsBottomSheet.kt
@@ -81,28 +81,27 @@ fun CommentBottomSheet(
                       }
                     }
 
-                if (SessionManager.getIsNetworkAvailable()) {
-                  Box(
-                      modifier =
-                          Modifier.fillMaxWidth()
-                              .clickable(
-                                  onClick = {
-                                    viewModel.editCommentOption()
-                                    onEdit(selectedComment!!.text)
-                                  })
-                              .padding(16.dp)
-                              .testTag("editCommentOption"),
-                      contentAlignment = Alignment.CenterStart) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                          Icon(
-                              imageVector = Icons.Outlined.Create,
-                              contentDescription = "Edit",
-                              modifier = Modifier.size(24.dp))
-                          Spacer(modifier = Modifier.width(16.dp)) // Space between icon and text
-                          Text("Edit comment", style = MaterialTheme.typography.bodyLarge)
-                        }
+                Box(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .clickable(
+                                enabled = SessionManager.getIsNetworkAvailable(),
+                                onClick = {
+                                  viewModel.editCommentOption()
+                                  onEdit(selectedComment!!.text)
+                                })
+                            .padding(16.dp)
+                            .testTag("editCommentOption"),
+                    contentAlignment = Alignment.CenterStart) {
+                      Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Outlined.Create,
+                            contentDescription = "Edit",
+                            modifier = Modifier.size(24.dp))
+                        Spacer(modifier = Modifier.width(16.dp)) // Space between icon and text
+                        Text("Edit comment", style = MaterialTheme.typography.bodyLarge)
                       }
-                }
+                    }
               }
             }
           }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CreateSuggestion.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/CreateSuggestion.kt
@@ -328,6 +328,7 @@ fun CreateSuggestion(
               modifier = Modifier.height(24.dp)) // the space between the last field and the button
 
           Button(
+              enabled = SessionManager.getIsNetworkAvailable(),
               modifier =
                   Modifier.padding(0.5.dp)
                       .width(300.dp)

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomBar.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.github.se.wanderpals.R
+import com.github.se.wanderpals.service.SessionManager
 
 @Composable
 fun SuggestionBottomBar(
@@ -54,6 +55,7 @@ fun SuggestionBottomBar(
               }
 
           Button(
+              enabled = SessionManager.getIsNetworkAvailable(),
               onClick = { onSuggestionClick() },
               modifier =
                   Modifier // .align(Alignment.BottomEnd) // Align the button to the bottom end of

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
@@ -103,27 +103,26 @@ fun SuggestionBottomSheet(
                     }
 
                 // Display the transform suggestion option
-                if (SessionManager.getIsNetworkAvailable()) {
-                  Box(
-                      modifier =
-                          Modifier.fillMaxWidth()
-                              .clickable(
-                                  onClick = { viewModel.transformToStop(selectedSuggestion!!) })
-                              .padding(16.dp)
-                              .testTag("transformSuggestionOption"),
-                      contentAlignment = Alignment.CenterStart) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                          Icon(
-                              imageVector = Icons.Outlined.Add,
-                              contentDescription = "TransformToStop",
-                              modifier = Modifier.size(24.dp))
-                          Spacer(modifier = Modifier.width(16.dp)) // Space between icon and text
-                          Text(
-                              "Transform suggestion to a stop",
-                              style = MaterialTheme.typography.bodyLarge)
-                        }
+                Box(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .clickable(
+                                enabled = SessionManager.getIsNetworkAvailable(),
+                                onClick = { viewModel.transformToStop(selectedSuggestion!!) })
+                            .padding(16.dp)
+                            .testTag("transformSuggestionOption"),
+                    contentAlignment = Alignment.CenterStart) {
+                      Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Outlined.Add,
+                            contentDescription = "TransformToStop",
+                            modifier = Modifier.size(24.dp))
+                        Spacer(modifier = Modifier.width(16.dp)) // Space between icon and text
+                        Text(
+                            "Transform suggestion to a stop",
+                            style = MaterialTheme.typography.bodyLarge)
                       }
-                }
+                    }
               }
             }
           }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
@@ -143,9 +143,10 @@ fun SuggestionBottomSheet(
         confirmButton = {
           TextButton(
               onClick = {
-                if (SessionManager.getIsNetworkAvailable()) {
-                  viewModel.confirmDeleteSuggestion(selectedSuggestion!!)
-                } else viewModel.hideDeleteDialog()
+                when (SessionManager.getIsNetworkAvailable()) {
+                  true -> viewModel.confirmDeleteSuggestion(selectedSuggestion!!)
+                  false -> viewModel.hideDeleteDialog()
+                }
               },
               modifier = Modifier.testTag("confirmDeleteSuggestionButton")) {
                 Text(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
@@ -103,30 +103,27 @@ fun SuggestionBottomSheet(
                     }
 
                 // Display the transform suggestion option
-                Box(
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .clickable(
-                                onClick = {
-                                  when (SessionManager.getIsNetworkAvailable()) {
-                                    true -> viewModel.transformToStop(selectedSuggestion!!)
-                                    false -> viewModel.hideBottomSheet()
-                                  }
-                                })
-                            .padding(16.dp)
-                            .testTag("transformSuggestionOption"),
-                    contentAlignment = Alignment.CenterStart) {
-                      Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            imageVector = Icons.Outlined.Add,
-                            contentDescription = "TransformToStop",
-                            modifier = Modifier.size(24.dp))
-                        Spacer(modifier = Modifier.width(16.dp)) // Space between icon and text
-                        Text(
-                            "Transform suggestion to a stop",
-                            style = MaterialTheme.typography.bodyLarge)
+                if (SessionManager.getIsNetworkAvailable()) {
+                  Box(
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .clickable(
+                                  onClick = { viewModel.transformToStop(selectedSuggestion!!) })
+                              .padding(16.dp)
+                              .testTag("transformSuggestionOption"),
+                      contentAlignment = Alignment.CenterStart) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                          Icon(
+                              imageVector = Icons.Outlined.Add,
+                              contentDescription = "TransformToStop",
+                              modifier = Modifier.size(24.dp))
+                          Spacer(modifier = Modifier.width(16.dp)) // Space between icon and text
+                          Text(
+                              "Transform suggestion to a stop",
+                              style = MaterialTheme.typography.bodyLarge)
+                        }
                       }
-                    }
+                }
               }
             }
           }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
@@ -149,12 +149,7 @@ fun SuggestionBottomSheet(
                 }
               },
               modifier = Modifier.testTag("confirmDeleteSuggestionButton")) {
-                Text(
-                    when (SessionManager.getIsNetworkAvailable()) {
-                      true -> "Confirm"
-                      false -> "Exit"
-                    },
-                    color = MaterialTheme.colorScheme.error)
+                Text("Confirm", color = MaterialTheme.colorScheme.error)
               }
         },
         dismissButton = {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionBottomSheet.kt
@@ -107,7 +107,12 @@ fun SuggestionBottomSheet(
                     modifier =
                         Modifier.fillMaxWidth()
                             .clickable(
-                                onClick = { viewModel.transformToStop(selectedSuggestion!!) })
+                                onClick = {
+                                  when (SessionManager.getIsNetworkAvailable()) {
+                                    true -> viewModel.transformToStop(selectedSuggestion!!)
+                                    false -> viewModel.hideBottomSheet()
+                                  }
+                                })
                             .padding(16.dp)
                             .testTag("transformSuggestionOption"),
                     contentAlignment = Alignment.CenterStart) {
@@ -131,12 +136,27 @@ fun SuggestionBottomSheet(
     AlertDialog(
         onDismissRequest = { viewModel.hideDeleteDialog() },
         title = { Text("Confirm Deletion") },
-        text = { Text("Are you sure you want to delete this suggestion?") },
+        text = {
+          Text(
+              when (SessionManager.getIsNetworkAvailable()) {
+                true -> "Are you sure you want to delete this suggestion?"
+                false -> "You are offline. You can't delete this suggestion."
+              })
+        },
         confirmButton = {
           TextButton(
-              onClick = { viewModel.confirmDeleteSuggestion(selectedSuggestion!!) },
+              onClick = {
+                if (SessionManager.getIsNetworkAvailable()) {
+                  viewModel.confirmDeleteSuggestion(selectedSuggestion!!)
+                } else viewModel.hideDeleteDialog()
+              },
               modifier = Modifier.testTag("confirmDeleteSuggestionButton")) {
-                Text("Confirm", color = MaterialTheme.colorScheme.error)
+                Text(
+                    when (SessionManager.getIsNetworkAvailable()) {
+                      true -> "Confirm"
+                      false -> "Exit"
+                    },
+                    color = MaterialTheme.colorScheme.error)
               }
         },
         dismissButton = {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionFeedContent.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionFeedContent.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.model.data.Suggestion
 import com.github.se.wanderpals.model.viewmodel.SuggestionsViewModel
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
 import com.github.se.wanderpals.ui.navigation.NavigationActions
 import com.github.se.wanderpals.ui.navigation.Route
@@ -125,7 +126,12 @@ fun SuggestionFeedContent(
                     .height(55.dp)
                     .align(Alignment.Center)
                     .testTag("noSuggestionsForUserText"),
-            text = "Looks like there is no suggestions yet. ",
+            text =
+                when {
+                  SessionManager.getIsNetworkAvailable() ->
+                      "Looks like there is no suggestions yet. "
+                  else -> "Looks like you are offline. Check your connection."
+                },
             style =
                 TextStyle(
                     lineHeight = 20.sp,
@@ -136,6 +142,7 @@ fun SuggestionFeedContent(
                     color = scrimLight),
         )
         IconButton(
+            enabled = SessionManager.getIsNetworkAvailable(),
             onClick = { suggestionsViewModel.loadSuggestion(tripId) },
             modifier = Modifier.align(Alignment.Center).padding(top = 60.dp),
             content = { Icon(Icons.Default.Refresh, contentDescription = "Refresh suggestions") })

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionHistoryFeedContent.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionHistoryFeedContent.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.model.viewmodel.SuggestionsViewModel
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
 import com.github.se.wanderpals.ui.screens.trip.agenda.CalendarUiState
 
@@ -104,7 +105,11 @@ fun SuggestionHistoryFeedContent(suggestionsViewModel: SuggestionsViewModel) {
                           .height(55.dp)
                           .align(Alignment.Center)
                           .testTag("noSuggestionsHistoryToDisplay"),
-                  text = "No stops in the history yet.",
+                  text =
+                      when (SessionManager.getIsNetworkAvailable()) {
+                        true -> "No stops in the history yet."
+                        false -> "No internet connection"
+                      },
                   style =
                       TextStyle(
                           lineHeight = 20.sp,
@@ -115,6 +120,7 @@ fun SuggestionHistoryFeedContent(suggestionsViewModel: SuggestionsViewModel) {
                           color = MaterialTheme.colorScheme.scrim),
               )
               IconButton(
+                  enabled = SessionManager.getIsNetworkAvailable(),
                   onClick = { suggestionsViewModel.loadSuggestion(tripId) },
                   modifier = Modifier.align(Alignment.Center).padding(top = 60.dp),
                   content = {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
@@ -141,12 +141,22 @@ fun Dashboard(
           AlertDialog(
               onDismissRequest = { dashboardViewModel.hideDeleteDialog() },
               title = { Text("Confirm Deletion") },
-              text = { Text("Are you sure you want to delete this Trip?") },
+              text = {
+                Text(
+                    when (SessionManager.getIsNetworkAvailable()) {
+                      true -> "Are you sure you want to delete this Trip?"
+                      false -> "No internet connection. Please try again later."
+                    })
+              },
               confirmButton = {
                 TextButton(
                     onClick = {
-                      dashboardViewModel.confirmDeleteTrip()
-                      navActions.navigateTo(Route.OVERVIEW)
+                      if (SessionManager.getIsNetworkAvailable()) {
+                        dashboardViewModel.confirmDeleteTrip()
+                        navActions.navigateTo(Route.OVERVIEW)
+                      } else {
+                        dashboardViewModel.hideDeleteDialog()
+                      }
                     },
                     modifier = Modifier.testTag("confirmDeleteTripButton")) {
                       Text("Confirm", color = Color.Red)
@@ -239,7 +249,8 @@ fun Menu(
           }
         })
 
-    if (SessionManager.getCurrentUser()!!.role == Role.OWNER) {
+    if (SessionManager.getCurrentUser()!!.role == Role.OWNER &&
+        SessionManager.getIsNetworkAvailable()) {
       ElevatedButton(
           modifier = Modifier.fillMaxWidth().padding(horizontal = 2.dp).testTag("deleteTripButton"),
           content = {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DailyActivities.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.AgendaViewModel
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
 import com.github.se.wanderpals.ui.screens.trip.stops.StopItem
 
@@ -51,11 +52,16 @@ fun DailyActivities(
   if (dailyActivities.isEmpty()) {
     Box(modifier = Modifier.fillMaxSize()) {
       Text(
-          text = "No activities for this date",
+          text =
+              when (SessionManager.getIsNetworkAvailable()) {
+                true -> "No activities for this date"
+                false -> "No internet connection"
+              },
           style = MaterialTheme.typography.bodyLarge,
           color = MaterialTheme.colorScheme.secondary,
           modifier = Modifier.padding(16.dp).testTag("NoActivitiesMessage").align(Alignment.Center))
       IconButton(
+          enabled = SessionManager.getIsNetworkAvailable(),
           onClick = { refreshFunction() },
           modifier = Modifier.align(Alignment.Center).padding(top = 60.dp),
           content = { Icon(Icons.Default.Refresh, contentDescription = "Refresh trips") })

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
@@ -65,12 +65,22 @@ fun ExpenseInfo(financeViewModel: FinanceViewModel) {
     AlertDialog(
         onDismissRequest = { financeViewModel.setShowDeleteDialogState(false) },
         title = { Text("Confirm Deletion") },
-        text = { Text("Are you sure you want to delete this expense?") },
+        text = {
+          Text(
+              when (SessionManager.getIsNetworkAvailable()) {
+                true -> "Are you sure you want to delete this expense?"
+                false -> "You can't delete this expense because you are offline"
+              })
+        },
         confirmButton = {
           TextButton(
               onClick = {
-                financeViewModel.deleteExpense(expense)
-                navigationActions.navigateTo(Route.FINANCE)
+                if (SessionManager.getIsNetworkAvailable()) {
+                  financeViewModel.deleteExpense(expense)
+                  navigationActions.navigateTo(Route.FINANCE)
+                } else {
+                  financeViewModel.setShowDeleteDialogState(false)
+                }
               },
               modifier = Modifier.testTag("confirmDeleteExpenseButton")) {
                 Text("Confirm", color = Color.Red)

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpensesContent.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpensesContent.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.model.data.Expense
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
 import java.time.format.DateTimeFormatter
 
@@ -61,7 +62,11 @@ fun ExpensesContent(
     Box(modifier = Modifier.fillMaxSize()) {
       Text(
           modifier = Modifier.align(Alignment.Center).testTag("noExpensesTripText"),
-          text = "Looks like you have no expenses. ",
+          text =
+              when (SessionManager.getIsNetworkAvailable()) {
+                true -> "Looks like you have no expenses. "
+                false -> "No internet connection"
+              },
           style =
               TextStyle(
                   fontSize = 18.sp,
@@ -72,6 +77,7 @@ fun ExpensesContent(
               ),
       )
       IconButton(
+          enabled = SessionManager.getIsNetworkAvailable(),
           onClick = { onRefresh() },
           modifier = Modifier.align(Alignment.Center).padding(top = 60.dp),
           content = { Icon(Icons.Default.Refresh, contentDescription = "Refresh expense list") })

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.se.wanderpals.model.data.Role
@@ -58,6 +59,8 @@ enum class FinanceOption(private val optionName: String) {
 @Composable
 fun Finance(financeViewModel: FinanceViewModel, navigationActions: NavigationActions) {
 
+  val context = LocalContext.current
+
   var currentSelectedOption by remember { mutableStateOf(FinanceOption.EXPENSES) }
 
   val expenseList by financeViewModel.expenseStateList.collectAsState()
@@ -82,7 +85,8 @@ fun Finance(financeViewModel: FinanceViewModel, navigationActions: NavigationAct
       },
       floatingActionButton = {
         if (currentSelectedOption == FinanceOption.EXPENSES &&
-            SessionManager.getCurrentUser()!!.role != Role.VIEWER) {
+            SessionManager.getCurrentUser()!!.role != Role.VIEWER &&
+            SessionManager.getIsNetworkAvailable()) {
           FloatingActionButton(
               modifier = Modifier.testTag("financeFloatingActionButton"),
               onClick = { navigationActions.navigateTo(Route.CREATE_EXPENSE) },

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.se.wanderpals.model.data.Role
@@ -58,8 +57,6 @@ enum class FinanceOption(private val optionName: String) {
  */
 @Composable
 fun Finance(financeViewModel: FinanceViewModel, navigationActions: NavigationActions) {
-
-  val context = LocalContext.current
 
   var currentSelectedOption by remember { mutableStateOf(FinanceOption.EXPENSES) }
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/AnnouncementInfoDialog.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/AnnouncementInfoDialog.kt
@@ -78,11 +78,7 @@ fun AnnouncementInfoDialog(
                   showDeleteDialog = false
                 },
                 modifier = Modifier.testTag("confirmDeleteAnnouncementButton")) {
-                  Text(
-                      when (SessionManager.getIsNetworkAvailable()) {
-                        true -> "Confirm"
-                        false -> "Exit"
-                      })
+                  Text("Confirm")
                 }
           },
           dismissButton = { TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") } },

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/AnnouncementInfoDialog.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/AnnouncementInfoDialog.kt
@@ -61,16 +61,28 @@ fun AnnouncementInfoDialog(
           modifier = Modifier.testTag("deleteAnnouncementDialog"),
           onDismissRequest = { showDeleteDialog = false },
           title = { Text("Confirm Deletion") },
-          text = { Text("Are you sure you want to delete this announcement?") },
+          text = {
+            Text(
+                when (SessionManager.getIsNetworkAvailable()) {
+                  true -> "Are you sure you want to delete this announcement?"
+                  false -> "Network is not available. Please try again later."
+                })
+          },
           confirmButton = {
             TextButton(
                 onClick = {
-                  notificationsViewModel.removeAnnouncement(announcement.announcementId)
-                  notificationsViewModel.setAnnouncementItemPressState(false)
+                  if (SessionManager.getIsNetworkAvailable()) {
+                    notificationsViewModel.removeAnnouncement(announcement.announcementId)
+                    notificationsViewModel.setAnnouncementItemPressState(false)
+                  }
                   showDeleteDialog = false
                 },
                 modifier = Modifier.testTag("confirmDeleteAnnouncementButton")) {
-                  Text("Confirm")
+                  Text(
+                      when (SessionManager.getIsNetworkAvailable()) {
+                        true -> "Confirm"
+                        false -> "Exit"
+                      })
                 }
           },
           dismissButton = { TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") } },

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/CreateAnnoucement.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/CreateAnnoucement.kt
@@ -138,6 +138,7 @@ fun CreateAnnouncement(viewModel: NotificationsViewModel, onNavigationBack: () -
           Spacer(modifier = Modifier.height(32.dp))
 
           Button(
+              enabled = SessionManager.getIsNetworkAvailable(),
               modifier = Modifier.fillMaxWidth().height(50.dp).testTag("createAnnouncementButton"),
               onClick = {
                 titleError = if (title.trim().isEmpty()) "Title cannot be empty" else ""

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/Notification.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/Notification.kt
@@ -169,7 +169,12 @@ fun Notification(
         Box(modifier = Modifier.fillMaxWidth().weight(1f).padding(vertical = 16.dp)) {
           // text if no items found
           Text(
-              text = "Looks like there is no $emptyItemText.",
+              text =
+                  when {
+                    SessionManager.getIsNetworkAvailable() ->
+                        "Looks like there is no $emptyItemText."
+                    else -> "Looks like you are offline. Please check your network connection."
+                  },
               modifier =
                   Modifier.align(Alignment.Center)
                       .padding(horizontal = 16.dp)
@@ -177,6 +182,7 @@ fun Notification(
               textAlign = TextAlign.Center,
               style = MaterialTheme.typography.bodyLarge)
           IconButton(
+              enabled = SessionManager.getIsNetworkAvailable(),
               onClick = { notificationsViewModel.updateStateLists() },
               modifier = Modifier.align(Alignment.Center).padding(top = 60.dp),
               content = {
@@ -234,6 +240,7 @@ fun Notification(
     if (!notificationSelected && SessionManager.isAdmin()) {
       Box(modifier = Modifier.fillMaxWidth().height(100.dp)) {
         Button(
+            enabled = SessionManager.getIsNetworkAvailable(),
             onClick = { navigationActions.navigateTo(Route.CREATE_ANNOUNCEMENT) },
             modifier =
                 Modifier.padding(horizontal = 20.dp)

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/Notification.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/Notification.kt
@@ -232,7 +232,9 @@ fun Notification(
               }
             }
         PullToRefreshLazyColumn(
-            inputLazyColumn = lazyColumn, onRefresh = { notificationsViewModel.updateStateLists() })
+            inputLazyColumn = lazyColumn,
+            onRefresh = { notificationsViewModel.updateStateLists() },
+            modifier = Modifier.weight(1f))
       }
     }
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopItem.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopItem.kt
@@ -204,12 +204,20 @@ fun StopItem(stop: Stop, tripId: String, tripsRepository: TripsRepository, onDel
     AlertDialog(
         onDismissRequest = { showDeleteConfirmDialog = false },
         title = { Text("Confirm Deletion") },
-        text = { Text("Are you sure you want to delete this stop?") },
+        text = {
+          Text(
+              when (SessionManager.getIsNetworkAvailable()) {
+                true -> "Are you sure you want to delete this stop?"
+                false -> "You are offline. You can't delete this stop."
+              })
+        },
         confirmButton = {
           TextButton(
               modifier = Modifier.testTag("confirmDeleteButton" + stop.stopId),
               onClick = {
-                stopItemViewModel.deleteStop(stop.stopId)
+                if (SessionManager.getIsNetworkAvailable()) {
+                  stopItemViewModel.deleteStop(stop.stopId)
+                }
                 showDeleteConfirmDialog = false
               }) {
                 Text("Confirm", color = MaterialTheme.colorScheme.error)

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopsList.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/stops/StopsList.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.sp
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.StopsListViewModel
 import com.github.se.wanderpals.navigationActions
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
 import com.github.se.wanderpals.ui.screens.trip.agenda.DisplayDate
 import java.time.LocalDate
@@ -162,7 +163,11 @@ fun StopsList(
             } else { // Display a message if there are no stops
               Box(modifier = Modifier.fillMaxSize()) {
                 Text(
-                    text = "No stops for this trip",
+                    text =
+                        when (SessionManager.getIsNetworkAvailable()) {
+                          true -> "No stops for this trip"
+                          false -> "No internet connection"
+                        },
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.secondary,
                     modifier =
@@ -170,6 +175,7 @@ fun StopsList(
                             .testTag("NoActivitiesMessage")
                             .align(Alignment.Center))
                 IconButton(
+                    enabled = SessionManager.getIsNetworkAvailable(),
                     onClick = { stopsListViewModel.loadStops() },
                     modifier =
                         Modifier.align(Alignment.Center)


### PR DESCRIPTION
In this PR, the following was done when Offline
* "No internet connection" toast on Pull to Refresh
* Added Offline message on screens that had an icon button refresh when Empty List
* Disable Trip Creation and Join Button
* Hide Edit comment
* Hide TransformToStop Suggestion
* Disable Suggestion Creation/Deletion
* Disable/Hide Trip Deletion
* Disable Expense Deletion
* Disable/Hide Expense Creation
* Disable Announcement Creation/Deletion
* Disable Stop Deletion 

Bugs Fixed:
* Fixed SessionManager being online by default when starting the app already Offline
* Announcement Creation Button was hidden when Announcement List contained at least one element

Missing:
* Admin Screen wasn't touched since it is currently being reworked, will be done next week

