### PR TITLE
Agenda markers; add calendar trip range background; refactor markers related part of the code

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/agenda/AgendaTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/agenda/AgendaTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.wanderpals.model.data.Stop
+import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.AgendaViewModel
 import com.github.se.wanderpals.ui.screens.trip.agenda.Agenda
@@ -97,6 +98,24 @@ class FakeAgendaViewModel(
                     it.copy(stopStatus = status)
                   } else it
                 })
+  }
+
+  /**
+   * Simulates loading trip data into the ViewModel.
+   *
+   * @param startDate The start date of the trip.
+   * @param endDate The end date of the trip.
+   */
+  fun loadTripData(startDate: LocalDate, endDate: LocalDate) {
+    val testTrip =
+        Trip(
+            tripId = "testTripId",
+            title = "Test Trip",
+            startDate = startDate,
+            endDate = endDate,
+            totalBudget = 1000.0,
+            description = "Test Trip Description")
+    _trip.value = testTrip
   }
 }
 
@@ -253,10 +272,20 @@ class AgendaTest {
 
   /** Test to verify that the marker with "ADDED" stop status exists and is displayed. */
   @Test
-  fun calendarDateWithAddedStatusShowsMarker() {
+  fun calendarDateWithCurrentStatusShowsMarker() {
     val testYearMonth = YearMonth.of(2024, 5)
     val testDate = LocalDate.of(2024, 5, 5)
     val fakeViewModel = FakeAgendaViewModel(testYearMonth, emptyList())
+
+    // Create a Trip object to pass as the trip parameter
+    val testTrip =
+        Trip(
+            tripId = "testTripId",
+            title = "Test Trip",
+            startDate = LocalDate.of(2024, 5, 1),
+            endDate = LocalDate.of(2024, 5, 31),
+            totalBudget = 1000.0,
+            description = "Test Trip Description")
 
     // Simulate adding a stop with ADDED status on May 5, 2024
     fakeViewModel.simulateStopStatusChange(testDate, CalendarUiState.StopStatus.CURRENT)
@@ -277,22 +306,119 @@ class AgendaTest {
           onPreviousMonthButtonClicked = {},
           onNextMonthButtonClicked = {},
           onDateClickListener = {},
-      )
+          trip = testTrip)
     }
 
-    // Find the marker and assert it's displayed on the screen because the stop status is "ADDED"
-    composeTestRule.onNodeWithTag("MarkerADDED", useUnmergedTree = true).assertExists()
-    composeTestRule.onNodeWithTag("MarkerADDED", useUnmergedTree = true).assertIsDisplayed()
+    // Find the marker and assert it's displayed on the screen because the stop status is "CURRENT"
+    composeTestRule.onNodeWithTag("MarkerCURRENT", useUnmergedTree = true).assertExists()
+    composeTestRule.onNodeWithTag("MarkerCURRENT", useUnmergedTree = true).assertIsDisplayed()
   }
 
-  /**
-   * Test to verify that the marker with "ADDED" stop status does not exist and is not displayed.
-   */
+  /** Test to verify that the marker with "COMING_SOON" stop status exists and is displayed. */
   @Test
-  fun calendarDateWithNoAddedStatusShowsNoMarker() {
+  fun calendarDateWithComingSoonStatusShowsMarker() {
     val testYearMonth = YearMonth.of(2024, 5)
-    val testDate = LocalDate.of(2024, 5, 6)
+    val testDate = LocalDate.of(2024, 5, 21)
     val fakeViewModel = FakeAgendaViewModel(testYearMonth, emptyList())
+
+    // Create a Trip object to pass as the trip parameter
+    val testTrip =
+        Trip(
+            tripId = "testTripId",
+            title = "Test Trip",
+            startDate = LocalDate.of(2024, 5, 1),
+            endDate = LocalDate.of(2024, 5, 31),
+            totalBudget = 1000.0,
+            description = "Test Trip Description")
+
+    // Simulate adding a stop with COMING_SOON status on May 21, 2024
+    fakeViewModel.simulateStopStatusChange(testDate, CalendarUiState.StopStatus.COMING_SOON)
+
+    // Set up the environment for the test
+    composeTestRule.setContent {
+      CalendarWidget(
+          days = arrayOf("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"),
+          yearMonth = testYearMonth,
+          dates =
+              listOf(
+                  CalendarUiState.Date(
+                      "21",
+                      testYearMonth.withMonth(5),
+                      year = Year.of(2024),
+                      isSelected = false,
+                      stopStatus = CalendarUiState.StopStatus.COMING_SOON)),
+          onPreviousMonthButtonClicked = {},
+          onNextMonthButtonClicked = {},
+          onDateClickListener = {},
+          trip = testTrip)
+    }
+
+    // Find the marker and assert it's displayed on the screen because the stop status is
+    // "COMING_SOON"
+    composeTestRule.onNodeWithTag("MarkerCOMING_SOON", useUnmergedTree = true).assertExists()
+    composeTestRule.onNodeWithTag("MarkerCOMING_SOON", useUnmergedTree = true).assertIsDisplayed()
+  }
+
+  /** Test to verify that the marker with "PAST" stop status exists and is displayed. */
+  @Test
+  fun calendarDateWithPastStatusShowsMarker() {
+    val testYearMonth = YearMonth.of(2024, 5)
+    val testDate = LocalDate.of(2024, 5, 19)
+    val fakeViewModel = FakeAgendaViewModel(testYearMonth, emptyList())
+
+    // Create a Trip object to pass as the trip parameter
+    val testTrip =
+        Trip(
+            tripId = "testTripId",
+            title = "Test Trip",
+            startDate = LocalDate.of(2024, 5, 1),
+            endDate = LocalDate.of(2024, 5, 31),
+            totalBudget = 1000.0,
+            description = "Test Trip Description")
+
+    // Simulate adding a stop with PAST status on May 19, 2024
+    fakeViewModel.simulateStopStatusChange(testDate, CalendarUiState.StopStatus.PAST)
+
+    // Set up the environment for the test
+    composeTestRule.setContent {
+      CalendarWidget(
+          days = arrayOf("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"),
+          yearMonth = testYearMonth,
+          dates =
+              listOf(
+                  CalendarUiState.Date(
+                      "19",
+                      testYearMonth.withMonth(5),
+                      year = Year.of(2024),
+                      isSelected = false,
+                      stopStatus = CalendarUiState.StopStatus.PAST)),
+          onPreviousMonthButtonClicked = {},
+          onNextMonthButtonClicked = {},
+          onDateClickListener = {},
+          trip = testTrip)
+    }
+
+    // Find the marker and assert it's displayed on the screen because the stop status is "PAST"
+    composeTestRule.onNodeWithTag("MarkerPAST", useUnmergedTree = true).assertExists()
+    composeTestRule.onNodeWithTag("MarkerPAST", useUnmergedTree = true).assertIsDisplayed()
+  }
+
+  /** Test to verify that the marker with "NONE" stop status does not exist and is not displayed. */
+  @Test
+  fun calendarDateWithNoStopStatusShowsNoMarker() {
+    val testYearMonth = YearMonth.of(2024, 5)
+    val testDate = LocalDate.of(2024, 5, 22)
+    val fakeViewModel = FakeAgendaViewModel(testYearMonth, emptyList())
+
+    // Create a Trip object to pass as the trip parameter
+    val testTrip =
+        Trip(
+            tripId = "testTripId",
+            title = "Test Trip",
+            startDate = LocalDate.of(2024, 5, 1),
+            endDate = LocalDate.of(2024, 5, 31),
+            totalBudget = 1000.0,
+            description = "Test Trip Description")
 
     // Ensure the status is NONE for the test date
     fakeViewModel.simulateStopStatusChange(testDate, CalendarUiState.StopStatus.NONE)
@@ -305,18 +431,60 @@ class AgendaTest {
           dates =
               listOf(
                   CalendarUiState.Date(
-                      "6",
+                      "22",
                       testYearMonth.withMonth(5),
                       year = Year.of(2024),
                       isSelected = false,
                       stopStatus = CalendarUiState.StopStatus.NONE)),
           onPreviousMonthButtonClicked = {},
           onNextMonthButtonClicked = {},
-          onDateClickListener = {})
+          onDateClickListener = {},
+          trip = testTrip)
     }
 
-    // Assert that the marker with "ADDED" status is not displayed because the stop status is "NONE"
-    composeTestRule.onNodeWithTag("MarkerADDED", useUnmergedTree = true).assertDoesNotExist()
-    composeTestRule.onNodeWithTag("MarkerADDED", useUnmergedTree = true).isNotDisplayed()
+    // Assert that the marker with "NONE" status is not displayed because the stop status is "NONE"
+    composeTestRule.onNodeWithTag("MarkerNONE", useUnmergedTree = true).assertDoesNotExist()
+    composeTestRule.onNodeWithTag("MarkerNONE", useUnmergedTree = true).isNotDisplayed()
+  }
+
+  /** Test to verify that the continuous background for the trip range is displayed correctly. */
+  @Test
+  fun calendarTripRangeBackgroundIsDisplayed() {
+    val testYearMonth = YearMonth.of(2024, 5)
+    val tripStartDate = LocalDate.of(2024, 5, 15)
+    val tripEndDate = LocalDate.of(2024, 5, 24)
+    val fakeViewModel = FakeAgendaViewModel(testYearMonth, emptyList())
+
+    // Simulate the trip data
+    fakeViewModel.loadTripData(tripStartDate, tripEndDate)
+
+    // Set up the environment for the test
+    composeTestRule.setContent {
+      CalendarWidget(
+          days = arrayOf("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"),
+          yearMonth = testYearMonth,
+          dates =
+              (1..31).map {
+                CalendarUiState.Date(
+                    it.toString(),
+                    testYearMonth,
+                    Year.of(2024),
+                    isSelected = false,
+                    stopStatus = CalendarUiState.StopStatus.NONE)
+              },
+          onPreviousMonthButtonClicked = {},
+          onNextMonthButtonClicked = {},
+          onDateClickListener = {},
+          trip = fakeViewModel.trip.value,
+      )
+    }
+
+    // Assert that the continuous background for the trip range is displayed correctly
+    (15..24).forEach {
+      composeTestRule
+          .onNodeWithTag("DateBackground_$it", useUnmergedTree = true)
+          .assertExists()
+          .assertIsDisplayed()
+    }
   }
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/agenda/AgendaTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/agenda/AgendaTest.kt
@@ -259,7 +259,7 @@ class AgendaTest {
     val fakeViewModel = FakeAgendaViewModel(testYearMonth, emptyList())
 
     // Simulate adding a stop with ADDED status on May 5, 2024
-    fakeViewModel.simulateStopStatusChange(testDate, CalendarUiState.StopStatus.ADDED)
+    fakeViewModel.simulateStopStatusChange(testDate, CalendarUiState.StopStatus.CURRENT)
 
     // Set up the environment for the test
     composeTestRule.setContent {
@@ -273,7 +273,7 @@ class AgendaTest {
                       testYearMonth.withMonth(5),
                       year = Year.of(2024),
                       isSelected = false,
-                      stopStatus = CalendarUiState.StopStatus.ADDED)),
+                      stopStatus = CalendarUiState.StopStatus.CURRENT)),
           onPreviousMonthButtonClicked = {},
           onNextMonthButtonClicked = {},
           onDateClickListener = {},

--- a/app/src/androidTest/java/com/github/se/wanderpals/suggestion/SuggestionHistoryFeedContentTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/suggestion/SuggestionHistoryFeedContentTest.kt
@@ -60,7 +60,7 @@ class SuggestionHistoryFeedContentTest {
             title = "First Stop",
             description = "Description for first stop",
             geoCords = GeoCords(37.7749, -122.4194),
-            stopStatus = CalendarUiState.StopStatus.ADDED)
+            stopStatus = CalendarUiState.StopStatus.CURRENT)
 
     val stop2 =
         Stop(
@@ -68,7 +68,7 @@ class SuggestionHistoryFeedContentTest {
             title = "Second Stop",
             description = "Description for second stop",
             geoCords = GeoCords(40.7128, -74.0060),
-            stopStatus = CalendarUiState.StopStatus.ADDED)
+            stopStatus = CalendarUiState.StopStatus.CURRENT)
 
     suggestionList =
         listOf(
@@ -154,7 +154,7 @@ class SuggestionHistoryFeedContentTest {
             date = LocalDate.of(2024, 4, 16),
             startTime = LocalTime.of(12, 0),
             duration = 60,
-            stopStatus = CalendarUiState.StopStatus.ADDED)
+            stopStatus = CalendarUiState.StopStatus.CURRENT)
 
     val suggestion =
         Suggestion(

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.launch
  * calendar view.
  *
  * @property tripId The identifier of the trip for which the agenda is being managed.
+ * @property tripsRepository The repository for accessing trip data.
  */
 open class AgendaViewModel(
   private val tripId: String,
@@ -45,6 +46,7 @@ open class AgendaViewModel(
   open var selectedDate: LocalDate? = LocalDate.now()
 
   open val _stopsInfo = MutableStateFlow<Map<LocalDate, CalendarUiState.StopStatus>>(emptyMap())
+
   private val _trip = MutableStateFlow(Trip(tripId, "", LocalDate.now(), LocalDate.now(), 0.0, ""))
   val trip: StateFlow<Trip> = _trip.asStateFlow()
 
@@ -56,8 +58,7 @@ open class AgendaViewModel(
     viewModelScope.launch { // after the data is loaded,
       // the stops info is loaded and the UI state is updated with the dates for the current month,
       // in a synchronous manner.
-      loadTripData()
-
+      loadTripData() // Load trip data when ViewModel initializes
       loadStopsInfo() // Load stops info when ViewModel initializes
 
       _uiState.update { currentState ->
@@ -69,6 +70,9 @@ open class AgendaViewModel(
     }
   }
 
+  /**
+   * Loads the trip data from the repository and updates the UI state with the trip information.
+   */
   private suspend fun loadTripData() {
     tripsRepository?.getTrip(tripId)?.let { trip ->
       _trip.value = trip
@@ -85,10 +89,6 @@ open class AgendaViewModel(
     // Create a map with the date of each stop and mark it as ADDED
     // Continue if the list is not empty
     if (stops.isNotEmpty()) {
-      //      val statusMap =
-      //          stops.associateBy(
-      //              keySelector = { it.date }, valueTransform = { CalendarUiState.StopStatus.ADDED
-      // })
       val statusMap =
         stops.associate { stop ->
           val status =

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
@@ -47,8 +47,9 @@ open class AgendaViewModel(
 
   open val _stopsInfo = MutableStateFlow<Map<LocalDate, CalendarUiState.StopStatus>>(emptyMap())
 
-  private val _trip = MutableStateFlow(Trip(tripId, "", LocalDate.now(), LocalDate.now(), 0.0, ""))
-  val trip: StateFlow<Trip> = _trip.asStateFlow()
+  protected val _trip =
+      MutableStateFlow(Trip(tripId, "", LocalDate.now(), LocalDate.now(), 0.0, ""))
+  open val trip: StateFlow<Trip> = _trip.asStateFlow()
 
   /**
    * Initializes the UI state of the agenda by fetching the dates for the current month and updating

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
@@ -70,13 +70,25 @@ open class AgendaViewModel(
     // Fetch all stops related to a specific trip from the repository
     val stops = tripsRepository?.getAllStopsFromTrip(tripId) ?: listOf()
 
+    val today = LocalDate.now()
+
     // Create a map with the date of each stop and mark it as ADDED
     // Continue if the list is not empty
     if (stops.isNotEmpty()) {
+      //      val statusMap =
+      //          stops.associateBy(
+      //              keySelector = { it.date }, valueTransform = { CalendarUiState.StopStatus.ADDED
+      // })
       val statusMap =
-          stops.associateBy(
-              keySelector = { it.date }, valueTransform = { CalendarUiState.StopStatus.ADDED })
-
+          stops.associate { stop ->
+            val status =
+                when {
+                  stop.date.isBefore(today) -> CalendarUiState.StopStatus.PAST
+                  stop.date.isAfter(today) -> CalendarUiState.StopStatus.COMING_SOON
+                  else -> CalendarUiState.StopStatus.CURRENT
+                }
+            stop.date to status
+          }
       _stopsInfo.value = statusMap
     }
   }

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
@@ -24,8 +24,8 @@ import kotlinx.coroutines.launch
  * @property tripsRepository The repository for accessing trip data.
  */
 open class AgendaViewModel(
-  private val tripId: String,
-  private val tripsRepository: TripsRepository?
+    private val tripId: String,
+    private val tripsRepository: TripsRepository?
 ) : ViewModel() {
 
   /** Lazily initialized data source for calendar data. */
@@ -63,20 +63,16 @@ open class AgendaViewModel(
 
       _uiState.update { currentState ->
         currentState.copy(
-          dates =
-          dataSource.getDates(
-            currentState.yearMonth, LocalDate.now(), stopsInfo = _stopsInfo.value))
+            dates =
+                dataSource.getDates(
+                    currentState.yearMonth, LocalDate.now(), stopsInfo = _stopsInfo.value))
       }
     }
   }
 
-  /**
-   * Loads the trip data from the repository and updates the UI state with the trip information.
-   */
+  /** Loads the trip data from the repository and updates the UI state with the trip information. */
   private suspend fun loadTripData() {
-    tripsRepository?.getTrip(tripId)?.let { trip ->
-      _trip.value = trip
-    }
+    tripsRepository?.getTrip(tripId)?.let { trip -> _trip.value = trip }
   }
   /** Loads the stops information for the trip, marking all existing stops as ADDED. */
   suspend fun loadStopsInfo() { // a suspend function is asynchronous and can be called from
@@ -90,15 +86,15 @@ open class AgendaViewModel(
     // Continue if the list is not empty
     if (stops.isNotEmpty()) {
       val statusMap =
-        stops.associate { stop ->
-          val status =
-            when {
-              stop.date.isBefore(today) -> CalendarUiState.StopStatus.PAST
-              stop.date.isAfter(today) -> CalendarUiState.StopStatus.COMING_SOON
-              else -> CalendarUiState.StopStatus.CURRENT
-            }
-          stop.date to status
-        }
+          stops.associate { stop ->
+            val status =
+                when {
+                  stop.date.isBefore(today) -> CalendarUiState.StopStatus.PAST
+                  stop.date.isAfter(today) -> CalendarUiState.StopStatus.COMING_SOON
+                  else -> CalendarUiState.StopStatus.CURRENT
+                }
+            stop.date to status
+          }
       _stopsInfo.value = statusMap
     }
   }
@@ -111,10 +107,10 @@ open class AgendaViewModel(
   fun onDateSelected(selectedDate: CalendarUiState.Date) {
     viewModelScope.launch {
       val selectedLocalDate =
-        LocalDate.of(
-          selectedDate.year.value,
-          selectedDate.yearMonth.month,
-          selectedDate.dayOfMonth.toInt())
+          LocalDate.of(
+              selectedDate.year.value,
+              selectedDate.yearMonth.month,
+              selectedDate.dayOfMonth.toInt())
 
       // Determine if the newly selected date is different from the current state's selected date.
       val isSameAsCurrentSelected = this@AgendaViewModel.selectedDate == selectedLocalDate
@@ -126,15 +122,15 @@ open class AgendaViewModel(
       // Now, update the UI state to reflect this change.
       _uiState.update { currentState ->
         val updatedDates =
-          currentState.dates.map { date ->
-            if (date.dayOfMonth == selectedDate.dayOfMonth) {
-              // Toggle the selection status of the date
-              selectedDate.copy(isSelected = !selectedDate.isSelected)
-            } else {
-              // If it's not the selected date, ensure it's not marked as selected
-              if (date.isSelected) date.copy(isSelected = false) else date
+            currentState.dates.map { date ->
+              if (date.dayOfMonth == selectedDate.dayOfMonth) {
+                // Toggle the selection status of the date
+                selectedDate.copy(isSelected = !selectedDate.isSelected)
+              } else {
+                // If it's not the selected date, ensure it's not marked as selected
+                if (date.isSelected) date.copy(isSelected = false) else date
+              }
             }
-          }
         currentState.copy(dates = updatedDates, selectedDate = newSelectedDate)
       }
     }
@@ -149,8 +145,8 @@ open class AgendaViewModel(
     viewModelScope.launch {
       _uiState.update { currentState ->
         currentState.copy(
-          yearMonth = nextMonth,
-          dates = dataSource.getDates(nextMonth, currentState.selectedDate, _stopsInfo.value))
+            yearMonth = nextMonth,
+            dates = dataSource.getDates(nextMonth, currentState.selectedDate, _stopsInfo.value))
       }
     }
   }
@@ -164,8 +160,8 @@ open class AgendaViewModel(
     viewModelScope.launch {
       _uiState.update { currentState ->
         currentState.copy(
-          yearMonth = prevMonth,
-          dates = dataSource.getDates(prevMonth, currentState.selectedDate, _stopsInfo.value))
+            yearMonth = prevMonth,
+            dates = dataSource.getDates(prevMonth, currentState.selectedDate, _stopsInfo.value))
       }
     }
   }
@@ -186,8 +182,8 @@ open class AgendaViewModel(
   }
 
   class AgendaViewModelFactory(
-    private val tripId: String,
-    private val tripsRepository: TripsRepository
+      private val tripId: String,
+      private val tripsRepository: TripsRepository
   ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/AgendaViewModel.kt
@@ -72,7 +72,7 @@ open class AgendaViewModel(
   }
 
   /** Loads the trip data from the repository and updates the UI state with the trip information. */
-  private suspend fun loadTripData() {
+  suspend fun loadTripData() {
     tripsRepository?.getTrip(tripId)?.let { trip -> _trip.value = trip }
   }
   /** Loads the stops information for the trip, marking all existing stops as ADDED. */

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SuggestionsViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/SuggestionsViewModel.kt
@@ -390,7 +390,7 @@ open class SuggestionsViewModel(
         val wasStopAdded = suggestionRepository?.addStopToTrip(tripId, suggestion.stop) ?: false
         if (wasStopAdded) {
           // Update suggestion with ADDED stopStatus
-          val updatedStop = suggestion.stop.copy(stopStatus = CalendarUiState.StopStatus.ADDED)
+          val updatedStop = suggestion.stop.copy(stopStatus = CalendarUiState.StopStatus.CURRENT)
           val updatedSuggestion = suggestion.copy(stop = updatedStop)
 
           // Update the state flow list to include this updated suggestion
@@ -464,7 +464,7 @@ open class SuggestionsViewModel(
       NotificationsManager.addStopNotification(tripId, suggestion.stop)
 
       // Update suggestion with ADDED stopStatus
-      val updatedStop = suggestion.stop.copy(stopStatus = CalendarUiState.StopStatus.ADDED)
+      val updatedStop = suggestion.stop.copy(stopStatus = CalendarUiState.StopStatus.CURRENT)
       val updatedSuggestion = suggestion.copy(stop = updatedStop)
 
       // Insert the updated suggestion at the beginning of the list

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionHistoryFeedContent.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/suggestion/SuggestionHistoryFeedContent.kt
@@ -52,7 +52,7 @@ fun SuggestionHistoryFeedContent(suggestionsViewModel: SuggestionsViewModel) {
   // Filter suggestions that have been added as stops
   val addedSuggestions =
       suggestions
-          .filter { it.stop.stopStatus == CalendarUiState.StopStatus.ADDED }
+          .filter { it.stop.stopStatus == CalendarUiState.StopStatus.CURRENT }
           .asReversed() // Reverse the list to show the most recent suggestions history item first
 
   val tripId =
@@ -133,7 +133,7 @@ fun SuggestionHistoryFeedContent(suggestionsViewModel: SuggestionsViewModel) {
                 @Composable {
                   LazyColumn(modifier = Modifier.testTag("suggestionHistoryFeedContentList")) {
                     itemsIndexed(addedSuggestions) { index, suggestion ->
-                      if (suggestion.stop.stopStatus == CalendarUiState.StopStatus.ADDED) {
+                      if (suggestion.stop.stopStatus == CalendarUiState.StopStatus.CURRENT) {
                         // Add space between suggestionHistoryItems:
                         Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
@@ -292,9 +292,10 @@ fun ContentItem(
   // Set the marker color based on the stop status
   val markerColor =
       when (date.stopStatus) {
-        CalendarUiState.StopStatus.ADDED -> MaterialTheme.colorScheme.tertiary // Stop added
-        CalendarUiState.StopStatus.COMING_SOON -> MaterialTheme.colorScheme.inversePrimary // Coming soon
-        CalendarUiState.StopStatus.PAST -> MaterialTheme.colorScheme.inverseSurface // Past stop
+        CalendarUiState.StopStatus.CURRENT -> MaterialTheme.colorScheme.tertiary // Stop added
+        CalendarUiState.StopStatus.COMING_SOON ->
+            MaterialTheme.colorScheme.inversePrimary // Coming soon
+        CalendarUiState.StopStatus.PAST -> MaterialTheme.colorScheme.outlineVariant // Past stop
         else -> Color.Transparent // No stop
       }
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
@@ -293,6 +293,8 @@ fun ContentItem(
   val markerColor =
       when (date.stopStatus) {
         CalendarUiState.StopStatus.ADDED -> MaterialTheme.colorScheme.tertiary // Stop added
+        CalendarUiState.StopStatus.COMING_SOON -> MaterialTheme.colorScheme.inversePrimary // Coming soon
+        CalendarUiState.StopStatus.PAST -> MaterialTheme.colorScheme.inverseSurface // Past stop
         else -> Color.Transparent // No stop
       }
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
@@ -349,6 +349,7 @@ fun ContentItem(
               if (isWithinTrip)
                   MaterialTheme.colorScheme.tertiaryContainer // background for trip range
               else Color.Transparent)
+          .testTag("DateBackground_${date.dayOfMonth}") // test tag for trip range background
 
   val dateBackgroundModifier =
       if (!isEmptyDate && date.isSelected) {
@@ -390,8 +391,13 @@ fun ContentItem(
                     .clip(CircleShape) // Make it circular
                     .background(markerColor) // Set the appropriate color
                     .padding(bottom = 4.dp) // Add some padding to the bottom
-                    .testTag("MarkerADDED") // Add test tag here
-            )
+                    .testTag(
+                        when (date.stopStatus) {
+                          CalendarUiState.StopStatus.CURRENT -> "MarkerCURRENT"
+                          CalendarUiState.StopStatus.COMING_SOON -> "MarkerCOMING_SOON"
+                          CalendarUiState.StopStatus.PAST -> "MarkerPAST"
+                          else -> "MarkerNONE"
+                        }))
       }
     }
   }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/Agenda.kt
@@ -61,57 +61,57 @@ private const val MAX_ROWS_CALENDAR = 6
  *
  * @param agendaViewModel The ViewModel that holds and manages UI-related data for the Agenda
  *   screen. It defaults to a ViewModel instance provided by the `viewModel()` function.
- *   @param tripId The unique identifier of the trip for which the agenda is being displayed.
- *   @param tripsRepository The repository for accessing trips data.
+ *     @param tripId The unique identifier of the trip for which the agenda is being displayed.
+ *     @param tripsRepository The repository for accessing trips data.
  */
 @Composable
 fun Agenda(agendaViewModel: AgendaViewModel, tripId: String, tripsRepository: TripsRepository) {
-    val uiState by agendaViewModel.uiState.collectAsState()
-    val trip by agendaViewModel.trip.collectAsState()
+  val uiState by agendaViewModel.uiState.collectAsState()
+  val trip by agendaViewModel.trip.collectAsState()
 
-    var isDrawerExpanded by remember { mutableStateOf(false) }
+  var isDrawerExpanded by remember { mutableStateOf(false) }
 
-    Scaffold(
-        topBar = {
-            Column(modifier = Modifier.background(MaterialTheme.colorScheme.primary)) {
-                Banner(
-                    agendaViewModel,
-                    isDrawerExpanded,
-                    onToggle = { isDrawerExpanded = !isDrawerExpanded })
-                AnimatedVisibility(
-                    visible = isDrawerExpanded,
-                    modifier =
-                    Modifier.background(color = MaterialTheme.colorScheme.surface).fillMaxWidth()) {
-                    CalendarWidget(
-                        days = getDaysOfWeekLabels(),
-                        yearMonth = uiState.yearMonth,
-                        dates = uiState.dates,
-                        onPreviousMonthButtonClicked = { prevMonth ->
-                            agendaViewModel.toPreviousMonth(prevMonth)
-                        },
-                        onNextMonthButtonClicked = { nextMonth ->
-                            agendaViewModel.toNextMonth(nextMonth)
-                        },
-                        onDateClickListener = { date -> agendaViewModel.onDateSelected(date) },
-                        trip = trip)
-                }
-                Spacer(modifier = Modifier.padding(1.dp))
-            }
-        },
-        modifier = Modifier.fillMaxSize().testTag("agendaScreen"),
-    ) { paddingValues ->
-        Column(modifier = Modifier.padding(paddingValues)) {
-            if (isDrawerExpanded) {
-                HorizontalDivider(
-                    modifier = Modifier.fillMaxWidth(),
-                    thickness = 1.dp,
-                    color = MaterialTheme.colorScheme.secondary)
-            }
-            // Daily agenda implementation
-            DailyActivities(
-                agendaViewModel = agendaViewModel, tripId = tripId, tripsRepository = tripsRepository)
+  Scaffold(
+      topBar = {
+        Column(modifier = Modifier.background(MaterialTheme.colorScheme.primary)) {
+          Banner(
+              agendaViewModel,
+              isDrawerExpanded,
+              onToggle = { isDrawerExpanded = !isDrawerExpanded })
+          AnimatedVisibility(
+              visible = isDrawerExpanded,
+              modifier =
+                  Modifier.background(color = MaterialTheme.colorScheme.surface).fillMaxWidth()) {
+                CalendarWidget(
+                    days = getDaysOfWeekLabels(),
+                    yearMonth = uiState.yearMonth,
+                    dates = uiState.dates,
+                    onPreviousMonthButtonClicked = { prevMonth ->
+                      agendaViewModel.toPreviousMonth(prevMonth)
+                    },
+                    onNextMonthButtonClicked = { nextMonth ->
+                      agendaViewModel.toNextMonth(nextMonth)
+                    },
+                    onDateClickListener = { date -> agendaViewModel.onDateSelected(date) },
+                    trip = trip)
+              }
+          Spacer(modifier = Modifier.padding(1.dp))
         }
+      },
+      modifier = Modifier.fillMaxSize().testTag("agendaScreen"),
+  ) { paddingValues ->
+    Column(modifier = Modifier.padding(paddingValues)) {
+      if (isDrawerExpanded) {
+        HorizontalDivider(
+            modifier = Modifier.fillMaxWidth(),
+            thickness = 1.dp,
+            color = MaterialTheme.colorScheme.secondary)
+      }
+      // Daily agenda implementation
+      DailyActivities(
+          agendaViewModel = agendaViewModel, tripId = tripId, tripsRepository = tripsRepository)
     }
+  }
 }
 
 /**
@@ -137,21 +137,21 @@ fun CalendarWidget(
     onPreviousMonthButtonClicked: (YearMonth) -> Unit,
     onNextMonthButtonClicked: (YearMonth) -> Unit,
     onDateClickListener: (CalendarUiState.Date) -> Unit,
-    trip:Trip
+    trip: Trip
 ) {
-    Column(modifier = Modifier.padding(16.dp).background(MaterialTheme.colorScheme.surface)) {
-        Row {
-            repeat(days.size) {
-                val item = days[it]
-                DayItem(item, modifier = Modifier.weight(1f))
-            }
-        }
-        Header(
-            yearMonth = yearMonth,
-            onPreviousMonthButtonClicked = onPreviousMonthButtonClicked,
-            onNextMonthButtonClicked = onNextMonthButtonClicked)
-        Content(dates = dates, onDateClickListener = onDateClickListener, trip = trip)
+  Column(modifier = Modifier.padding(16.dp).background(MaterialTheme.colorScheme.surface)) {
+    Row {
+      repeat(days.size) {
+        val item = days[it]
+        DayItem(item, modifier = Modifier.weight(1f))
+      }
     }
+    Header(
+        yearMonth = yearMonth,
+        onPreviousMonthButtonClicked = onPreviousMonthButtonClicked,
+        onNextMonthButtonClicked = onNextMonthButtonClicked)
+    Content(dates = dates, onDateClickListener = onDateClickListener, trip = trip)
+  }
 }
 
 /**
@@ -159,46 +159,47 @@ fun CalendarWidget(
  *
  * @param agendaViewModel The view model for managing the agenda of a trip.
  * @param isExpanded A boolean value indicating whether the daily activities are expanded.
- * @param onToggle A lambda function to be invoked when the daily activities are expanded or collapsed.
+ * @param onToggle A lambda function to be invoked when the daily activities are expanded or
+ *   collapsed.
  */
 @Composable
 fun Banner(agendaViewModel: AgendaViewModel, isExpanded: Boolean, onToggle: () -> Unit) {
-    val uiState by agendaViewModel.uiState.collectAsState()
-    val selectedDate = uiState.selectedDate ?: LocalDate.now()
+  val uiState by agendaViewModel.uiState.collectAsState()
+  val selectedDate = uiState.selectedDate ?: LocalDate.now()
 
-    Box(
-        modifier =
-        Modifier.fillMaxWidth()
-            .clickable { onToggle() }
-            .padding(8.dp)
-            .background(MaterialTheme.colorScheme.primary)
-            .testTag("Banner")) {
+  Box(
+      modifier =
+          Modifier.fillMaxWidth()
+              .clickable { onToggle() }
+              .padding(8.dp)
+              .background(MaterialTheme.colorScheme.primary)
+              .testTag("Banner")) {
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            DisplayDate(date = selectedDate, color = MaterialTheme.colorScheme.onPrimary)
-            // Optional: Add an icon to indicate the expand/collapse action
-            Icon(
-                imageVector =
-                if (isExpanded) Icons.Default.KeyboardArrowUp
-                else Icons.Default.KeyboardArrowDown,
-                contentDescription = "Toggle",
-                tint = MaterialTheme.colorScheme.onPrimary)
-            Spacer(modifier = Modifier.weight(1f))
-            // Add an icon to tap that opens the full list of all stops for the trip
-            IconButton(
-                onClick = {
-                    // Navigate to the stops list screen
-                    navigationActions.navigateTo(Route.STOPS_LIST)
-                },
-                modifier = Modifier.testTag("AllStopsButton"),
-                content = {
-                    Icon(
-                        painter = painterResource(id = R.drawable.stops_list_icon),
-                        contentDescription = "Open Stops",
-                        tint = MaterialTheme.colorScheme.onPrimary,
-                    )
-                })
+          DisplayDate(date = selectedDate, color = MaterialTheme.colorScheme.onPrimary)
+          // Optional: Add an icon to indicate the expand/collapse action
+          Icon(
+              imageVector =
+                  if (isExpanded) Icons.Default.KeyboardArrowUp
+                  else Icons.Default.KeyboardArrowDown,
+              contentDescription = "Toggle",
+              tint = MaterialTheme.colorScheme.onPrimary)
+          Spacer(modifier = Modifier.weight(1f))
+          // Add an icon to tap that opens the full list of all stops for the trip
+          IconButton(
+              onClick = {
+                // Navigate to the stops list screen
+                navigationActions.navigateTo(Route.STOPS_LIST)
+              },
+              modifier = Modifier.testTag("AllStopsButton"),
+              content = {
+                Icon(
+                    painter = painterResource(id = R.drawable.stops_list_icon),
+                    contentDescription = "Open Stops",
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                )
+              })
         }
-    }
+      }
 }
 
 /**
@@ -217,23 +218,23 @@ fun Header(
     onPreviousMonthButtonClicked: (YearMonth) -> Unit,
     onNextMonthButtonClicked: (YearMonth) -> Unit,
 ) {
-    Row {
-        IconButton(onClick = { onPreviousMonthButtonClicked.invoke(yearMonth.minusMonths(1)) }) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
-                contentDescription = stringResource(id = R.string.back))
-        }
-        Text(
-            text = yearMonth.getDisplayName(),
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.weight(1f).align(Alignment.CenterVertically))
-        IconButton(onClick = { onNextMonthButtonClicked.invoke(yearMonth.plusMonths(1)) }) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = stringResource(id = R.string.next))
-        }
+  Row {
+    IconButton(onClick = { onPreviousMonthButtonClicked.invoke(yearMonth.minusMonths(1)) }) {
+      Icon(
+          imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+          contentDescription = stringResource(id = R.string.back))
     }
+    Text(
+        text = yearMonth.getDisplayName(),
+        textAlign = TextAlign.Center,
+        style = MaterialTheme.typography.bodyLarge,
+        modifier = Modifier.weight(1f).align(Alignment.CenterVertically))
+    IconButton(onClick = { onNextMonthButtonClicked.invoke(yearMonth.plusMonths(1)) }) {
+      Icon(
+          imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+          contentDescription = stringResource(id = R.string.next))
+    }
+  }
 }
 
 /**
@@ -245,13 +246,13 @@ fun Header(
  */
 @Composable
 fun DayItem(day: String, modifier: Modifier = Modifier) {
-    Box(modifier = modifier) {
-        Text(
-            text = day,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.align(Alignment.Center).padding(10.dp))
-    }
+  Box(modifier = modifier) {
+    Text(
+        text = day,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.align(Alignment.Center).padding(10.dp))
+  }
 }
 
 /**
@@ -268,24 +269,33 @@ fun Content(
     onDateClickListener: (CalendarUiState.Date) -> Unit,
     trip: Trip
 ) {
-    Column {
-        var index = 0
-        repeat(MAX_ROWS_CALENDAR) {
-            if (index >= dates.size) return@repeat
-            Row {
-                repeat(DAYS_IN_A_WEEK) {
-                    val item = if (index < dates.size) dates[index] else CalendarUiState.Date.Empty
-                    val isWithinTrip = isWithinTripRange(item, trip.startDate, trip.endDate)
+  Column {
+    var index = 0
+    repeat(MAX_ROWS_CALENDAR) {
+      if (index >= dates.size) return@repeat
+      Row {
+        repeat(DAYS_IN_A_WEEK) {
+          val item = if (index < dates.size) dates[index] else CalendarUiState.Date.Empty
+          val isWithinTrip = isWithinTripRange(item, trip.startDate, trip.endDate)
 
-                    ContentItem(
-                        date = item, onClickListener = onDateClickListener, modifier = Modifier.weight(1f), isWithinTrip = isWithinTrip,
-                        isStartDate = item.dayOfMonth == trip.startDate.dayOfMonth.toString() && item.yearMonth == YearMonth.from(trip.startDate), isEndDate = item.dayOfMonth == trip.endDate.dayOfMonth.toString() && item.yearMonth == YearMonth.from(trip.endDate),
-                        isStartOfLine = index % DAYS_IN_A_WEEK == 0, isEndOfLine = index % DAYS_IN_A_WEEK == DAYS_IN_A_WEEK - 1)
-                    index++
-                }
-            }
+          ContentItem(
+              date = item,
+              onClickListener = onDateClickListener,
+              modifier = Modifier.weight(1f),
+              isWithinTrip = isWithinTrip,
+              isStartDate =
+                  item.dayOfMonth == trip.startDate.dayOfMonth.toString() &&
+                      item.yearMonth == YearMonth.from(trip.startDate),
+              isEndDate =
+                  item.dayOfMonth == trip.endDate.dayOfMonth.toString() &&
+                      item.yearMonth == YearMonth.from(trip.endDate),
+              isStartOfLine = index % DAYS_IN_A_WEEK == 0,
+              isEndOfLine = index % DAYS_IN_A_WEEK == DAYS_IN_A_WEEK - 1)
+          index++
         }
+      }
     }
+  }
 }
 
 /**
@@ -298,8 +308,10 @@ fun Content(
  * @param isWithinTrip A boolean value indicating whether the date is within the trip range.
  * @param isStartDate A boolean value indicating whether the date is the start date of the trip.
  * @param isEndDate A boolean value indicating whether the date is the end date of the trip.
- * @param isStartOfLine A boolean value indicating whether this date item is at the start of a row of the calendar.
- * @param isEndOfLine A boolean value indicating whether this date item is at the end of a row of the calendar.
+ * @param isStartOfLine A boolean value indicating whether this date item is at the start of a row
+ *   of the calendar.
+ * @param isEndOfLine A boolean value indicating whether this date item is at the end of a row of
+ *   the calendar.
  */
 @Composable
 fun ContentItem(
@@ -312,83 +324,92 @@ fun ContentItem(
     isStartOfLine: Boolean,
     isEndOfLine: Boolean
 ) {
-    // Assuming dayOfMonth is an empty string for empty dates, or add a specific check if possible.
-    val isEmptyDate = date.dayOfMonth.isEmpty()
+  // Assuming dayOfMonth is an empty string for empty dates, or add a specific check if possible.
+  val isEmptyDate = date.dayOfMonth.isEmpty()
 
-    // Set the marker color based on the stop status
-    val markerColor =
-        when (date.stopStatus) {
-            CalendarUiState.StopStatus.CURRENT -> MaterialTheme.colorScheme.tertiary // Stop added
-            CalendarUiState.StopStatus.COMING_SOON ->
-                MaterialTheme.colorScheme.inversePrimary // Coming soon
-            CalendarUiState.StopStatus.PAST -> MaterialTheme.colorScheme.outlineVariant // Past stop
-            else -> Color.Transparent // No stop
-        }
+  // Set the marker color based on the stop status
+  val markerColor =
+      when (date.stopStatus) {
+        CalendarUiState.StopStatus.CURRENT -> MaterialTheme.colorScheme.tertiary // Stop added
+        CalendarUiState.StopStatus.COMING_SOON ->
+            MaterialTheme.colorScheme.inversePrimary // Coming soon
+        CalendarUiState.StopStatus.PAST -> MaterialTheme.colorScheme.outlineVariant // Past stop
+        else -> Color.Transparent // No stop
+      }
 
-    val backgroundShape = when {
+  val backgroundShape =
+      when {
         isStartDate || isStartOfLine -> RoundedCornerShape(topStart = 50.dp, bottomStart = 50.dp)
         isEndDate || isEndOfLine -> RoundedCornerShape(topEnd = 50.dp, bottomEnd = 50.dp)
         else -> RoundedCornerShape(0.dp)
-    }
-    val tripBackgroundModifier = Modifier
-        .clip(backgroundShape)
-        .background(
-            if (isWithinTrip) MaterialTheme.colorScheme.tertiaryContainer // background for trip range
-            else Color.Transparent
-        )
+      }
+  val tripBackgroundModifier =
+      Modifier.clip(backgroundShape)
+          .background(
+              if (isWithinTrip)
+                  MaterialTheme.colorScheme.tertiaryContainer // background for trip range
+              else Color.Transparent)
 
-    val dateBackgroundModifier = if (!isEmptyDate && date.isSelected) {
+  val dateBackgroundModifier =
+      if (!isEmptyDate && date.isSelected) {
         Modifier.clip(CircleShape).background(MaterialTheme.colorScheme.secondaryContainer)
-    } else Modifier
+      } else Modifier
 
-    // Apply clickable only if the date is not empty.
-    val finalModifier = modifier
-        .aspectRatio(1f)
-        .background(Color.Transparent)
-        .then(tripBackgroundModifier) // first apply the trip background modifier
-        .clickable(enabled = !isEmptyDate) { onClickListener(date) }
-        .then(dateBackgroundModifier) // then apply the date background modifier
-        .padding(10.dp)
-        .semantics {
+  // Apply clickable only if the date is not empty.
+  val finalModifier =
+      modifier
+          .aspectRatio(1f)
+          .background(Color.Transparent)
+          .then(tripBackgroundModifier) // first apply the trip background modifier
+          .clickable(enabled = !isEmptyDate) { onClickListener(date) }
+          .then(dateBackgroundModifier) // then apply the date background modifier
+          .padding(10.dp)
+          .semantics {
             contentDescription =
-                if (!isEmptyDate) "Date ${date.dayOfMonth}, ${if (date.isSelected) "Selected" else "Not Selected"}"
+                if (!isEmptyDate)
+                    "Date ${date.dayOfMonth}, ${if (date.isSelected) "Selected" else "Not Selected"}"
                 else "Empty Date Cell"
-        }
+          }
 
-    Box(modifier = finalModifier) {
-        if (!isEmptyDate) {
-            Text(
-                text = date.dayOfMonth,
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.align(Alignment.TopCenter))
-            // Displaying the status dot below the date
-            if (date.stopStatus !=
-                CalendarUiState.StopStatus
-                    .NONE) { // I use "not equal to the NONE status" here, because we might have more
-                // statuses in the future
-                Box(
-                    modifier =
-                    Modifier.align(
+  Box(modifier = finalModifier) {
+    if (!isEmptyDate) {
+      Text(
+          text = date.dayOfMonth,
+          style = MaterialTheme.typography.bodyMedium,
+          modifier = Modifier.align(Alignment.TopCenter))
+      // Displaying the status dot below the date
+      if (date.stopStatus !=
+          CalendarUiState.StopStatus
+              .NONE) { // I use "not equal to the NONE status" here, because we might have more
+        // statuses in the future
+        Box(
+            modifier =
+                Modifier.align(
                         Alignment.BottomCenter) // Center the dot at the bottom of the date cell
-                        .size(8.dp) // Size of the dot
-                        .clip(CircleShape) // Make it circular
-                        .background(markerColor) // Set the appropriate color
-                        .padding(bottom = 4.dp) // Add some padding to the bottom
-                        .testTag("MarkerADDED") // Add test tag here
-                )
-            }
-        }
+                    .size(8.dp) // Size of the dot
+                    .clip(CircleShape) // Make it circular
+                    .background(markerColor) // Set the appropriate color
+                    .padding(bottom = 4.dp) // Add some padding to the bottom
+                    .testTag("MarkerADDED") // Add test tag here
+            )
+      }
     }
+  }
 }
 
 /**
  * the function to determine if the date is within the trip range.
+ *
  * @param date The date to be checked.
  * @param startDate The start date of the trip.
  * @param endDate The end date of the trip.
  */
-fun isWithinTripRange(date: CalendarUiState.Date, startDate: LocalDate, endDate: LocalDate): Boolean {
-    if (date.dayOfMonth.isEmpty()) return false
-    val currentDate = LocalDate.of(date.year.value, date.yearMonth.month, date.dayOfMonth.toInt())
-    return currentDate.isAfter(startDate.minusDays(1)) && currentDate.isBefore(endDate.plusDays(1))
+fun isWithinTripRange(
+    date: CalendarUiState.Date,
+    startDate: LocalDate,
+    endDate: LocalDate
+): Boolean {
+  if (date.dayOfMonth.isEmpty()) return false
+  val currentDate = LocalDate.of(date.year.value, date.yearMonth.month, date.dayOfMonth.toInt())
+  return currentDate.isAfter(startDate.minusDays(1)) && currentDate.isBefore(endDate.plusDays(1))
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
@@ -25,6 +25,8 @@ import java.util.Locale
  * @property yearMonth The current year and month being displayed in the calendar.
  * @property dates A list of `Date` objects representing the dates in the current month.
  * @property selectedDate An optional `LocalDate` representing the currently selected date, if any.
+ * @property trip An optional `Trip` object representing the trip associated with the calendar. This
+ *   is used to indicating the startDate and endDate of the trip.
  */
 data class CalendarUiState(
     val yearMonth: YearMonth,
@@ -35,20 +37,23 @@ data class CalendarUiState(
     val Init = CalendarUiState(yearMonth = YearMonth.now(), dates = emptyList())
   }
 
-    /**
-     * Enum class representing the status of the stop addition.
-     *
-     * @property ADDED Suggestion was added to the trip, it is a stop of the trip now.
-     * @property NONE Suggestion has not been added, it is still a suggestion of the trip.
-     * @property COMING_SOON Stop is the next event of the current stop of the trip.
-     * @property PAST Stop is a past event of the current stop of the trip.
-     */
-    enum class StopStatus {
-        ADDED,
-        NONE,
-        COMING_SOON,
-        PAST
-    }
+  /**
+   * Enum class representing the status of the stop addition.
+   *
+   * @property CURRENT Suggestion was added to the trip, it is a stop of the trip of the current
+   *   day.
+   * @property NONE Suggestion has not been added, it is still a suggestion of the trip.
+   * @property COMING_SOON Suggestion was added to the trip, is is a stop in the following days of
+   *   the current day of the trip.
+   * @property PAST Suggestion was added to the trip, it is a stop of the trip of days before the
+   *   current day of the trip.
+   */
+  enum class StopStatus {
+    CURRENT,
+    NONE,
+    COMING_SOON,
+    PAST
+  }
 
   /**
    * Data class representing a single date in the calendar. Includes information about the day of

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
@@ -31,50 +31,50 @@ data class CalendarUiState(
     val dates: List<Date>,
     val selectedDate: LocalDate? = LocalDate.now() // By default selected day is today
 ) {
+  companion object {
+    val Init = CalendarUiState(yearMonth = YearMonth.now(), dates = emptyList())
+  }
+
+  /**
+   * Enum class representing the status of a stop in the trip.
+   *
+   * @property CURRENT Suggestion was transformed into a stop of the trip, it is a stop of the trip
+   *   of the current day.
+   * @property COMING_SOON Suggestion was transformed into a stop of the trip, is is a stop in the
+   *   following days of the current day of the trip.
+   * @property PAST Suggestion was transformed into a stop of the trip, it is a stop of the trip of
+   *   days before the current day of the trip.
+   * @property NONE Suggestion has not been transformed into a stop of the trip yet, it is still a
+   *   suggestion of the trip.
+   */
+  enum class StopStatus {
+    CURRENT,
+    COMING_SOON,
+    PAST,
+    NONE
+  }
+
+  /**
+   * Data class representing a single date in the calendar. Includes information about the day of
+   * the month, the corresponding year and month, and whether the date is selected.
+   *
+   * @property dayOfMonth The day of the month as a string.
+   * @property yearMonth The year and month to which this date belongs.
+   * @property year The year as a `Year` object.
+   * @property isSelected Boolean indicating whether this date is currently selected.
+   */
+  data class Date(
+      val dayOfMonth: String,
+      val yearMonth: YearMonth,
+      val year: Year,
+      val isSelected: Boolean,
+      val stopStatus: StopStatus = StopStatus.NONE
+  ) {
     companion object {
-        val Init = CalendarUiState(yearMonth = YearMonth.now(), dates = emptyList())
+      // Represents an empty date, used as a placeholder in the calendar grid
+      val Empty = Date("", YearMonth.now(), Year.now(), false, StopStatus.NONE)
     }
-
-    /**
-     * Enum class representing the status of a stop in the trip.
-     *
-     * @property CURRENT Suggestion was transformed into a stop of the trip, it is a stop of the trip
-     *   of the current day.
-     * @property COMING_SOON Suggestion was transformed into a stop of the trip, is is a stop in the
-     *   following days of the current day of the trip.
-     * @property PAST Suggestion was transformed into a stop of the trip, it is a stop of the trip of
-     *   days before the current day of the trip.
-     * @property NONE Suggestion has not been transformed into a stop of the trip yet, it is still a
-     *   suggestion of the trip.
-     */
-    enum class StopStatus {
-        CURRENT,
-        COMING_SOON,
-        PAST,
-        NONE
-    }
-
-    /**
-     * Data class representing a single date in the calendar. Includes information about the day of
-     * the month, the corresponding year and month, and whether the date is selected.
-     *
-     * @property dayOfMonth The day of the month as a string.
-     * @property yearMonth The year and month to which this date belongs.
-     * @property year The year as a `Year` object.
-     * @property isSelected Boolean indicating whether this date is currently selected.
-     */
-    data class Date(
-        val dayOfMonth: String,
-        val yearMonth: YearMonth,
-        val year: Year,
-        val isSelected: Boolean,
-        val stopStatus: StopStatus = StopStatus.NONE
-    ) {
-        companion object {
-            // Represents an empty date, used as a placeholder in the calendar grid
-            val Empty = Date("", YearMonth.now(), Year.now(), false, StopStatus.NONE)
-        }
-    }
+  }
 }
 
 /**
@@ -83,31 +83,31 @@ data class CalendarUiState(
  */
 class CalendarDataSource {
 
-    /**
-     * Generates a list of `CalendarUiState.Date` objects for a given year and month. This list
-     * includes dates from the specified month, marking the selected date if provided.
-     *
-     * @param yearMonth The year and month for which to generate the date list.
-     * @param selectedDate An optional `LocalDate` representing the currently selected date.
-     * @param stopsInfo A map of `LocalDate` to `CalendarUiState.StopStatus` representing the status
-     *   of stops.
-     * @return A list of `CalendarUiState.Date` objects representing the dates of the specified month.
-     */
-    fun getDates(
-        yearMonth: YearMonth,
-        selectedDate: LocalDate?,
-        stopsInfo: Map<LocalDate, CalendarUiState.StopStatus>
-    ): List<CalendarUiState.Date> {
-        return yearMonth.getDayOfMonthStartingFromMonday().map { date ->
-            val isSelected = date == selectedDate && date.monthValue == yearMonth.monthValue
-            CalendarUiState.Date(
-                dayOfMonth = if (date.monthValue == yearMonth.monthValue) "${date.dayOfMonth}" else "",
-                yearMonth = yearMonth,
-                year = Year.of(date.year),
-                isSelected = isSelected,
-                stopStatus = stopsInfo[date] ?: CalendarUiState.StopStatus.NONE)
-        }
+  /**
+   * Generates a list of `CalendarUiState.Date` objects for a given year and month. This list
+   * includes dates from the specified month, marking the selected date if provided.
+   *
+   * @param yearMonth The year and month for which to generate the date list.
+   * @param selectedDate An optional `LocalDate` representing the currently selected date.
+   * @param stopsInfo A map of `LocalDate` to `CalendarUiState.StopStatus` representing the status
+   *   of stops.
+   * @return A list of `CalendarUiState.Date` objects representing the dates of the specified month.
+   */
+  fun getDates(
+      yearMonth: YearMonth,
+      selectedDate: LocalDate?,
+      stopsInfo: Map<LocalDate, CalendarUiState.StopStatus>
+  ): List<CalendarUiState.Date> {
+    return yearMonth.getDayOfMonthStartingFromMonday().map { date ->
+      val isSelected = date == selectedDate && date.monthValue == yearMonth.monthValue
+      CalendarUiState.Date(
+          dayOfMonth = if (date.monthValue == yearMonth.monthValue) "${date.dayOfMonth}" else "",
+          yearMonth = yearMonth,
+          year = Year.of(date.year),
+          isSelected = isSelected,
+          stopStatus = stopsInfo[date] ?: CalendarUiState.StopStatus.NONE)
     }
+  }
 }
 
 /**
@@ -130,13 +130,13 @@ fun getDaysOfWeekLabels(): Array<String> =
  *   Monday, to be used in the calendar grid.
  */
 fun YearMonth.getDayOfMonthStartingFromMonday(): List<LocalDate> {
-    val firstDayOfMonth = LocalDate.of(year, month, 1)
-    val firstMondayOfMonth = firstDayOfMonth.with(DayOfWeek.MONDAY)
-    val firstDayOfNextMonth = firstDayOfMonth.plusMonths(1)
+  val firstDayOfMonth = LocalDate.of(year, month, 1)
+  val firstMondayOfMonth = firstDayOfMonth.with(DayOfWeek.MONDAY)
+  val firstDayOfNextMonth = firstDayOfMonth.plusMonths(1)
 
-    return generateSequence(firstMondayOfMonth) { it.plusDays(1) }
-        .takeWhile { it.isBefore(firstDayOfNextMonth) }
-        .toList()
+  return generateSequence(firstMondayOfMonth) { it.plusDays(1) }
+      .takeWhile { it.isBefore(firstDayOfNextMonth) }
+      .toList()
 }
 
 /**
@@ -148,7 +148,7 @@ fun YearMonth.getDayOfMonthStartingFromMonday(): List<LocalDate> {
  *   2024").
  */
 fun YearMonth.getDisplayName(): String {
-    return "${month.getDisplayName(TextStyle.FULL, Locale.getDefault())} $year"
+  return "${month.getDisplayName(TextStyle.FULL, Locale.getDefault())} $year"
 }
 
 /**
@@ -158,28 +158,28 @@ fun YearMonth.getDisplayName(): String {
  */
 @Composable
 fun DisplayDate(date: LocalDate?, color: Color) {
-    // Define a formatter
-    val formatter = DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy").withLocale(Locale.getDefault())
+  // Define a formatter
+  val formatter = DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy").withLocale(Locale.getDefault())
 
-    // Format the selected date using the formatter
-    val formattedDate =
-        date?.format(formatter)?.let { it ->
-            it.split(", ").joinToString(", ") { part ->
-                part.split(" ").joinToString(" ") { word ->
-                    word.replaceFirstChar {
-                        if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
-                    }
-                }
+  // Format the selected date using the formatter
+  val formattedDate =
+      date?.format(formatter)?.let { it ->
+        it.split(", ").joinToString(", ") { part ->
+          part.split(" ").joinToString(" ") { word ->
+            word.replaceFirstChar {
+              if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
             }
-        } ?: "No date selected"
+          }
+        }
+      } ?: "No date selected"
 
-    // Display the formatted date
-    Text(
-        text = formattedDate,
-        style =
-        androidx.compose.ui.text.TextStyle(
-            color = color, fontSize = 16.sp, fontWeight = FontWeight.Bold),
-        color = color,
-        textAlign = TextAlign.Center,
-        modifier = Modifier.padding(8.dp).testTag("displayDateText"))
+  // Display the formatted date
+  Text(
+      text = formattedDate,
+      style =
+          androidx.compose.ui.text.TextStyle(
+              color = color, fontSize = 16.sp, fontWeight = FontWeight.Bold),
+      color = color,
+      textAlign = TextAlign.Center,
+      modifier = Modifier.padding(8.dp).testTag("displayDateText"))
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
@@ -31,50 +31,50 @@ data class CalendarUiState(
     val dates: List<Date>,
     val selectedDate: LocalDate? = LocalDate.now() // By default selected day is today
 ) {
-  companion object {
-    val Init = CalendarUiState(yearMonth = YearMonth.now(), dates = emptyList())
-  }
-
-  /**
-   * Enum class representing the status of a stop in the trip.
-   *
-   * @property CURRENT Suggestion was transformed into a stop of the trip, it is a stop of the trip
-   *   of the current day.
-   * @property COMING_SOON Suggestion was transformed into a stop of the trip, is is a stop in the
-   *   following days of the current day of the trip.
-   * @property PAST Suggestion was transformed into a stop of the trip, it is a stop of the trip of
-   *   days before the current day of the trip.
-   * @property NONE Suggestion has not been transformed into a stop of the trip yet, it is still a
-   *   suggestion of the trip.
-   */
-  enum class StopStatus {
-    CURRENT,
-    COMING_SOON,
-    PAST,
-    NONE
-  }
-
-  /**
-   * Data class representing a single date in the calendar. Includes information about the day of
-   * the month, the corresponding year and month, and whether the date is selected.
-   *
-   * @property dayOfMonth The day of the month as a string.
-   * @property yearMonth The year and month to which this date belongs.
-   * @property year The year as a `Year` object.
-   * @property isSelected Boolean indicating whether this date is currently selected.
-   */
-  data class Date(
-      val dayOfMonth: String,
-      val yearMonth: YearMonth,
-      val year: Year,
-      val isSelected: Boolean,
-      val stopStatus: StopStatus = StopStatus.NONE
-  ) {
     companion object {
-      // Represents an empty date, used as a placeholder in the calendar grid
-      val Empty = Date("", YearMonth.now(), Year.now(), false, StopStatus.NONE)
+        val Init = CalendarUiState(yearMonth = YearMonth.now(), dates = emptyList())
     }
-  }
+
+    /**
+     * Enum class representing the status of a stop in the trip.
+     *
+     * @property CURRENT Suggestion was transformed into a stop of the trip, it is a stop of the trip
+     *   of the current day.
+     * @property COMING_SOON Suggestion was transformed into a stop of the trip, is is a stop in the
+     *   following days of the current day of the trip.
+     * @property PAST Suggestion was transformed into a stop of the trip, it is a stop of the trip of
+     *   days before the current day of the trip.
+     * @property NONE Suggestion has not been transformed into a stop of the trip yet, it is still a
+     *   suggestion of the trip.
+     */
+    enum class StopStatus {
+        CURRENT,
+        COMING_SOON,
+        PAST,
+        NONE
+    }
+
+    /**
+     * Data class representing a single date in the calendar. Includes information about the day of
+     * the month, the corresponding year and month, and whether the date is selected.
+     *
+     * @property dayOfMonth The day of the month as a string.
+     * @property yearMonth The year and month to which this date belongs.
+     * @property year The year as a `Year` object.
+     * @property isSelected Boolean indicating whether this date is currently selected.
+     */
+    data class Date(
+        val dayOfMonth: String,
+        val yearMonth: YearMonth,
+        val year: Year,
+        val isSelected: Boolean,
+        val stopStatus: StopStatus = StopStatus.NONE
+    ) {
+        companion object {
+            // Represents an empty date, used as a placeholder in the calendar grid
+            val Empty = Date("", YearMonth.now(), Year.now(), false, StopStatus.NONE)
+        }
+    }
 }
 
 /**
@@ -83,31 +83,31 @@ data class CalendarUiState(
  */
 class CalendarDataSource {
 
-  /**
-   * Generates a list of `CalendarUiState.Date` objects for a given year and month. This list
-   * includes dates from the specified month, marking the selected date if provided.
-   *
-   * @param yearMonth The year and month for which to generate the date list.
-   * @param selectedDate An optional `LocalDate` representing the currently selected date.
-   * @param stopsInfo A map of `LocalDate` to `CalendarUiState.StopStatus` representing the status
-   *   of stops.
-   * @return A list of `CalendarUiState.Date` objects representing the dates of the specified month.
-   */
-  fun getDates(
-      yearMonth: YearMonth,
-      selectedDate: LocalDate?,
-      stopsInfo: Map<LocalDate, CalendarUiState.StopStatus>
-  ): List<CalendarUiState.Date> {
-    return yearMonth.getDayOfMonthStartingFromMonday().map { date ->
-      val isSelected = date == selectedDate && date.monthValue == yearMonth.monthValue
-      CalendarUiState.Date(
-          dayOfMonth = if (date.monthValue == yearMonth.monthValue) "${date.dayOfMonth}" else "",
-          yearMonth = yearMonth,
-          year = Year.of(date.year),
-          isSelected = isSelected,
-          stopStatus = stopsInfo[date] ?: CalendarUiState.StopStatus.NONE)
+    /**
+     * Generates a list of `CalendarUiState.Date` objects for a given year and month. This list
+     * includes dates from the specified month, marking the selected date if provided.
+     *
+     * @param yearMonth The year and month for which to generate the date list.
+     * @param selectedDate An optional `LocalDate` representing the currently selected date.
+     * @param stopsInfo A map of `LocalDate` to `CalendarUiState.StopStatus` representing the status
+     *   of stops.
+     * @return A list of `CalendarUiState.Date` objects representing the dates of the specified month.
+     */
+    fun getDates(
+        yearMonth: YearMonth,
+        selectedDate: LocalDate?,
+        stopsInfo: Map<LocalDate, CalendarUiState.StopStatus>
+    ): List<CalendarUiState.Date> {
+        return yearMonth.getDayOfMonthStartingFromMonday().map { date ->
+            val isSelected = date == selectedDate && date.monthValue == yearMonth.monthValue
+            CalendarUiState.Date(
+                dayOfMonth = if (date.monthValue == yearMonth.monthValue) "${date.dayOfMonth}" else "",
+                yearMonth = yearMonth,
+                year = Year.of(date.year),
+                isSelected = isSelected,
+                stopStatus = stopsInfo[date] ?: CalendarUiState.StopStatus.NONE)
+        }
     }
-  }
 }
 
 /**
@@ -130,13 +130,13 @@ fun getDaysOfWeekLabels(): Array<String> =
  *   Monday, to be used in the calendar grid.
  */
 fun YearMonth.getDayOfMonthStartingFromMonday(): List<LocalDate> {
-  val firstDayOfMonth = LocalDate.of(year, month, 1)
-  val firstMondayOfMonth = firstDayOfMonth.with(DayOfWeek.MONDAY)
-  val firstDayOfNextMonth = firstDayOfMonth.plusMonths(1)
+    val firstDayOfMonth = LocalDate.of(year, month, 1)
+    val firstMondayOfMonth = firstDayOfMonth.with(DayOfWeek.MONDAY)
+    val firstDayOfNextMonth = firstDayOfMonth.plusMonths(1)
 
-  return generateSequence(firstMondayOfMonth) { it.plusDays(1) }
-      .takeWhile { it.isBefore(firstDayOfNextMonth) }
-      .toList()
+    return generateSequence(firstMondayOfMonth) { it.plusDays(1) }
+        .takeWhile { it.isBefore(firstDayOfNextMonth) }
+        .toList()
 }
 
 /**
@@ -148,7 +148,7 @@ fun YearMonth.getDayOfMonthStartingFromMonday(): List<LocalDate> {
  *   2024").
  */
 fun YearMonth.getDisplayName(): String {
-  return "${month.getDisplayName(TextStyle.FULL, Locale.getDefault())} $year"
+    return "${month.getDisplayName(TextStyle.FULL, Locale.getDefault())} $year"
 }
 
 /**
@@ -158,28 +158,28 @@ fun YearMonth.getDisplayName(): String {
  */
 @Composable
 fun DisplayDate(date: LocalDate?, color: Color) {
-  // Define a formatter
-  val formatter = DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy").withLocale(Locale.getDefault())
+    // Define a formatter
+    val formatter = DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy").withLocale(Locale.getDefault())
 
-  // Format the selected date using the formatter
-  val formattedDate =
-      date?.format(formatter)?.let { it ->
-        it.split(", ").joinToString(", ") { part ->
-          part.split(" ").joinToString(" ") { word ->
-            word.replaceFirstChar {
-              if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+    // Format the selected date using the formatter
+    val formattedDate =
+        date?.format(formatter)?.let { it ->
+            it.split(", ").joinToString(", ") { part ->
+                part.split(" ").joinToString(" ") { word ->
+                    word.replaceFirstChar {
+                        if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+                    }
+                }
             }
-          }
-        }
-      } ?: "No date selected"
+        } ?: "No date selected"
 
-  // Display the formatted date
-  Text(
-      text = formattedDate,
-      style =
-          androidx.compose.ui.text.TextStyle(
-              color = color, fontSize = 16.sp, fontWeight = FontWeight.Bold),
-      color = color,
-      textAlign = TextAlign.Center,
-      modifier = Modifier.padding(8.dp).testTag("displayDateText"))
+    // Display the formatted date
+    Text(
+        text = formattedDate,
+        style =
+        androidx.compose.ui.text.TextStyle(
+            color = color, fontSize = 16.sp, fontWeight = FontWeight.Bold),
+        color = color,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(8.dp).testTag("displayDateText"))
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.github.se.wanderpals.model.data.Trip
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.Year
@@ -31,28 +32,30 @@ import java.util.Locale
 data class CalendarUiState(
     val yearMonth: YearMonth,
     val dates: List<Date>,
-    val selectedDate: LocalDate? = LocalDate.now() // By default selected day is today
+    val selectedDate: LocalDate? = LocalDate.now(), // By default selected day is today
+    val trip: Trip? = null
 ) {
   companion object {
     val Init = CalendarUiState(yearMonth = YearMonth.now(), dates = emptyList())
   }
 
   /**
-   * Enum class representing the status of the stop addition.
+   * Enum class representing the status of a stop in the trip.
    *
-   * @property CURRENT Suggestion was added to the trip, it is a stop of the trip of the current
-   *   day.
-   * @property NONE Suggestion has not been added, it is still a suggestion of the trip.
-   * @property COMING_SOON Suggestion was added to the trip, is is a stop in the following days of
-   *   the current day of the trip.
-   * @property PAST Suggestion was added to the trip, it is a stop of the trip of days before the
-   *   current day of the trip.
+   * @property CURRENT Suggestion was transformed into a stop of the trip, it is a stop of the trip
+   *   of the current day.
+   * @property COMING_SOON Suggestion was transformed into a stop of the trip, is is a stop in the
+   *   following days of the current day of the trip.
+   * @property PAST Suggestion was transformed into a stop of the trip, it is a stop of the trip of
+   *   days before the current day of the trip.
+   * @property NONE Suggestion has not been transformed into a stop of the trip yet, it is still a
+   *   suggestion of the trip.
    */
   enum class StopStatus {
     CURRENT,
-    NONE,
     COMING_SOON,
-    PAST
+    PAST,
+    NONE
   }
 
   /**

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.github.se.wanderpals.model.data.Trip
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.Year
@@ -26,14 +25,11 @@ import java.util.Locale
  * @property yearMonth The current year and month being displayed in the calendar.
  * @property dates A list of `Date` objects representing the dates in the current month.
  * @property selectedDate An optional `LocalDate` representing the currently selected date, if any.
- * @property trip An optional `Trip` object representing the trip associated with the calendar. This
- *   is used to indicating the startDate and endDate of the trip.
  */
 data class CalendarUiState(
     val yearMonth: YearMonth,
     val dates: List<Date>,
-    val selectedDate: LocalDate? = LocalDate.now(), // By default selected day is today
-    val trip: Trip? = null
+    val selectedDate: LocalDate? = LocalDate.now() // By default selected day is today
 ) {
   companion object {
     val Init = CalendarUiState(yearMonth = YearMonth.now(), dates = emptyList())

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/agenda/DatesOperations.kt
@@ -35,16 +35,20 @@ data class CalendarUiState(
     val Init = CalendarUiState(yearMonth = YearMonth.now(), dates = emptyList())
   }
 
-  /**
-   * Enum class representing the status of the stop addition.
-   *
-   * @property ADDED Suggestion was added to the trip, it is a stop of the trip now.
-   * @property NONE Suggestion has not been added, it is still a suggestion of the trip.
-   */
-  enum class StopStatus {
-    ADDED,
-    NONE
-  }
+    /**
+     * Enum class representing the status of the stop addition.
+     *
+     * @property ADDED Suggestion was added to the trip, it is a stop of the trip now.
+     * @property NONE Suggestion has not been added, it is still a suggestion of the trip.
+     * @property COMING_SOON Stop is the next event of the current stop of the trip.
+     * @property PAST Stop is a past event of the current stop of the trip.
+     */
+    enum class StopStatus {
+        ADDED,
+        NONE,
+        COMING_SOON,
+        PAST
+    }
 
   /**
    * Data class representing a single date in the calendar. Includes information about the day of

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/AgendaViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/AgendaViewModelTest.kt
@@ -120,7 +120,7 @@ class AgendaViewModelTest {
    * is updated correctly to different statuses.
    */
   @Test
-  fun `loadStopsInfo updates stopsInfo state with different statuses`() = runTest {
+  fun `loadStopsInfo updates stopsInfo state with different statuses`() = runBlockingTest {
     // Prepare mock response
     val today = LocalDate.now()
     val mockStops =

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/AgendaViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/AgendaViewModelTest.kt
@@ -83,8 +83,8 @@ class AgendaViewModelTest {
 
     // Check the resulting state
     assertEquals(2, viewModel._stopsInfo.value.size)
-    assertEquals(CalendarUiState.StopStatus.ADDED, viewModel._stopsInfo.value[mockStops[0].date])
-    assertEquals(CalendarUiState.StopStatus.ADDED, viewModel._stopsInfo.value[mockStops[1].date])
+    assertEquals(CalendarUiState.StopStatus.CURRENT, viewModel._stopsInfo.value[mockStops[0].date])
+    assertEquals(CalendarUiState.StopStatus.CURRENT, viewModel._stopsInfo.value[mockStops[1].date])
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/AgendaViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/AgendaViewModelTest.kt
@@ -2,6 +2,7 @@ package com.github.se.wanderpals.viewmodel
 
 import com.github.se.wanderpals.model.data.GeoCords
 import com.github.se.wanderpals.model.data.Stop
+import com.github.se.wanderpals.model.data.Trip
 import com.github.se.wanderpals.model.repository.TripsRepository
 import com.github.se.wanderpals.model.viewmodel.AgendaViewModel
 import com.github.se.wanderpals.ui.screens.trip.agenda.CalendarUiState
@@ -33,6 +34,32 @@ class AgendaViewModelTest {
 
     // Create the ViewModel
     viewModel = AgendaViewModel("tripId", mockTripsRepository)
+  }
+
+  /**
+   * Test the loadTripData method of the AgendaViewModel class to ensure that the trip state is
+   * updated correctly.
+   */
+  @Test
+  fun `loadTripData updates trip state correctly`() = runBlockingTest {
+    // Prepare mock trip data
+    val mockTrip =
+        Trip(
+            tripId = "tripId",
+            title = "Test Trip",
+            startDate = LocalDate.of(2024, 5, 15),
+            endDate = LocalDate.of(2024, 5, 24),
+            totalBudget = 1000.0,
+            description = "Test Trip Description")
+
+    coEvery { mockTripsRepository.getTrip("tripId") } returns mockTrip
+
+    // Call the method to test
+    viewModel.loadTripData() // Assuming this method is public or internal for testing
+    advanceUntilIdle() // Wait for all coroutines to complete
+
+    // Check the resulting state
+    assertEquals(mockTrip, viewModel.trip.value)
   }
 
   /**
@@ -86,6 +113,67 @@ class AgendaViewModelTest {
     assertEquals(2, viewModel._stopsInfo.value.size)
     assertEquals(CalendarUiState.StopStatus.PAST, viewModel._stopsInfo.value[mockStops[0].date])
     assertEquals(CalendarUiState.StopStatus.PAST, viewModel._stopsInfo.value[mockStops[1].date])
+  }
+
+  /**
+   * Test the loadStopsInfo method of the AgendaViewModel class to ensure that the stopsInfo state
+   * is updated correctly to different statuses.
+   */
+  @Test
+  fun `loadStopsInfo updates stopsInfo state with different statuses`() = runTest {
+    // Prepare mock response
+    val today = LocalDate.now()
+    val mockStops =
+        listOf(
+            Stop(
+                stopId = "stop1",
+                title = "Location1",
+                address = "Address1",
+                date = today,
+                startTime = LocalTime.of(10, 0),
+                duration = 120,
+                budget = 50.0,
+                description = "Description of Location1",
+                geoCords = GeoCords(40.712776, -74.005974),
+                website = "http://location1.com",
+                imageUrl = "http://example.com/location1.jpg"),
+            Stop(
+                stopId = "stop2",
+                title = "Location2",
+                address = "Address2",
+                date = today.plusDays(1),
+                startTime = LocalTime.of(15, 30),
+                duration = 90,
+                budget = 75.0,
+                description = "Description of Location2",
+                geoCords = GeoCords(34.052235, -118.243683),
+                website = "http://location2.com",
+                imageUrl = "http://example.com/location2.jpg"),
+            Stop(
+                stopId = "stop3",
+                title = "Location3",
+                address = "Address3",
+                date = today.minusDays(1),
+                startTime = LocalTime.of(9, 0),
+                duration = 60,
+                budget = 30.0,
+                description = "Description of Location3",
+                geoCords = GeoCords(51.507351, -0.127758),
+                website = "http://location3.com",
+                imageUrl = "http://example.com/location3.jpg"))
+
+    coEvery { mockTripsRepository.getAllStopsFromTrip(any()) } returns mockStops
+
+    // Call the method to test
+    viewModel.loadStopsInfo() // Assuming this method is public or internal for testing
+    advanceUntilIdle() // Wait for all coroutines to complete
+
+    // Check the resulting state
+    assertEquals(3, viewModel._stopsInfo.value.size)
+    assertEquals(CalendarUiState.StopStatus.CURRENT, viewModel._stopsInfo.value[mockStops[0].date])
+    assertEquals(
+        CalendarUiState.StopStatus.COMING_SOON, viewModel._stopsInfo.value[mockStops[1].date])
+    assertEquals(CalendarUiState.StopStatus.PAST, viewModel._stopsInfo.value[mockStops[2].date])
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/AgendaViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/AgendaViewModelTest.kt
@@ -55,7 +55,7 @@ class AgendaViewModelTest {
     coEvery { mockTripsRepository.getTrip("tripId") } returns mockTrip
 
     // Call the method to test
-    viewModel.loadTripData() // Assuming this method is public or internal for testing
+    viewModel.loadTripData()
     advanceUntilIdle() // Wait for all coroutines to complete
 
     // Check the resulting state

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/AgendaViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/AgendaViewModelTest.kt
@@ -37,7 +37,8 @@ class AgendaViewModelTest {
 
   /**
    * Test the loadStopsInfo method of the AgendaViewModel class to ensure that the stopsInfo state
-   * is updated correctly. The method should fetch the stops for the trip and update the stopsInfo.
+   * is updated correctly to PAST. The method should fetch the stops for the trip and update the
+   * stopsInfo.
    */
   @Test
   fun `loadStopsInfo updates stopsInfo state`() = runBlockingTest {
@@ -83,8 +84,8 @@ class AgendaViewModelTest {
 
     // Check the resulting state
     assertEquals(2, viewModel._stopsInfo.value.size)
-    assertEquals(CalendarUiState.StopStatus.CURRENT, viewModel._stopsInfo.value[mockStops[0].date])
-    assertEquals(CalendarUiState.StopStatus.CURRENT, viewModel._stopsInfo.value[mockStops[1].date])
+    assertEquals(CalendarUiState.StopStatus.PAST, viewModel._stopsInfo.value[mockStops[0].date])
+    assertEquals(CalendarUiState.StopStatus.PAST, viewModel._stopsInfo.value[mockStops[1].date])
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/StopItemViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/StopItemViewModelTest.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertFalse
@@ -49,7 +49,7 @@ class StopItemViewModelTest {
 
   @Test
   fun `deleteStop updates isDeleted state to true`() =
-      runTest(testDispatcher) {
+      runBlockingTest(testDispatcher) {
         // Call the deleteStop method
         viewModel.deleteStop(stopId)
 

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/StopsListViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/StopsListViewModelTest.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -66,7 +66,7 @@ class StopsListViewModelTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
   fun `loadStops fetches stops successfully and updates state`() =
-      runTest(testDispatcher) {
+      runBlockingTest(testDispatcher) {
         viewModel.loadStops()
 
         // Wait for all coroutines started during the test to complete

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
@@ -577,27 +577,6 @@ class SuggestionsViewModelTest {
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
-  fun testStartCountdown() =
-      runBlockingTest(testDispatcher) {
-        // Load the suggestions to set initial state
-        viewModel.loadSuggestion(tripId)
-        advanceUntilIdle()
-
-        // Capture the suggestion state before clicking the vote icon
-        val suggestion = viewModel.state.value.first()
-        assertFalse(viewModel.getVoteIconClicked(suggestion.suggestionId))
-
-        // Perform the action to toggle the vote icon and start the countdown
-        viewModel.toggleVoteIconClicked(suggestion)
-        advanceUntilIdle()
-
-        // Assert that the countdown is running
-        val remainingTimeFlow = viewModel.getRemainingTimeFlow(suggestion.suggestionId)
-        assertTrue(remainingTimeFlow.value == "23:59:59") // the countdown starts at 23:59:59
-      }
-
-  @OptIn(ExperimentalCoroutinesApi::class)
-  @Test
   fun testCountdownFormat() =
       runBlockingTest(testDispatcher) {
         // Load the suggestions to set initial state

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
@@ -577,6 +577,30 @@ class SuggestionsViewModelTest {
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
+  fun testStartCountdown() =
+      runBlockingTest(testDispatcher) {
+        // Load the suggestions to set initial state
+        viewModel.loadSuggestion(tripId)
+        advanceUntilIdle()
+
+        // Capture the suggestion state before clicking the vote icon
+        val suggestion = viewModel.state.value.first()
+        assertFalse(viewModel.getVoteIconClicked(suggestion.suggestionId))
+
+        // Perform the action to toggle the vote icon and start the countdown
+        viewModel.toggleVoteIconClicked(suggestion)
+        advanceUntilIdle()
+
+        // Assert that the countdown is running
+        val remainingTimeFlow = viewModel.getRemainingTimeFlow(suggestion.suggestionId)
+        assertTrue(
+            remainingTimeFlow.value !=
+                "23:59:59") // the countdown starts at 23:59:59, so it should not be equal to
+                            // 23:59:59
+      }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
   fun testCountdownFormat() =
       runBlockingTest(testDispatcher) {
         // Load the suggestions to set initial state

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
@@ -281,7 +281,7 @@ class SuggestionsViewModelTest {
 
         // Modify userLikes to simulate a toggle that reaches majority
         val updatedLikes = suggestion.userLikes + "currentUser"
-        val updatedStop = suggestion.stop.copy(stopStatus = CalendarUiState.StopStatus.ADDED)
+        val updatedStop = suggestion.stop.copy(stopStatus = CalendarUiState.StopStatus.CURRENT)
         val updatedSuggestion = suggestion.copy(userLikes = updatedLikes, stop = updatedStop)
 
         coEvery { mockTripsRepository.getSuggestionFromTrip(any(), any()) } returns
@@ -303,7 +303,7 @@ class SuggestionsViewModelTest {
                 suggestion.suggestionId)) // Check if added to stops
         coVerify {
           mockTripsRepository.updateSuggestionInTrip(
-              tripId, match { it.stop.stopStatus == CalendarUiState.StopStatus.ADDED })
+              tripId, match { it.stop.stopStatus == CalendarUiState.StopStatus.CURRENT })
         }
       }
 

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
@@ -596,7 +596,7 @@ class SuggestionsViewModelTest {
         assertTrue(
             remainingTimeFlow.value !=
                 "23:59:59") // the countdown starts at 23:59:59, so it should not be equal to
-                            // 23:59:59
+        // 23:59:59
       }
 
   @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/SuggestionsViewModelTest.kt
@@ -577,30 +577,6 @@ class SuggestionsViewModelTest {
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
-  fun testStartCountdown() =
-      runBlockingTest(testDispatcher) {
-        // Load the suggestions to set initial state
-        viewModel.loadSuggestion(tripId)
-        advanceUntilIdle()
-
-        // Capture the suggestion state before clicking the vote icon
-        val suggestion = viewModel.state.value.first()
-        assertFalse(viewModel.getVoteIconClicked(suggestion.suggestionId))
-
-        // Perform the action to toggle the vote icon and start the countdown
-        viewModel.toggleVoteIconClicked(suggestion)
-        advanceUntilIdle()
-
-        // Assert that the countdown is running
-        val remainingTimeFlow = viewModel.getRemainingTimeFlow(suggestion.suggestionId)
-        assertTrue(
-            remainingTimeFlow.value !=
-                "23:59:59") // the countdown starts at 23:59:59, so it should not be equal to
-        // 23:59:59
-      }
-
-  @OptIn(ExperimentalCoroutinesApi::class)
-  @Test
   fun testCountdownFormat() =
       runBlockingTest(testDispatcher) {
         // Load the suggestions to set initial state


### PR DESCRIPTION
In this pull request,
1) 
I have developed the agenda markers to have more statuses associated with different colors on the calendar of the agenda.
There are four statuses for the StopStatus enumeration class:
1) the `CURRENT` status which stands for a suggestion that has been transformed to a stop of the trip and it is a stop of the trip of the current day;
2) the `COMING_SOON` status which stands for a suggestion that has been transformed to a stop of the trip and it is a stop of the trip on a day between the next day of the current day and the end of the trip date (included);
3) the `PAST` status which stands for a suggestion that has been transformed to a stop of the trip and it is a stop of the trip on a day between the the start of the trip date (included) and the day before the current day (included);
4) the `NONE` status which stands for a suggestion that has not been transformed to a stop of the trip yet, it is still a suggestion of the trip.

The colors of the stop statuses are dynamic. Meaning:
- If the current day is 2024 May 20th and there is a stop on that day, then the marker color will be purple on that day, and for the other days of the trip: the marker color will be either grey if the days where there is a stop is before 2024 May 20th or light blue if the days where there is a stop is after 2024 May 20th.
- If we come back to the app the next day (for example), the marker color for the day 2024 May 20th will be grey, and if there are stops on 2024 May 21st, then the marker color for 2024 May 21st will be purple, and for the other days of the trip: the marker color will be either grey if the days where there is a stop is before 2024 May 21st or light blue if the days where there is a stop is after 2024 May 21st.
If there are no stops on 2024 May 21st, then there will be no markers on that day on the calendar.

\
Note that the `ADDED` status has been removed and there are `CURRENT`, `PAST`, and `COMING_SOON`.

\
2) (after discussing with TAs, this pull request will be light if I only add more `stopStatus`es because it is a functionality that I have already developed, thus here is a new functionality:) There is now a continuous light-purple background to indicate the trip range. For example, if the trip starts on May 15th, 2024, and ends on May 24th, 2024, then the background within this trip range will be displayed on the calendar.

\
3) I have refactored the code related to 1) and 2).

\
\
Therefore, more tests are built in AgendaTest.kt and AgendaViewModelTest.kt for testing the UI elements and the functionalities of 1) and 2).
\
This pull request is for issue #361 .