### PR TITLE
Fix AddAnnouncement to Prevent Duplicate Execution on Multiple Clicks

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/notifications/CreateAnnouncementTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/notifications/CreateAnnouncementTest.kt
@@ -105,52 +105,51 @@ class CreateAnnouncementTest : TestCase(kaspressoBuilder = Kaspresso.Builder.wit
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
-  fun multipleCallsToAddAnnouncementDoNotCreateMultipleObjects() =
-      runBlockingTest {
-        val tripsRepository = mockk<TripsRepository>()
-        val tripId = "test_trip_id"
+  fun multipleCallsToAddAnnouncementDoNotCreateMultipleObjects() = runBlockingTest {
+    val tripsRepository = mockk<TripsRepository>()
+    val tripId = "test_trip_id"
 
-        // Create a spy of the NotificationsViewModel
-        val vm = spyk(NotificationsViewModel(tripsRepository, tripId), recordPrivateCalls = true)
+    // Create a spy of the NotificationsViewModel
+    val vm = spyk(NotificationsViewModel(tripsRepository, tripId), recordPrivateCalls = true)
 
-        // Set user session and role
-        SessionManager.setUserSession()
-        SessionManager.setRole(Role.OWNER)
+    // Set user session and role
+    SessionManager.setUserSession()
+    SessionManager.setRole(Role.OWNER)
 
-        // Mock the repository functions as needed
-        coEvery { tripsRepository.addAnnouncementToTrip(any(), any()) } returns true
-        coEvery { tripsRepository.getTrip(any()) } coAnswers
-            {
-              // Simulate a delay to mimic the coroutine execution time
-              delay(500)
-              null
-            }
-
-        // Set the content of the test
-        composeTestRule.setContent {
-          CreateAnnouncement(
-              viewModel = vm,
-              onNavigationBack = { mockNavActions.navigateTo(Route.NOTIFICATION) },
-          )
+    // Mock the repository functions as needed
+    coEvery { tripsRepository.addAnnouncementToTrip(any(), any()) } returns true
+    coEvery { tripsRepository.getTrip(any()) } coAnswers
+        {
+          // Simulate a delay to mimic the coroutine execution time
+          delay(500)
+          null
         }
 
-        // Access the UI controls using your custom screen class
-        val screen = CreateAnnouncementScreen(composeTestRule)
+    // Set the content of the test
+    composeTestRule.setContent {
+      CreateAnnouncement(
+          viewModel = vm,
+          onNavigationBack = { mockNavActions.navigateTo(Route.NOTIFICATION) },
+      )
+    }
 
-        // Simulate user inputs and interactions
-        screen.inputAnnouncementTitle.performTextInput("Title1")
-        screen.inputAnnouncementDescription.performTextInput("This is Title1.")
+    // Access the UI controls using your custom screen class
+    val screen = CreateAnnouncementScreen(composeTestRule)
 
-        // Simulate clicking the create button twice concurrently
-        launch { screen.createAnnouncementButton.performClick() }
-        launch { screen.createAnnouncementButton.performClick() }
+    // Simulate user inputs and interactions
+    screen.inputAnnouncementTitle.performTextInput("Title1")
+    screen.inputAnnouncementDescription.performTextInput("This is Title1.")
 
-        // Wait for Compose to process potential recompositions due to state changes
-        composeTestRule.waitForIdle()
+    // Simulate clicking the create button twice concurrently
+    launch { screen.createAnnouncementButton.performClick() }
+    launch { screen.createAnnouncementButton.performClick() }
 
-        // Verify that the addAnnouncement method was only called once
-        coVerify(exactly = 1) { tripsRepository.addAnnouncementToTrip(any(), any()) }
-      }
+    // Wait for Compose to process potential recompositions due to state changes
+    composeTestRule.waitForIdle()
+
+    // Verify that the addAnnouncement method was only called once
+    coVerify(exactly = 1) { tripsRepository.addAnnouncementToTrip(any(), any()) }
+  }
 
   @Test
   fun createAnnouncementFailsWithMissingTitleAndDoesNotWorkWithEmptyTitle() = run {

--- a/app/src/androidTest/java/com/github/se/wanderpals/notifications/CreateAnnouncementTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/notifications/CreateAnnouncementTest.kt
@@ -3,6 +3,8 @@ package com.github.se.wanderpals.notifications
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.wanderpals.model.data.Role
+import com.github.se.wanderpals.model.repository.TripsRepository
+import com.github.se.wanderpals.model.viewmodel.NotificationsViewModel
 import com.github.se.wanderpals.screens.CreateAnnouncementScreen
 import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.navigation.NavigationActions
@@ -13,10 +15,18 @@ import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.mockk.Called
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
+import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -49,55 +59,97 @@ class CreateAnnouncementTest : TestCase(kaspressoBuilder = Kaspresso.Builder.wit
     }
   }
 
+  @OptIn(ExperimentalCoroutinesApi::class)
   @Test
-  fun createTripAnnouncementReturnToAnnouncementWhenSuccessfulAndWorksWithOnlyMandatoryField() =
-      run {
+  fun createTripAnnouncementReturnToAnnouncementWhenSuccessfulAndWorksWithOnlyMandatoryFields() =
+      runBlockingTest {
         ComposeScreen.onComposeScreen<CreateAnnouncementScreen>(composeTestRule) {
+
+          // Set up the ViewModel
+          val vm = spyk(NotificationsViewModelTest(), recordPrivateCalls = true)
+
           SessionManager.setUserSession()
           SessionManager.setRole(Role.OWNER)
-          val vm = NotificationsViewModelTest()
+
+          // Mock the ViewModel's function if needed
+          coEvery { vm.addAnnouncement(any()) } coAnswers
+              {
+                vm.apply { this.setCreateAnnouncementFinished(true) }
+              }
           composeTestRule.setContent {
             CreateAnnouncement(
-                vm,
+                viewModel = vm,
                 onNavigationBack = { mockNavActions.navigateTo(Route.NOTIFICATION) },
             )
           }
 
-          step("Open create tripAnnouncement screen") {
-            inputAnnouncementTitle {
-              assertIsDisplayed()
-              performClick()
+          // Access the UI controls using your custom screen class
+          val screen = CreateAnnouncementScreen(composeTestRule)
 
-              assertTextContains("Trip Announcement Title*")
+          // Simulate user inputs and interactions
+          screen.inputAnnouncementTitle.performTextInput("Title1")
+          screen.inputAnnouncementDescription.performTextInput("This is Title1.")
 
-              performTextClearance()
-              performTextInput("Title1")
-            }
+          // Simulate clicking the create button
+          screen.createAnnouncementButton.performClick()
 
-            announcementTitleLengthText {
-              assertIsDisplayed()
-              assertTextEquals("6/55")
-            }
+          // Wait for Compose to process potential recompositions due to state changes
+          composeTestRule.waitForIdle()
 
-            inputAnnouncementDescription {
-              assertIsDisplayed()
-              performClick()
-
-              assertTextContains("Trip Announcement Description*")
-
-              performTextClearance()
-              performTextInput("This is Title1.")
-            }
-
-            createAnnouncementButton {
-              assertIsDisplayed()
-              performClick()
-            }
-
-            verify { mockNavActions.navigateTo(Route.NOTIFICATION) }
-            confirmVerified(mockNavActions)
-          }
+          // Verify that the navigation has been triggered as expected due to the ViewModel's state
+          // change
+          verify { mockNavActions.navigateTo(Route.NOTIFICATION) }
+          confirmVerified(mockNavActions)
         }
+      }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun multipleCallsToAddAnnouncementDoNotCreateMultipleObjects() =
+      runBlockingTest {
+        val tripsRepository = mockk<TripsRepository>()
+        val tripId = "test_trip_id"
+
+        // Create a spy of the NotificationsViewModel
+        val vm = spyk(NotificationsViewModel(tripsRepository, tripId), recordPrivateCalls = true)
+
+        // Set user session and role
+        SessionManager.setUserSession()
+        SessionManager.setRole(Role.OWNER)
+
+        // Mock the repository functions as needed
+        coEvery { tripsRepository.addAnnouncementToTrip(any(), any()) } returns true
+        coEvery { tripsRepository.getTrip(any()) } coAnswers
+            {
+              // Simulate a delay to mimic the coroutine execution time
+              delay(500)
+              null
+            }
+
+        // Set the content of the test
+        composeTestRule.setContent {
+          CreateAnnouncement(
+              viewModel = vm,
+              onNavigationBack = { mockNavActions.navigateTo(Route.NOTIFICATION) },
+          )
+        }
+
+        // Access the UI controls using your custom screen class
+        val screen = CreateAnnouncementScreen(composeTestRule)
+
+        // Simulate user inputs and interactions
+        screen.inputAnnouncementTitle.performTextInput("Title1")
+        screen.inputAnnouncementDescription.performTextInput("This is Title1.")
+
+        // Simulate clicking the create button twice concurrently
+        launch { screen.createAnnouncementButton.performClick() }
+        launch { screen.createAnnouncementButton.performClick() }
+
+        // Wait for Compose to process potential recompositions due to state changes
+        composeTestRule.waitForIdle()
+
+        // Verify that the addAnnouncement method was only called once
+        coVerify(exactly = 1) { tripsRepository.addAnnouncementToTrip(any(), any()) }
       }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/notifications/NotificationsTest.kt
@@ -92,6 +92,9 @@ class NotificationsViewModelTest :
   private val _isLoading = MutableStateFlow(false)
   override val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
+  private val _createTripFinished = MutableStateFlow(false)
+  val createTripFinished: StateFlow<Boolean> = _createTripFinished.asStateFlow()
+
   override fun getSuggestion(suggestionId: String) {
     _isLoading.value = true
   }
@@ -109,6 +112,7 @@ class NotificationsViewModelTest :
   override fun addAnnouncement(announcement: Announcement) {
     _announcementStateList.value =
         _announcementStateList.value.toMutableList().apply { add(announcement2) }
+    _createTripFinished.value = true
   }
 
   override fun removeAnnouncement(announcementId: String) {

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/NotificationsViewModel.kt
@@ -131,8 +131,6 @@ open class NotificationsViewModel(val tripsRepository: TripsRepository, val trip
         val listOfTokens = tripsRepository.getTrip(tripId)
         if (listOfTokens != null) {
           Log.d("NotificationAnnouncement", "List of tokens: ${listOfTokens.tokenIds}")
-        }
-        if (listOfTokens != null) {
           for (token in listOfTokens.tokenIds) {
             sendMessageToListOfUsers(token, announcement.title)
           }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/NotificationsViewModel.kt
@@ -56,6 +56,15 @@ open class NotificationsViewModel(val tripsRepository: TripsRepository, val trip
   private val _isExpenseReady = MutableStateFlow(false)
   val isExpenseReady: StateFlow<Boolean> = _isExpenseReady.asStateFlow()
 
+  // signal that the announcement was added successfully
+  private val _createAnnouncementFinished = MutableStateFlow(false)
+  open val createAnnouncementFinished: StateFlow<Boolean> =
+      _createAnnouncementFinished.asStateFlow()
+
+  // don't add an announcement twice
+  private val _isAddingAnnouncement = MutableStateFlow(false)
+  open val isAddingAnnouncement: StateFlow<Boolean> = _isAddingAnnouncement.asStateFlow()
+
   /**
    * Updates the state lists of notifications and announcements by launching a coroutine within the
    * viewModel scope.
@@ -114,18 +123,30 @@ open class NotificationsViewModel(val tripsRepository: TripsRepository, val trip
    * @return A boolean representing the success of the operation.
    */
   open fun addAnnouncement(announcement: Announcement) {
-    runBlocking {
-      tripsRepository.addAnnouncementToTrip(tripId, announcement)
-      val listOfTokens = tripsRepository.getTrip(tripId)
-      if (listOfTokens != null) {
-        Log.d("NotificationAnnouncement", "List of tokens: ${listOfTokens.tokenIds}")
-      }
-      if (listOfTokens != null) {
-        for (token in listOfTokens.tokenIds) {
-          sendMessageToListOfUsers(token, announcement.title)
+    viewModelScope.launch {
+      if (!isAddingAnnouncement.value && !createAnnouncementFinished.value) {
+
+        _isAddingAnnouncement.value = true
+        tripsRepository.addAnnouncementToTrip(tripId, announcement)
+        val listOfTokens = tripsRepository.getTrip(tripId)
+        if (listOfTokens != null) {
+          Log.d("NotificationAnnouncement", "List of tokens: ${listOfTokens.tokenIds}")
         }
+        if (listOfTokens != null) {
+          for (token in listOfTokens.tokenIds) {
+            sendMessageToListOfUsers(token, announcement.title)
+          }
+        }
+
+        _isAddingAnnouncement.value = false
+        _createAnnouncementFinished.value = true
       }
     }
+  }
+
+  /** Resets the CreateAnnouncementFinished flag */
+  fun setCreateAnnouncementFinished(value: Boolean) {
+    _createAnnouncementFinished.value = value
   }
 
   /**

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/CreateAnnoucement.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/notifications/CreateAnnoucement.kt
@@ -33,6 +33,16 @@ import java.time.LocalDateTime
 @Composable
 fun CreateAnnouncement(viewModel: NotificationsViewModel, onNavigationBack: () -> Unit) {
 
+  val createAnnouncementFinished by viewModel.createAnnouncementFinished.collectAsState()
+  // Effect to react to the createAnnouncementFinished state change
+  LaunchedEffect(createAnnouncementFinished) {
+    if (createAnnouncementFinished) {
+      viewModel.setNotificationSelectionState(false)
+      onNavigationBack()
+      viewModel.setCreateAnnouncementFinished(false) // Reset the flag after handling it
+    }
+  }
+
   val MAX_ANNOUNCEMENT_TITLE_LENGTH = 55 // limit the trip Announcement title to 55 characters
 
   var title by remember { mutableStateOf("") }
@@ -158,8 +168,7 @@ fun CreateAnnouncement(viewModel: NotificationsViewModel, onNavigationBack: () -
                           timestamp = LocalDateTime.now())
 
                   viewModel.addAnnouncement(announcement)
-                  viewModel.setNotificationSelectionState(false)
-                  onNavigationBack()
+                  // navigation done in launch effects
                 }
               }) {
                 Text("Announce", fontSize = 24.sp)

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/NotificationsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/NotificationsViewModelTest.kt
@@ -79,6 +79,7 @@ class NotificationsViewModelTest {
             Announcement(
                 "Ann2", "Update", "Here's an update", "Admin", "tripId", LocalDateTime.now())
         viewModel.addAnnouncement(newAnnouncement)
+        advanceUntilIdle()
 
         // Check that correct mocked method was called
         coVerify { mockTripsRepository.addAnnouncementToTrip("tripId", newAnnouncement) }


### PR DESCRIPTION
PR Description:
Ensured AddAnnouncement method does not execute multiple times on multiple clicks.
Changed runBlocking to CoroutineScope.launch to avoid blocking the main thread.
Fixed navigation issues and added LaunchedEffect in CreateAnnouncement screen.
Updated existing tests to reflect these changes.
Added a regression test to simulate multiple clicks and verify only one execution.