### PR TITLE
Redesign a menu for the dashboard

### DIFF
--- a/app/src/androidTest/java/com/github/se/wanderpals/dashboard/DashboardTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/dashboard/DashboardTest.kt
@@ -782,4 +782,62 @@ class DashboardTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeS
     composeTestRule.onNodeWithTag("menuButton", useUnmergedTree = true).performClick()
     composeTestRule.onNodeWithTag("deleteTripButton", useUnmergedTree = true).assertDoesNotExist()
   }
+
+  @Test
+  fun menuNavigationWorks() = run {
+    val viewModel = DashboardViewModelTest(emptyList())
+    viewModel.setLoading(false)
+    composeTestRule.setContent {
+      Dashboard(tripId = "", dashboardViewModel = viewModel, navActions = mockNavActions)
+    }
+
+    composeTestRule.onNodeWithTag("menuButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("AdminButtonTest", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("menuNav", useUnmergedTree = true).assertIsNotDisplayed()
+
+    verify { mockNavActions.navigateTo(Route.ADMIN_PAGE) }
+
+    composeTestRule.onNodeWithTag("menuButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("backToOverviewButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("menuNav", useUnmergedTree = true).assertIsNotDisplayed()
+
+    verify { mockNavActions.navigateTo(Route.OVERVIEW) }
+
+    composeTestRule.onNodeWithTag("menuButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("financeButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("menuNav", useUnmergedTree = true).assertIsNotDisplayed()
+
+    verify { mockNavActions.navigateTo(Route.FINANCE) }
+
+    composeTestRule.onNodeWithTag("menuButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("agendaButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("menuNav", useUnmergedTree = true).assertIsNotDisplayed()
+
+    verify { mockNavActions.navigateTo(Route.AGENDA) }
+
+    composeTestRule.onNodeWithTag("menuButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("suggestionButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("menuNav", useUnmergedTree = true).assertIsNotDisplayed()
+
+    verify { mockNavActions.navigateTo(Route.SUGGESTION) }
+
+    composeTestRule.onNodeWithTag("menuButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("documentButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("menuNav", useUnmergedTree = true).assertIsNotDisplayed()
+
+    verify { mockNavActions.navigateTo(Route.DOCUMENT) }
+
+    composeTestRule.onNodeWithTag("menuButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("notificationButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("menuNav", useUnmergedTree = true).assertIsNotDisplayed()
+
+    verify { mockNavActions.navigateTo(Route.NOTIFICATION) }
+
+    composeTestRule.onNodeWithTag("menuButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("mapButton", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("menuNav", useUnmergedTree = true).assertIsNotDisplayed()
+
+    verify { mockNavActions.navigateTo(Route.MAP) }
+    confirmVerified(mockNavActions)
+  }
 }

--- a/app/src/androidTest/java/com/github/se/wanderpals/dashboard/DashboardTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/dashboard/DashboardTest.kt
@@ -252,6 +252,7 @@ class DashboardTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeS
     composeTestRule.onNodeWithTag("suggestionTitle", useUnmergedTree = true).assertIsDisplayed()
     // Check that the suggestion widget is displayed
     composeTestRule.onNodeWithTag("noSuggestions", useUnmergedTree = true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("shareIcon", useUnmergedTree = true).assertIsDisplayed()
   }
 
   @Test

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/dashboard/DashboardStopWidget.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/dashboard/DashboardStopWidget.kt
@@ -138,11 +138,11 @@ fun DashboardStopWidget(viewModel: DashboardViewModel, onClick: () -> Unit = {})
                       } else {
                         Column {
                           StopWidgetItem(stop = sortedStops[0])
-                          HorizontalDivider(
-                              color = MaterialTheme.colorScheme.surfaceVariant,
-                              thickness = 1.dp,
-                              modifier = Modifier.padding(horizontal = 8.dp))
                           if (sortedStops.size > 1) {
+                            HorizontalDivider(
+                                color = MaterialTheme.colorScheme.surfaceVariant,
+                                thickness = 1.dp,
+                                modifier = Modifier.padding(horizontal = 8.dp))
                             StopWidgetItem(stop = sortedStops[1])
                           } else {
                             Box(modifier = Modifier.fillMaxSize())

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/dashboard/DashboardSuggestionWidget.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/dashboard/DashboardSuggestionWidget.kt
@@ -135,18 +135,18 @@ fun DashboardSuggestionWidget(viewModel: DashboardViewModel, onClick: () -> Unit
                       } else {
                         Column {
                           SuggestionWidgetItem(suggestion = sortedSuggestion[0])
-                          HorizontalDivider(
-                              color = MaterialTheme.colorScheme.surfaceVariant,
-                              thickness = 1.dp,
-                              modifier = Modifier.padding(horizontal = 8.dp))
                           if (sortedSuggestion.size > 1) {
-                            SuggestionWidgetItem(suggestion = sortedSuggestion[1])
                             HorizontalDivider(
                                 color = MaterialTheme.colorScheme.surfaceVariant,
                                 thickness = 1.dp,
                                 modifier = Modifier.padding(horizontal = 8.dp))
+                            SuggestionWidgetItem(suggestion = sortedSuggestion[1])
                           }
                           if (sortedSuggestion.size > 2) {
+                            HorizontalDivider(
+                                color = MaterialTheme.colorScheme.surfaceVariant,
+                                thickness = 1.dp,
+                                modifier = Modifier.padding(horizontal = 8.dp))
                             SuggestionWidgetItem(suggestion = sortedSuggestion[2])
                           } else {
                             Box(modifier = Modifier.fillMaxSize())

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/Dashboard.kt
@@ -424,7 +424,7 @@ fun TopDashboardBar(
                 Icon(
                     Icons.Default.Share,
                     contentDescription = "Menu",
-                    modifier = Modifier.size(40.dp),
+                    modifier = Modifier.size(32.dp).testTag("shareIcon"),
                     tint = MaterialTheme.colorScheme.onPrimary)
               }
             }


### PR DESCRIPTION
In this PR, the following has been done : 

- Changed the menu to be more in theme with the rest of the app and serve as a central point to navigating around
- Fixed a display issue in the widget of suggestion and stop where a horizontal divider would display where it shouldn't
- Added a share button in the dashboard to complete every feature the dashboard should have based on the figma