### PR TITLE
Offline Admin

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/dashboard/AdminTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/dashboard/AdminTest.kt
@@ -3,6 +3,7 @@ package com.github.se.wanderpals.dashboard
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -217,6 +218,23 @@ class AdminTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
   }
 
   @Test
+  fun confirmRoleChangeButtonIsDisabledOffline() = run {
+    SessionManager.setIsNetworkAvailable(false)
+    val user1 = FakeAdminViewModel().listOfUsers.value[0]
+    composeTestRule.setContent {
+      SessionManager.setUserSession(
+          user1.userId, user1.name, user1.email, user1.role, profilePhoto = user1.profilePictureURL)
+      Admin(adminViewModel = FakeAdminViewModel(), storageReference = null)
+    }
+    composeTestRule.onNodeWithTag("editRoleButton" + user1.userId).performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule
+        .onNodeWithTag("confirmRoleChangeButton", useUnmergedTree = true)
+        .assertIsNotEnabled()
+    SessionManager.setIsNetworkAvailable(true)
+  }
+
+  @Test
   fun checkUserProfilePictures() = run {
     val user1 = FakeAdminViewModel().listOfUsers.value[0]
     val user2 = FakeAdminViewModel().listOfUsers.value[1]
@@ -304,5 +322,101 @@ class AdminTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
           .assertTextContains(currUser.nickname)
           .assertIsDisplayed()
     }
+  }
+
+  @Test
+  fun userNameEnabledOnline() = run {
+    val user1 = FakeAdminViewModel().listOfUsers.value[0]
+    composeTestRule.setContent {
+      SessionManager.setUserSession(
+          user1.userId, user1.name, user1.email, user1.role, profilePhoto = user1.profilePictureURL)
+      Admin(adminViewModel = FakeAdminViewModel(), storageReference = null)
+    }
+    composeTestRule.onNodeWithTag("userName").assertIsEnabled()
+  }
+
+  @Test
+  fun userNameNotEnabledOffline() = run {
+    SessionManager.setIsNetworkAvailable(false)
+    val user1 = FakeAdminViewModel().listOfUsers.value[0]
+    composeTestRule.setContent {
+      SessionManager.setUserSession(
+          user1.userId, user1.name, user1.email, user1.role, profilePhoto = user1.profilePictureURL)
+      Admin(adminViewModel = FakeAdminViewModel(), storageReference = null)
+    }
+    composeTestRule.onNodeWithTag("userName").assertIsNotEnabled()
+    SessionManager.setIsNetworkAvailable(true)
+  }
+
+  @Test
+  fun iconAdminScreenEnabledOnline() = run {
+    val user1 = FakeAdminViewModel().listOfUsers.value[0]
+    composeTestRule.setContent {
+      SessionManager.setUserSession(
+          user1.userId, user1.name, user1.email, user1.role, profilePhoto = user1.profilePictureURL)
+      Admin(adminViewModel = FakeAdminViewModel(), storageReference = null)
+    }
+    composeTestRule.onNodeWithTag("IconAdminScreen").assertIsEnabled()
+  }
+
+  @Test
+  fun iconAdminScreeNotEnabledOffline() = run {
+    SessionManager.setIsNetworkAvailable(false)
+    val user1 = FakeAdminViewModel().listOfUsers.value[0]
+    composeTestRule.setContent {
+      SessionManager.setUserSession(
+          user1.userId, user1.name, user1.email, user1.role, profilePhoto = user1.profilePictureURL)
+      Admin(adminViewModel = FakeAdminViewModel(), storageReference = null)
+    }
+    composeTestRule.onNodeWithTag("IconAdminScreen").assertIsNotEnabled()
+    SessionManager.setIsNetworkAvailable(true)
+  }
+
+  @Test
+  fun promoteUserButtonEnabledOnline() = run {
+    val user2 = FakeAdminViewModel().listOfUsers.value[1]
+    composeTestRule.setContent {
+      SessionManager.setUserSession(
+          user2.userId, user2.name, user2.email, user2.role, profilePhoto = user2.profilePictureURL)
+      Admin(adminViewModel = FakeAdminViewModel(), storageReference = null)
+    }
+    composeTestRule.onNodeWithTag("promoteUserButton" + "3").assertIsEnabled()
+  }
+
+  @Test
+  fun promoteUserButtonNotEnabledOffline() = run {
+    SessionManager.setIsNetworkAvailable(false)
+    val user2 = FakeAdminViewModel().listOfUsers.value[1]
+    composeTestRule.setContent {
+      SessionManager.setUserSession(
+          user2.userId, user2.name, user2.email, user2.role, profilePhoto = user2.profilePictureURL)
+      Admin(adminViewModel = FakeAdminViewModel(), storageReference = null)
+    }
+    composeTestRule.onNodeWithTag("promoteUserButton" + "3").assertIsNotEnabled()
+    SessionManager.setIsNetworkAvailable(true)
+  }
+
+  @Test
+  fun deleteUserButtonEnabledOnline() = run {
+    val user2 = FakeAdminViewModel().listOfUsers.value[1]
+    composeTestRule.setContent {
+      SessionManager.setUserSession(
+          user2.userId, user2.name, user2.email, user2.role, profilePhoto = user2.profilePictureURL)
+      Admin(adminViewModel = FakeAdminViewModel(), storageReference = null)
+    }
+    composeTestRule.onNodeWithTag("deleteUserButton" + "3").assertIsEnabled()
+  }
+
+  @Test
+  fun deleteUserButtonNotEnabledOffline() = run {
+    SessionManager.setIsNetworkAvailable(false)
+    val user2 = FakeAdminViewModel().listOfUsers.value[1]
+    composeTestRule.setContent {
+      SessionManager.setUserSession(
+          user2.userId, user2.name, user2.email, user2.role, profilePhoto = user2.profilePictureURL)
+      Admin(adminViewModel = FakeAdminViewModel(), storageReference = null)
+    }
+    composeTestRule.onNodeWithTag("deleteUserButton" + "3").assertIsNotEnabled()
+    SessionManager.setIsNetworkAvailable(true)
   }
 }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AdminViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AdminViewModel.kt
@@ -70,6 +70,7 @@ open class AdminViewModel(
 
   // Modify the current user's profil photo
   open fun modifyCurrentUserProfilePhoto(profilePhoto: String) {
+    if (!SessionManager.getIsNetworkAvailable()) return // Check if the network is available
     currentUser.value = currentUser.value?.copy(profilePhoto = profilePhoto)
     SessionManager.setPhoto(profilePhoto)
     val user = listOfUsers.value.find { it.userId == currentUser.value?.userId }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/Admin.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/Admin.kt
@@ -78,6 +78,7 @@ import com.github.se.wanderpals.model.data.Role
 import com.github.se.wanderpals.model.data.User
 import com.github.se.wanderpals.model.viewmodel.AdminViewModel
 import com.github.se.wanderpals.navigationActions
+import com.github.se.wanderpals.service.SessionManager
 import com.github.se.wanderpals.ui.PullToRefreshLazyColumn
 import com.github.se.wanderpals.ui.navigation.Route
 import com.github.se.wanderpals.ui.screens.dashboard.DashboardMemberDetail
@@ -214,14 +215,15 @@ fun Admin(adminViewModel: AdminViewModel, storageReference: StorageReference?) {
                                       MaterialTheme.colorScheme.error
                                   else MaterialTheme.colorScheme.primary,
                               modifier =
-                                  Modifier.clickable {
-                                        if (modifierButton && !isAlreadyClicked) {
-                                          isAlreadyClicked = true
-                                          modifierButton = false
-                                          newName = currentUser!!.name
-                                          editNameDialog = true
-                                        }
-                                      }
+                                  Modifier.clickable(
+                                          enabled = SessionManager.getIsNetworkAvailable()) {
+                                            if (modifierButton && !isAlreadyClicked) {
+                                              isAlreadyClicked = true
+                                              modifierButton = false
+                                              newName = currentUser!!.name
+                                              editNameDialog = true
+                                            }
+                                          }
                                       .padding(horizontal = 10.dp)
                                       .testTag("userName"),
                               fontWeight = FontWeight.Bold)
@@ -365,7 +367,7 @@ fun Admin(adminViewModel: AdminViewModel, storageReference: StorageReference?) {
                                           MaterialTheme.colorScheme.error
                                       else MaterialTheme.colorScheme.surfaceVariant,
                                   CircleShape)
-                              .clickable {
+                              .clickable(enabled = SessionManager.getIsNetworkAvailable()) {
                                 if (modifierButton && !isAlreadyClicked) {
                                   isAlreadyClicked = true
                                   modifierButton = false
@@ -446,6 +448,7 @@ fun Admin(adminViewModel: AdminViewModel, storageReference: StorageReference?) {
                             if (currentUser!!.role == Role.OWNER &&
                                 currentUser!!.userId != user.userId) {
                               IconButton(
+                                  enabled = SessionManager.getIsNetworkAvailable(),
                                   onClick = {
                                     userToPromote = user
                                     promoteMemberDialog = true
@@ -463,6 +466,7 @@ fun Admin(adminViewModel: AdminViewModel, storageReference: StorageReference?) {
                                 currentUser!!.role.ordinal < user.role.ordinal) &&
                                 user.role != Role.OWNER) {
                               IconButton(
+                                  enabled = SessionManager.getIsNetworkAvailable(),
                                   onClick = {
                                     deleteMemberDialog = true
                                     userToDelete = user.userId
@@ -484,7 +488,7 @@ fun Admin(adminViewModel: AdminViewModel, storageReference: StorageReference?) {
           inputLazyColumn = lazyColumn, onRefresh = { adminViewModel.getUsers() })
 
       // Dialog to promote a member of the trip to owner
-      if (promoteMemberDialog) {
+      if (promoteMemberDialog && SessionManager.getIsNetworkAvailable()) {
         AlertDialog(
             onDismissRequest = { promoteMemberDialog = false },
             confirmButton = {
@@ -509,7 +513,7 @@ fun Admin(adminViewModel: AdminViewModel, storageReference: StorageReference?) {
       }
 
       // Dialog to kick a member of the trip
-      if (deleteMemberDialog) {
+      if (deleteMemberDialog && SessionManager.getIsNetworkAvailable()) {
         AlertDialog(
             onDismissRequest = { deleteMemberDialog = false },
             confirmButton = {
@@ -581,6 +585,7 @@ fun Admin(adminViewModel: AdminViewModel, storageReference: StorageReference?) {
                   HorizontalDivider()
                   Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                     TextButton(
+                        enabled = SessionManager.getIsNetworkAvailable(),
                         onClick = {
                           if (currentUser?.userId != userToUpdate.userId &&
                               userToUpdate.role.ordinal > currentUser?.role!!.ordinal) {
@@ -603,7 +608,7 @@ fun Admin(adminViewModel: AdminViewModel, storageReference: StorageReference?) {
       }
 
       // Dialog to edit the user name
-      if (editNameDialog) {
+      if (editNameDialog && SessionManager.getIsNetworkAvailable()) {
         AlertDialog(
             onDismissRequest = { editNameDialog = false },
             confirmButton = {

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/AdminViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/AdminViewModelTest.kt
@@ -96,6 +96,28 @@ class AdminViewModelTest {
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
+  fun testModifyCurrentUserProfilePhotoOffline() =
+      runBlockingTest(testDispatcher) {
+        SessionManager.setIsNetworkAvailable(false)
+        // Given
+        viewModel.currentUser.value =
+            SessionUser(userId = "currentUser", role = Role.MEMBER, profilePhoto = "oldUrl")
+        viewModel.listOfUsers.value =
+            listOf(User(userId = "currentUser", profilePictureURL = "oldUrl"))
+
+        // When
+        viewModel.modifyCurrentUserProfilePhoto("newUrl")
+
+        // Then
+        assertEquals("oldUrl", viewModel.currentUser.value?.profilePhoto)
+        assertEquals(
+            "oldUrl",
+            viewModel.listOfUsers.value.find { it.userId == "currentUser" }?.profilePictureURL)
+        SessionManager.setIsNetworkAvailable(true)
+      }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
   fun testGetUsers() =
       runBlockingTest(testDispatcher) {
         // When

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/AdminViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/AdminViewModelTest.kt
@@ -78,6 +78,7 @@ class AdminViewModelTest {
   @Test
   fun testModifyCurrentUserProfilePhoto() =
       runBlockingTest(testDispatcher) {
+        SessionManager.setIsNetworkAvailable(true)
         // Given
         viewModel.currentUser.value =
             SessionUser(userId = "currentUser", role = Role.MEMBER, profilePhoto = "oldUrl")
@@ -92,6 +93,7 @@ class AdminViewModelTest {
         assertEquals(
             "newUrl",
             viewModel.listOfUsers.value.find { it.userId == "currentUser" }?.profilePictureURL)
+        SessionManager.setIsNetworkAvailable(true)
       }
 
   @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
As said in "Visual cues for offline mode #341", this PR aims to complete the offline visual cues that were missing in the admin panel last week. 

This is done like the previous PR, by disabling and enabling click actions based on if the device is only or not. 
Additional tests were also added