### PR TITLE
Fix displayed names across the app that were not synced with the current name of the users

### DIFF
--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SuggestionsViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SuggestionsViewModel.kt
@@ -135,7 +135,22 @@ open class SuggestionsViewModel(
                 it.suggestionId
               } // get the list of suggestions that have the vote icon that have been clicked
 
+      _state.value.forEach { updateSuggestionUsername(it) }
+
       _isLoading.value = false
+    }
+  }
+
+  /**
+   * Updates the backend and local state with the new suggestion.
+   *
+   * @param suggestion The new suggestion to be added.
+   */
+  open fun updateSuggestionUsername(suggestion: Suggestion) {
+    viewModelScope.launch {
+      val userName = suggestionRepository?.getUserFromTrip(tripId, suggestion.userId)!!.name
+      val updatedSuggestion = suggestion.copy(userName = userName)
+      suggestionRepository.updateSuggestionInTrip(tripId, updatedSuggestion)
     }
   }
 

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SuggestionsViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SuggestionsViewModel.kt
@@ -164,12 +164,12 @@ open class SuggestionsViewModel(
   open fun updateSuggestionCommentUsername() {
     viewModelScope.launch {
       for (suggestion in _state.value) {
-        suggestion.comments.forEach { it ->
-          val userName = suggestionRepository?.getUserFromTrip(tripId, it.userId)!!.name
-          if (userName != it.userName) {
-            val updatedComment = it.copy(userName = userName)
+        suggestion.comments.forEach { comment ->
+          val userName = suggestionRepository?.getUserFromTrip(tripId, comment.userId)!!.name
+          if (userName != comment.userName) {
+            val updatedComment = comment.copy(userName = userName)
             val updatedSuggestion =
-                suggestion.copy(comments = suggestion.comments - it + updatedComment)
+                suggestion.copy(comments = suggestion.comments - comment + updatedComment)
             suggestionRepository.updateSuggestionInTrip(tripId, updatedSuggestion)
             _state.value =
                 _state.value.map {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpenseInfo.kt
@@ -110,7 +110,7 @@ fun ExpenseInfo(financeViewModel: FinanceViewModel) {
         }
 
         // Display of the list of participant related to the expense
-        ExpenseParticipantsInfo(expense = expense, currencySmybol = tripCurrency.symbol)
+        ExpenseParticipantsInfo(expense = expense, currencySymbol = tripCurrency.symbol)
       }
 }
 
@@ -219,7 +219,7 @@ fun ExpenseTopInfo(expense: Expense, currencySymbol: String, onDeleteExpenseClic
  * @param expense The expense object containing participant information.
  */
 @Composable
-fun ExpenseParticipantsInfo(expense: Expense, currencySmybol: String) {
+fun ExpenseParticipantsInfo(expense: Expense, currencySymbol: String) {
   LazyColumn(modifier = Modifier.fillMaxSize()) {
     items(expense.names) { userName ->
       Box(modifier = Modifier.fillMaxWidth().height(80.dp).padding(horizontal = 15.dp)) {
@@ -233,7 +233,7 @@ fun ExpenseParticipantsInfo(expense: Expense, currencySmybol: String) {
           Text(
               text =
                   String.format(
-                      "%.2f $currencySmybol", expense.amount / expense.participantsIds.size),
+                      "%.2f $currencySymbol", expense.amount / expense.participantsIds.size),
               style = MaterialTheme.typography.bodyLarge)
         }
       }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/Finance.kt
@@ -70,8 +70,8 @@ fun Finance(financeViewModel: FinanceViewModel, navigationActions: NavigationAct
   val tripCurrency by financeViewModel.tripCurrency.collectAsState()
 
   LaunchedEffect(Unit) {
-    financeViewModel.updateStateLists()
     financeViewModel.loadMembers(navigationActions.variables.currentTrip)
+    financeViewModel.updateStateLists()
   }
 
   Scaffold(

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
@@ -132,7 +132,7 @@ class SuggestionsViewModelTest {
 
     coEvery { mockTripsRepository.addStopToTrip(any(), any()) } returns true
     coEvery { mockTripsRepository.removeSuggestionFromTrip(any(), any()) } returns true
-      coEvery { mockTripsRepository.getUserFromTrip(tripId, any()) } returns user1
+    coEvery { mockTripsRepository.getUserFromTrip(tripId, any()) } returns user1
   }
 
   // Example test for loading suggestions
@@ -179,7 +179,8 @@ class SuggestionsViewModelTest {
         advanceUntilIdle()
 
         // Assert the new comment is included and the comments count is correct
-        assertTrue(viewModel.state.value.first().comments.contains(newComment.copy(userName = "John Doe")))
+        assertTrue(
+            viewModel.state.value.first().comments.contains(newComment.copy(userName = "John Doe")))
         assertEquals(suggestion.comments.size + 1, viewModel.state.value.first().comments.size)
       }
 

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
@@ -132,6 +132,7 @@ class SuggestionsViewModelTest {
 
     coEvery { mockTripsRepository.addStopToTrip(any(), any()) } returns true
     coEvery { mockTripsRepository.removeSuggestionFromTrip(any(), any()) } returns true
+      coEvery { mockTripsRepository.getUserFromTrip(tripId, any()) } returns user1
   }
 
   // Example test for loading suggestions
@@ -178,7 +179,7 @@ class SuggestionsViewModelTest {
         advanceUntilIdle()
 
         // Assert the new comment is included and the comments count is correct
-        assertTrue(viewModel.state.value.first().comments.contains(newComment))
+        assertTrue(viewModel.state.value.first().comments.contains(newComment.copy(userName = "John Doe")))
         assertEquals(suggestion.comments.size + 1, viewModel.state.value.first().comments.size)
       }
 


### PR DESCRIPTION
In this PR :
- The new name entered by the user is now displayed in other screens.
- The corresponding composables must be loaded once to for the name fields to be updated on the trip repository.
- Once updated on the repo other users will see the new name. 