### PR TITLE
Fix UI bug display in Overview

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTextInput
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers
@@ -476,11 +477,13 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
   }
 
   @Test
-  fun tripTitleDoesntOverFlowStartAndEndDate() = run {
+  fun tripTitleDoesNotOverFlowStartAndEndDate() = run {
 
 
-      overviewViewModelTest.state.value.forEach{trip ->
-
+      overviewViewModelTest.state.value.forEachIndexed{index,trip ->
+        composeTestRule
+          .onNodeWithTag("overviewLazyColumn")
+          .performScrollToIndex(index)
 
         composeTestRule.onNodeWithTag("tripTitle${trip.tripId}", useUnmergedTree = true)
           .assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
@@ -1,6 +1,7 @@
 package com.github.se.wanderpals.overview
 
 import android.content.Intent
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -473,4 +474,23 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
       overviewScreen { assertIsDisplayed() }
     }
   }
+
+  @Test
+  fun tripTitleDoesntOverFlowStartAndEndDate() = run {
+
+
+      overviewViewModelTest.state.value.forEach{trip ->
+
+
+        composeTestRule.onNodeWithTag("tripTitle${trip.tripId}", useUnmergedTree = true)
+          .assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("startDate${trip.tripId}", useUnmergedTree = true)
+          .assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("endDate${trip.tripId}", useUnmergedTree = true)
+          .assertIsDisplayed()
+      }
+  }
+
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/overview/OverviewTest.kt
@@ -478,22 +478,20 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
 
   @Test
   fun tripTitleDoesNotOverFlowStartAndEndDate() = run {
+    overviewViewModelTest.state.value.forEachIndexed { index, trip ->
+      composeTestRule.onNodeWithTag("overviewLazyColumn").performScrollToIndex(index)
 
-
-      overviewViewModelTest.state.value.forEachIndexed{index,trip ->
-        composeTestRule
-          .onNodeWithTag("overviewLazyColumn")
-          .performScrollToIndex(index)
-
-        composeTestRule.onNodeWithTag("tripTitle${trip.tripId}", useUnmergedTree = true)
+      composeTestRule
+          .onNodeWithTag("tripTitle${trip.tripId}", useUnmergedTree = true)
           .assertIsDisplayed()
 
-        composeTestRule.onNodeWithTag("startDate${trip.tripId}", useUnmergedTree = true)
+      composeTestRule
+          .onNodeWithTag("startDate${trip.tripId}", useUnmergedTree = true)
           .assertIsDisplayed()
 
-        composeTestRule.onNodeWithTag("endDate${trip.tripId}", useUnmergedTree = true)
+      composeTestRule
+          .onNodeWithTag("endDate${trip.tripId}", useUnmergedTree = true)
           .assertIsDisplayed()
-      }
+    }
   }
-
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
@@ -124,17 +124,16 @@ fun OverviewContent(
         val lazyColumn =
             @Composable {
               LazyColumn(
-                  Modifier
-                      .padding(top = 10.dp, bottom = 20.dp)
+                  Modifier.padding(top = 10.dp, bottom = 20.dp)
                       .fillMaxSize()
                       .testTag("overviewLazyColumn")) {
-                items(filteredTripsByTitle) { trip ->
-                  OverviewTrip(
-                      trip = trip,
-                      navigationActions = navigationActions,
-                      overviewViewModel = overviewViewModel)
-                }
-              }
+                    items(filteredTripsByTitle) { trip ->
+                      OverviewTrip(
+                          trip = trip,
+                          navigationActions = navigationActions,
+                          overviewViewModel = overviewViewModel)
+                    }
+                  }
             }
         PullToRefreshLazyColumn(
             inputLazyColumn = lazyColumn, onRefresh = { overviewViewModel.getAllTrips() })

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewContent.kt
@@ -123,7 +123,11 @@ fun OverviewContent(
         // LazyColumn to display the list of trips
         val lazyColumn =
             @Composable {
-              LazyColumn(Modifier.padding(top = 10.dp, bottom = 20.dp).fillMaxSize()) {
+              LazyColumn(
+                  Modifier
+                      .padding(top = 10.dp, bottom = 20.dp)
+                      .fillMaxSize()
+                      .testTag("overviewLazyColumn")) {
                 items(filteredTripsByTitle) { trip ->
                   OverviewTrip(
                       trip = trip,

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -248,9 +248,8 @@ fun OverviewTrip(
                               .padding(top = 4.dp)
                               .testTag(
                                   "startDate" +
-                                      trip
-                                          .tripId), // the padding is for having the text on the
-                                                    // same
+                                      trip.tripId), // the padding is for having the text on the
+                      // same
                       // line and in the same height as the trip title
                       style =
                           TextStyle(
@@ -272,9 +271,8 @@ fun OverviewTrip(
                               .padding(top = 4.dp)
                               .testTag(
                                   "endDate" +
-                                      trip
-                                          .tripId), // the padding is for having the text on the
-                                                    // same
+                                      trip.tripId), // the padding is for having the text on the
+                      // same
                       // line and in the same height as the trip title
                       style =
                           TextStyle(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -230,7 +230,11 @@ fun OverviewTrip(
                   // Trip title
                   Text(
                       text = trip.title,
-                      modifier = Modifier.fillMaxWidth().weight(1f).height(24.dp),
+                      modifier = Modifier
+                          .fillMaxWidth()
+                          .weight(1f)
+                          .height(24.dp)
+                          .testTag("tripTitle" + trip.tripId),
                       style =
                           TextStyle(
                               fontSize = 18.sp,
@@ -249,9 +253,10 @@ fun OverviewTrip(
                   Text(
                       text = trip.startDate.format(DateTimeFormatter.ofPattern(datePattern)),
                       modifier =
-                          Modifier.height(24.dp)
-                              .padding(
-                                  top = 4.dp), // the padding is for having the text on the same
+                          Modifier
+                              .height(24.dp)
+                              .padding(top = 4.dp)
+                              .testTag("startDate"+trip.tripId), // the padding is for having the text on the same
                       // line and in the same height as the trip title
                       style =
                           TextStyle(
@@ -269,9 +274,10 @@ fun OverviewTrip(
                   Text(
                       text = trip.endDate.format(DateTimeFormatter.ofPattern(datePattern)),
                       modifier =
-                          Modifier.height(24.dp)
-                              .padding(
-                                  top = 4.dp), // the padding is for having the text on the same
+                          Modifier
+                              .height(24.dp)
+                              .padding(top = 4.dp)
+                              .testTag("endDate"+trip.tripId), // the padding is for having the text on the same
                       // line and in the same height as the trip title
                       style =
                           TextStyle(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -224,12 +224,13 @@ fun OverviewTrip(
                         .padding(
                             top = 12.dp,
                             start = 16.dp,
-                            end = 16.dp) // Ensure padding for visual spacing
+                            end = 16.dp) ,
+                // Ensure padding for visual spacing
                 ) {
                   // Trip title
                   Text(
                       text = trip.title,
-                      modifier = Modifier.height(24.dp),
+                      modifier = Modifier.fillMaxWidth().weight(1f).height(24.dp),
                       style =
                           TextStyle(
                               fontSize = 18.sp,
@@ -242,7 +243,7 @@ fun OverviewTrip(
                       overflow = TextOverflow.Ellipsis,
                       maxLines = 1)
 
-                  Spacer(Modifier.weight(1f))
+                  Spacer(Modifier.weight(0.1f))
 
                   // Start date
                   Text(

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -346,7 +346,7 @@ fun OverviewTrip(
                           selectedIconButton.value = SelectedIconButton.DOCUMENT
                           displayedTheBoxSelector = true
                          },
-                      modifier = Modifier.width(24.dp).height(28.dp)) {
+                      modifier = Modifier.width(24.dp).height(28.dp).testTag("documentButton")) {
                         Icon(
                             imageVector = Icons.Default.Edit,
                             contentDescription = null,

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -205,7 +205,10 @@ fun OverviewTrip(
           CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)) {
         Box(modifier = Modifier.fillMaxSize()) {
           // Column containing trip information
-          Column(modifier = Modifier.fillMaxSize()) {
+          Column(
+              modifier = Modifier.fillMaxSize(),
+              verticalArrangement = Arrangement.SpaceBetween
+              ) {
             Row(
                 modifier =
                     Modifier.fillMaxWidth()
@@ -275,7 +278,7 @@ fun OverviewTrip(
             Row(
                 modifier =
                     Modifier.fillMaxWidth() // Ensure padding for visual spacing
-                        .padding(start = 16.dp, end = 16.dp)) {
+                        .padding(start = 16.dp, end = 16.dp,bottom = 16.dp)) {
                   Spacer(Modifier.weight(0.9f)) // Pushes the icon to the end
 
                   // Share trip code button

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -109,6 +109,20 @@ fun Context.sendTripCodeIntent(tripId: String, address: String) {
 }
 
 /**
+ * Enum class representing the state of the currently selected icon button in the UI.
+ *
+ * This enum is used to track which icon button is currently selected or pressed
+ * in the `OverviewTrip` composable function. It helps manage the visual feedback
+ * and actions associated with each button.
+ */
+private enum class SelectedIconButton {
+    NONE,
+    SEND,
+    SHARE,
+    DOCUMENT
+}
+
+/**
  * Composable function that represents an overview of a trip. Displays basic trip information such
  * as title, start date, and end date.
  *
@@ -122,15 +136,16 @@ fun OverviewTrip(
     overviewViewModel: OverviewViewModel
 ) {
 
+
   // Date pattern for formatting start and end dates
   val datePattern = "dd/MM/yyyy"
 
   // Local context
   val context = LocalContext.current
 
-  // Mutable state to check if the icon button for sharing the trip is selected
-  val isSelected = remember { mutableStateOf(false) }
-  val isEmailSelected = remember { mutableStateOf(false) }
+  // Mutable state to check which button is selected
+  val selectedIconButton = remember { mutableStateOf(SelectedIconButton.NONE) }
+
 
   // Mutable state to check if the dialog is open
   var dialogIsOpen by remember { mutableStateOf(false) }
@@ -145,19 +160,13 @@ fun OverviewTrip(
           onResult = { uri -> selectedImagesLocal = uri })
 
   // Use of a launch effect to reset the value of isSelected to false after 100ms
-  LaunchedEffect(isSelected.value) {
-    if (isSelected.value) {
+  LaunchedEffect(selectedIconButton.value) {
+    if (selectedIconButton.value != SelectedIconButton.NONE) {
       delay(100)
-      isSelected.value = false
+      selectedIconButton.value = SelectedIconButton.NONE
     }
   }
 
-  LaunchedEffect(isEmailSelected.value) {
-    if (isEmailSelected.value) {
-      delay(100)
-      isEmailSelected.value = false
-    }
-  }
 
   if (dialogIsOpenEmail) {
     DialogHandlerEmail(
@@ -281,14 +290,14 @@ fun OverviewTrip(
                         .padding(start = 16.dp, end = 16.dp,bottom = 16.dp)) {
                   Spacer(Modifier.weight(0.9f)) // Pushes the icon to the end
 
-                  // Share trip code button
+                  // Send trip code button
                   IconButton(
                       modifier =
                           Modifier.width(24.dp)
                               .height(28.dp)
                               .testTag("sendTripButton" + trip.tripId),
                       onClick = {
-                        isEmailSelected.value = true
+                        selectedIconButton.value = SelectedIconButton.SEND
                         dialogIsOpenEmail = true
                       }) {
                         Icon(
@@ -297,7 +306,7 @@ fun OverviewTrip(
                             tint = MaterialTheme.colorScheme.onSecondaryContainer,
                             modifier =
                                 Modifier.background(
-                                    if (isEmailSelected.value) Color.LightGray
+                                    if (selectedIconButton.value == SelectedIconButton.SEND) Color.LightGray
                                     else Color.Transparent))
                       }
 
@@ -310,7 +319,7 @@ fun OverviewTrip(
                               .height(28.dp)
                               .testTag("shareTripButton" + trip.tripId),
                       onClick = {
-                        isSelected.value = true
+                        selectedIconButton.value = SelectedIconButton.SHARE
                         context.shareTripCodeIntent(trip.tripId)
                       }) {
                         Icon(
@@ -319,11 +328,17 @@ fun OverviewTrip(
                             tint = MaterialTheme.colorScheme.onSecondaryContainer,
                             modifier =
                                 Modifier.background(
-                                    if (isSelected.value) Color.LightGray else Color.Transparent))
+                                    if (selectedIconButton.value == SelectedIconButton.SHARE)
+                                        Color.LightGray
+                                    else Color.Transparent)
+                        )
                       }
                   Spacer(Modifier.width(10.dp))
                   IconButton(
-                      onClick = { displayedTheBoxSelector = true },
+                      onClick = {
+                          selectedIconButton.value = SelectedIconButton.DOCUMENT
+                          displayedTheBoxSelector = true
+                         },
                       modifier = Modifier.width(24.dp).height(28.dp)) {
                         Icon(
                             imageVector = Icons.Default.Edit,
@@ -331,7 +346,10 @@ fun OverviewTrip(
                             tint = MaterialTheme.colorScheme.onSecondaryContainer,
                             modifier =
                                 Modifier.background(
-                                    if (isSelected.value) Color.LightGray else Color.Transparent))
+                                    if (selectedIconButton.value == SelectedIconButton.DOCUMENT)
+                                        Color.LightGray
+                                    else Color.Transparent)
+                        )
                       }
                 }
           }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/overview/OverviewTrip.kt
@@ -111,15 +111,15 @@ fun Context.sendTripCodeIntent(tripId: String, address: String) {
 /**
  * Enum class representing the state of the currently selected icon button in the UI.
  *
- * This enum is used to track which icon button is currently selected or pressed
- * in the `OverviewTrip` composable function. It helps manage the visual feedback
- * and actions associated with each button.
+ * This enum is used to track which icon button is currently selected or pressed in the
+ * `OverviewTrip` composable function. It helps manage the visual feedback and actions associated
+ * with each button.
  */
 private enum class SelectedIconButton {
-    NONE,
-    SEND,
-    SHARE,
-    DOCUMENT
+  NONE,
+  SEND,
+  SHARE,
+  DOCUMENT
 }
 
 /**
@@ -136,7 +136,6 @@ fun OverviewTrip(
     overviewViewModel: OverviewViewModel
 ) {
 
-
   // Date pattern for formatting start and end dates
   val datePattern = "dd/MM/yyyy"
 
@@ -145,7 +144,6 @@ fun OverviewTrip(
 
   // Mutable state to check which button is selected
   val selectedIconButton = remember { mutableStateOf(SelectedIconButton.NONE) }
-
 
   // Mutable state to check if the dialog is open
   var dialogIsOpen by remember { mutableStateOf(false) }
@@ -166,7 +164,6 @@ fun OverviewTrip(
       selectedIconButton.value = SelectedIconButton.NONE
     }
   }
-
 
   if (dialogIsOpenEmail) {
     DialogHandlerEmail(
@@ -215,26 +212,20 @@ fun OverviewTrip(
         Box(modifier = Modifier.fillMaxSize()) {
           // Column containing trip information
           Column(
-              modifier = Modifier.fillMaxSize(),
-              verticalArrangement = Arrangement.SpaceBetween
-              ) {
-            Row(
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .padding(
-                            top = 12.dp,
-                            start = 16.dp,
-                            end = 16.dp) ,
-                // Ensure padding for visual spacing
+              modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.SpaceBetween) {
+                Row(
+                    modifier =
+                        Modifier.fillMaxWidth().padding(top = 12.dp, start = 16.dp, end = 16.dp),
+                    // Ensure padding for visual spacing
                 ) {
                   // Trip title
                   Text(
                       text = trip.title,
-                      modifier = Modifier
-                          .fillMaxWidth()
-                          .weight(1f)
-                          .height(24.dp)
-                          .testTag("tripTitle" + trip.tripId),
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .weight(1f)
+                              .height(24.dp)
+                              .testTag("tripTitle" + trip.tripId),
                       style =
                           TextStyle(
                               fontSize = 18.sp,
@@ -253,10 +244,13 @@ fun OverviewTrip(
                   Text(
                       text = trip.startDate.format(DateTimeFormatter.ofPattern(datePattern)),
                       modifier =
-                          Modifier
-                              .height(24.dp)
+                          Modifier.height(24.dp)
                               .padding(top = 4.dp)
-                              .testTag("startDate"+trip.tripId), // the padding is for having the text on the same
+                              .testTag(
+                                  "startDate" +
+                                      trip
+                                          .tripId), // the padding is for having the text on the
+                                                    // same
                       // line and in the same height as the trip title
                       style =
                           TextStyle(
@@ -274,10 +268,13 @@ fun OverviewTrip(
                   Text(
                       text = trip.endDate.format(DateTimeFormatter.ofPattern(datePattern)),
                       modifier =
-                          Modifier
-                              .height(24.dp)
+                          Modifier.height(24.dp)
                               .padding(top = 4.dp)
-                              .testTag("endDate"+trip.tripId), // the padding is for having the text on the same
+                              .testTag(
+                                  "endDate" +
+                                      trip
+                                          .tripId), // the padding is for having the text on the
+                                                    // same
                       // line and in the same height as the trip title
                       style =
                           TextStyle(
@@ -290,76 +287,76 @@ fun OverviewTrip(
                       textAlign = TextAlign.End)
                 }
 
-            Spacer(Modifier.height(20.dp))
-            Row(
-                modifier =
-                    Modifier.fillMaxWidth() // Ensure padding for visual spacing
-                        .padding(start = 16.dp, end = 16.dp,bottom = 16.dp)) {
-                  Spacer(Modifier.weight(0.9f)) // Pushes the icon to the end
+                Spacer(Modifier.height(20.dp))
+                Row(
+                    modifier =
+                        Modifier.fillMaxWidth() // Ensure padding for visual spacing
+                            .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)) {
+                      Spacer(Modifier.weight(0.9f)) // Pushes the icon to the end
 
-                  // Send trip code button
-                  IconButton(
-                      modifier =
-                          Modifier.width(24.dp)
-                              .height(28.dp)
-                              .testTag("sendTripButton" + trip.tripId),
-                      onClick = {
-                        selectedIconButton.value = SelectedIconButton.SEND
-                        dialogIsOpenEmail = true
-                      }) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.Send,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                            modifier =
-                                Modifier.background(
-                                    if (selectedIconButton.value == SelectedIconButton.SEND) Color.LightGray
-                                    else Color.Transparent))
-                      }
+                      // Send trip code button
+                      IconButton(
+                          modifier =
+                              Modifier.width(24.dp)
+                                  .height(28.dp)
+                                  .testTag("sendTripButton" + trip.tripId),
+                          onClick = {
+                            selectedIconButton.value = SelectedIconButton.SEND
+                            dialogIsOpenEmail = true
+                          }) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.Send,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                modifier =
+                                    Modifier.background(
+                                        if (selectedIconButton.value == SelectedIconButton.SEND)
+                                            Color.LightGray
+                                        else Color.Transparent))
+                          }
 
-                  Spacer(Modifier.width(10.dp))
+                      Spacer(Modifier.width(10.dp))
 
-                  // Share trip code button
-                  IconButton(
-                      modifier =
-                          Modifier.width(24.dp)
-                              .height(28.dp)
-                              .testTag("shareTripButton" + trip.tripId),
-                      onClick = {
-                        selectedIconButton.value = SelectedIconButton.SHARE
-                        context.shareTripCodeIntent(trip.tripId)
-                      }) {
-                        Icon(
-                            imageVector = Icons.Default.Share,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                            modifier =
-                                Modifier.background(
-                                    if (selectedIconButton.value == SelectedIconButton.SHARE)
-                                        Color.LightGray
-                                    else Color.Transparent)
-                        )
-                      }
-                  Spacer(Modifier.width(10.dp))
-                  IconButton(
-                      onClick = {
-                          selectedIconButton.value = SelectedIconButton.DOCUMENT
-                          displayedTheBoxSelector = true
-                         },
-                      modifier = Modifier.width(24.dp).height(28.dp).testTag("documentButton")) {
-                        Icon(
-                            imageVector = Icons.Default.Edit,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                            modifier =
-                                Modifier.background(
-                                    if (selectedIconButton.value == SelectedIconButton.DOCUMENT)
-                                        Color.LightGray
-                                    else Color.Transparent)
-                        )
-                      }
-                }
-          }
+                      // Share trip code button
+                      IconButton(
+                          modifier =
+                              Modifier.width(24.dp)
+                                  .height(28.dp)
+                                  .testTag("shareTripButton" + trip.tripId),
+                          onClick = {
+                            selectedIconButton.value = SelectedIconButton.SHARE
+                            context.shareTripCodeIntent(trip.tripId)
+                          }) {
+                            Icon(
+                                imageVector = Icons.Default.Share,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                modifier =
+                                    Modifier.background(
+                                        if (selectedIconButton.value == SelectedIconButton.SHARE)
+                                            Color.LightGray
+                                        else Color.Transparent))
+                          }
+                      Spacer(Modifier.width(10.dp))
+                      IconButton(
+                          onClick = {
+                            selectedIconButton.value = SelectedIconButton.DOCUMENT
+                            displayedTheBoxSelector = true
+                          },
+                          modifier =
+                              Modifier.width(24.dp).height(28.dp).testTag("documentButton")) {
+                            Icon(
+                                imageVector = Icons.Default.Edit,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                modifier =
+                                    Modifier.background(
+                                        if (selectedIconButton.value == SelectedIconButton.DOCUMENT)
+                                            Color.LightGray
+                                        else Color.Transparent))
+                          }
+                    }
+              }
         }
       }
   if (displayedTheBoxSelector) {


### PR DESCRIPTION
The goal of this PR was to fix 2 UI bugs in the overview :
- If the trip title was too long, it was moving the start and end date outside of the overview trip Card and was hiding them.
- When clicking on send,share or document icon button of the overview, a small visual effect was triggered. However when clicking on the share icon button, the effect was also triggered for the document button.

All of theses bugs have been fixed in this PR. Also a test has been added to check that trip title is handled correctly when it is too long (i.e. when it overflows)