### PR TITLE
Currency conversion in real time 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -207,6 +207,8 @@ dependencies {
     // Google Places
     implementation(libs.places)
 
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+
     debugImplementation("androidx.compose.ui:ui-tooling:1.6.7")
     implementation("androidx.compose.ui:ui-tooling-preview:1.6.7")
 

--- a/app/src/androidTest/java/com/github/se/wanderpals/finance/FinanceTest.kt
+++ b/app/src/androidTest/java/com/github/se/wanderpals/finance/FinanceTest.kt
@@ -125,7 +125,7 @@ class FinanceViewModelTest :
   }
 
   // Override the updateCurrencyFunction to avoid call from the tripsRepository in tests
-  override fun updateCurrency(currencyCode: String) {}
+  override fun updateCurrency(newCurrencyCode: String) {}
 }
 
 @RunWith(AndroidJUnit4::class)

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
@@ -117,7 +117,7 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
   open fun updateCurrency(newCurrencyCode: String) {
     viewModelScope.launch {
       val currentTrip = tripsRepository.getTrip(tripId)!!
-      updateExchangeRate(currentTrip.currencyCode, newCurrencyCode)
+      setExchangeRate(currentTrip.currencyCode, newCurrencyCode)
       if (exchangeRate.value != null) {
         val expenses = tripsRepository.getAllExpensesFromTrip(tripId)
         expenses.forEach {
@@ -131,7 +131,7 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
   }
 
   /**
-   * Updates the exchange rate between two currencies.
+   * Set the exchange rate between two currencies in the finance view model.
    *
    * This method fetches the exchange rate from a remote API by performing an http request and
    * updates the _exchangeRate state variable with the retrieved value.
@@ -139,7 +139,7 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
    * @param fromCurrency The original currency code.
    * @param toCurrency The target currency code.
    */
-  private suspend fun updateExchangeRate(fromCurrency: String, toCurrency: String) {
+  private suspend fun setExchangeRate(fromCurrency: String, toCurrency: String) {
     withContext(Dispatchers.IO) {
       try {
         val client = OkHttpClient()

--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
@@ -11,8 +11,10 @@ import com.github.se.wanderpals.service.NotificationsManager
 import com.squareup.okhttp.OkHttpClient
 import com.squareup.okhttp.Request
 import com.squareup.okhttp.Response
-import kotlinx.coroutines.Dispatchers
+import java.io.IOException
+import java.time.LocalDate
 import java.util.Currency
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,8 +23,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
 import org.json.JSONObject
-import java.io.IOException
-import java.time.LocalDate
 
 /**
  * ViewModel for managing the financial data of a trip.
@@ -58,7 +58,6 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
   open val tripCurrency = _tripCurrency.asStateFlow()
 
   val exchangeRate = MutableStateFlow<Double?>(null)
-
 
   /** Fetches all expenses from the trip and updates the state flow accordingly. */
   open fun updateStateLists() {
@@ -109,20 +108,21 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
   /**
    * Updates the currency code of the current trip.
    *
-   * This method retrieves the current trip from the repository, updates the exchange rate,
-   * converts all expenses to the new currency, updates the trip with the new currency code,
-   * and refreshes the related state lists.
+   * This method retrieves the current trip from the repository, updates the exchange rate, converts
+   * all expenses to the new currency, updates the trip with the new currency code, and refreshes
+   * the related state lists.
    *
    * @param newCurrencyCode The new currency code to be used for the trip.
    */
   open fun updateCurrency(newCurrencyCode: String) {
     viewModelScope.launch {
       val currentTrip = tripsRepository.getTrip(tripId)!!
-      updateExchangeRate(currentTrip.currencyCode,newCurrencyCode)
-      if(exchangeRate.value != null){
+      updateExchangeRate(currentTrip.currencyCode, newCurrencyCode)
+      if (exchangeRate.value != null) {
         val expenses = tripsRepository.getAllExpensesFromTrip(tripId)
-        expenses.forEach{
-          tripsRepository.updateExpenseInTrip(tripId,it.copy(amount = it.amount * exchangeRate.value!!))
+        expenses.forEach {
+          tripsRepository.updateExpenseInTrip(
+              tripId, it.copy(amount = it.amount * exchangeRate.value!!))
         }
         tripsRepository.updateTrip(currentTrip.copy(currencyCode = newCurrencyCode))
         updateStateLists()
@@ -133,8 +133,8 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
   /**
    * Updates the exchange rate between two currencies.
    *
-   * This method fetches the exchange rate from a remote API by performing an http request
-   * and updates the _exchangeRate state variable with the retrieved value.
+   * This method fetches the exchange rate from a remote API by performing an http request and
+   * updates the _exchangeRate state variable with the retrieved value.
    *
    * @param fromCurrency The original currency code.
    * @param toCurrency The target currency code.
@@ -144,20 +144,22 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
       try {
         val client = OkHttpClient()
 
-        val url = buildExchangeURL(fromCurrency,toCurrency)
+        val url = buildExchangeURL(fromCurrency, toCurrency)
 
-        val request = Request.Builder()
-          .url(url)
-          .build()
+        val request = Request.Builder().url(url).build()
 
         val response: Response = client.newCall(request).execute()
 
         if (response.isSuccessful) {
           val responseBody = response.body()?.string()
-          val exchangeRateResponse = responseBody?.let {
-            JSONObject(it).getJSONArray("response").getJSONObject(0)
-              .getString("average_bid").toDouble()
-          }
+          val exchangeRateResponse =
+              responseBody?.let {
+                JSONObject(it)
+                    .getJSONArray("response")
+                    .getJSONObject(0)
+                    .getString("average_bid")
+                    .toDouble()
+              }
           exchangeRate.value = exchangeRateResponse
           Log.d("UpdateExchangeRate", "Exchange rate updated successfully: $exchangeRate")
         } else {
@@ -181,27 +183,25 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
    * @param toCurrency The target currency code.
    * @return The URL for the exchange rate API.
    */
-  private fun buildExchangeURL(fromCurrency: String,toCurrency: String): String {
+  private fun buildExchangeURL(fromCurrency: String, toCurrency: String): String {
 
     val currentDate = LocalDate.now()
     val startDate = currentDate.minusDays(1).toString() // Yesterday's date
     val endDate = currentDate.toString() // Today's date
 
     return HttpUrl.Builder()
-      .scheme("https")
-      .host("fxds-public-exchange-rates-api.oanda.com")
-      .addPathSegment("cc-api")
-      .addPathSegment("currencies")
-      .addQueryParameter("base", fromCurrency)
-      .addQueryParameter("quote", toCurrency)
-      .addQueryParameter("data_type", "general_currency_pair")
-      .addQueryParameter("start_date", startDate)
-      .addQueryParameter("end_date", endDate)
-      .build()
-      .toString()
-
+        .scheme("https")
+        .host("fxds-public-exchange-rates-api.oanda.com")
+        .addPathSegment("cc-api")
+        .addPathSegment("currencies")
+        .addQueryParameter("base", fromCurrency)
+        .addQueryParameter("quote", toCurrency)
+        .addQueryParameter("data_type", "general_currency_pair")
+        .addQueryParameter("start_date", startDate)
+        .addQueryParameter("end_date", endDate)
+        .build()
+        .toString()
   }
-
 
   /** Setter functions */
   open fun setShowDeleteDialogState(value: Boolean) {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CurrencySelectionDialog.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CurrencySelectionDialog.kt
@@ -108,10 +108,8 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
                                       it.currencyCode.equals(searchedCurrency, ignoreCase = true)
                                 }
                             if (newCurrency != null) {
-                              val actualCurrencyCode = financeViewModel.tripCurrency.value.currencyCode
                               val newCurrencyCode = newCurrency.currencyCode
-                              financeViewModel.convertCurrency(actualCurrencyCode,newCurrencyCode)
-                              financeViewModel.updateCurrency(newCurrency.currencyCode)
+                              financeViewModel.updateCurrency(newCurrencyCode)
                               financeViewModel.setShowCurrencyDialogState(false)
 
                               isError = false

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CurrencySelectionDialog.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CurrencySelectionDialog.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,7 +40,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.github.se.wanderpals.model.viewmodel.FinanceViewModel
-import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * A composable function that displays a dialog for currency selection. The user can search the
@@ -57,7 +55,6 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
   var isError by remember { mutableStateOf(false) }
   val currencies = Currency.getAvailableCurrencies().filterNot { it.displayName.contains("(") }
 
-
   Dialog(
       onDismissRequest = {
         isError = false
@@ -65,10 +62,9 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
       }) {
         Surface(
             modifier =
-            Modifier
-                .fillMaxSize()
-                .padding(top = 100.dp, bottom = 100.dp)
-                .testTag("currencyDialog"),
+                Modifier.fillMaxSize()
+                    .padding(top = 100.dp, bottom = 100.dp)
+                    .testTag("currencyDialog"),
             color = MaterialTheme.colorScheme.background,
         ) {
           Column(
@@ -80,11 +76,10 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
                     value = searchedCurrency,
                     onValueChange = { value -> searchedCurrency = value },
                     modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(20.dp)
-                        .clip(RoundedCornerShape(5.dp))
-                        .testTag("currencySearchText"),
+                        Modifier.fillMaxWidth()
+                            .padding(20.dp)
+                            .clip(RoundedCornerShape(5.dp))
+                            .testTag("currencySearchText"),
                     label = {
                       Text(
                           text = if (isError) "Invalid currency" else "Select a currency",
@@ -143,16 +138,15 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
                       items(filteredCurrencies) { currency ->
                         Box(
                             modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 20.dp)
-                                .clip(RoundedCornerShape(5.dp))
-                                .border(
-                                    1.dp,
-                                    Color.Gray,
-                                    RoundedCornerShape(5.dp),
-                                )
-                                .testTag("currencyItem"),
+                                Modifier.fillMaxWidth()
+                                    .padding(horizontal = 20.dp)
+                                    .clip(RoundedCornerShape(5.dp))
+                                    .border(
+                                        1.dp,
+                                        Color.Gray,
+                                        RoundedCornerShape(5.dp),
+                                    )
+                                    .testTag("currencyItem"),
                             contentAlignment = Alignment.CenterStart) {
                               Button(
                                   modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CurrencySelectionDialog.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CurrencySelectionDialog.kt
@@ -56,7 +56,7 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
   var searchedCurrency by remember { mutableStateOf("") }
   var isError by remember { mutableStateOf(false) }
   val currencies = Currency.getAvailableCurrencies().filterNot { it.displayName.contains("(") }
-  val test by financeViewModel.test.asStateFlow().collectAsState()
+
 
   Dialog(
       onDismissRequest = {
@@ -108,10 +108,12 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
                                       it.currencyCode.equals(searchedCurrency, ignoreCase = true)
                                 }
                             if (newCurrency != null) {
-                              financeViewModel.exchangeCurrency(
-                                  financeViewModel.tripCurrency.value.currencyCode,newCurrency.currencyCode)
+                              val actualCurrencyCode = financeViewModel.tripCurrency.value.currencyCode
+                              val newCurrencyCode = newCurrency.currencyCode
+                              val success = financeViewModel.convertCurrency(actualCurrencyCode,newCurrencyCode)
                               financeViewModel.updateCurrency(newCurrency.currencyCode)
                               financeViewModel.setShowCurrencyDialogState(false)
+
                               isError = false
                             } else {
                               isError = true

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CurrencySelectionDialog.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CurrencySelectionDialog.kt
@@ -103,8 +103,7 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
                                       it.currencyCode.equals(searchedCurrency, ignoreCase = true)
                                 }
                             if (newCurrency != null) {
-                              val newCurrencyCode = newCurrency.currencyCode
-                              financeViewModel.updateCurrency(newCurrencyCode)
+                              financeViewModel.updateCurrency(newCurrency.currencyCode)
                               financeViewModel.setShowCurrencyDialogState(false)
 
                               isError = false

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CurrencySelectionDialog.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CurrencySelectionDialog.kt
@@ -110,7 +110,7 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
                             if (newCurrency != null) {
                               val actualCurrencyCode = financeViewModel.tripCurrency.value.currencyCode
                               val newCurrencyCode = newCurrency.currencyCode
-                              val success = financeViewModel.convertCurrency(actualCurrencyCode,newCurrencyCode)
+                              financeViewModel.convertCurrency(actualCurrencyCode,newCurrencyCode)
                               financeViewModel.updateCurrency(newCurrency.currencyCode)
                               financeViewModel.setShowCurrencyDialogState(false)
 

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CurrencySelectionDialog.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CurrencySelectionDialog.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -40,6 +41,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.github.se.wanderpals.model.viewmodel.FinanceViewModel
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * A composable function that displays a dialog for currency selection. The user can search the
@@ -54,6 +56,7 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
   var searchedCurrency by remember { mutableStateOf("") }
   var isError by remember { mutableStateOf(false) }
   val currencies = Currency.getAvailableCurrencies().filterNot { it.displayName.contains("(") }
+  val test by financeViewModel.test.asStateFlow().collectAsState()
 
   Dialog(
       onDismissRequest = {
@@ -62,9 +65,10 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
       }) {
         Surface(
             modifier =
-                Modifier.fillMaxSize()
-                    .padding(top = 100.dp, bottom = 100.dp)
-                    .testTag("currencyDialog"),
+            Modifier
+                .fillMaxSize()
+                .padding(top = 100.dp, bottom = 100.dp)
+                .testTag("currencyDialog"),
             color = MaterialTheme.colorScheme.background,
         ) {
           Column(
@@ -76,10 +80,11 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
                     value = searchedCurrency,
                     onValueChange = { value -> searchedCurrency = value },
                     modifier =
-                        Modifier.fillMaxWidth()
-                            .padding(20.dp)
-                            .clip(RoundedCornerShape(5.dp))
-                            .testTag("currencySearchText"),
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(20.dp)
+                        .clip(RoundedCornerShape(5.dp))
+                        .testTag("currencySearchText"),
                     label = {
                       Text(
                           text = if (isError) "Invalid currency" else "Select a currency",
@@ -103,6 +108,8 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
                                       it.currencyCode.equals(searchedCurrency, ignoreCase = true)
                                 }
                             if (newCurrency != null) {
+                              financeViewModel.exchangeCurrency(
+                                  financeViewModel.tripCurrency.value.currencyCode,newCurrency.currencyCode)
                               financeViewModel.updateCurrency(newCurrency.currencyCode)
                               financeViewModel.setShowCurrencyDialogState(false)
                               isError = false
@@ -136,15 +143,16 @@ fun CurrencySelectionDialog(financeViewModel: FinanceViewModel) {
                       items(filteredCurrencies) { currency ->
                         Box(
                             modifier =
-                                Modifier.fillMaxWidth()
-                                    .padding(horizontal = 20.dp)
-                                    .clip(RoundedCornerShape(5.dp))
-                                    .border(
-                                        1.dp,
-                                        Color.Gray,
-                                        RoundedCornerShape(5.dp),
-                                    )
-                                    .testTag("currencyItem"),
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 20.dp)
+                                .clip(RoundedCornerShape(5.dp))
+                                .border(
+                                    1.dp,
+                                    Color.Gray,
+                                    RoundedCornerShape(5.dp),
+                                )
+                                .testTag("currencyItem"),
                             contentAlignment = Alignment.CenterStart) {
                               Button(
                                   modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpensesContent.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/ExpensesContent.kt
@@ -172,7 +172,7 @@ fun ExpenseItem(expense: Expense, currencySymbol: String, onExpenseItemClick: (E
                     horizontalAlignment = Alignment.End) {
                       // Expense amount
                       Text(
-                          text = ("%.2f $currencySymbol" + "").format(expense.amount),
+                          text = ("%.2f $currencySymbol").format(expense.amount),
                           style =
                               TextStyle(
                                   fontSize = 14.sp, color = MaterialTheme.colorScheme.secondary))

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/FinanceBottomBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/FinanceBottomBar.kt
@@ -26,9 +26,8 @@ import com.github.se.wanderpals.service.SessionManager
  */
 @Composable
 fun FinanceBottomBar(expenses: List<Expense>, currencySymbol: String) {
-  val totalAmount = expenses
-    .filter { it.userId == SessionManager.getCurrentUser()?.userId }
-    .sumOf { it.amount }
+  val totalAmount =
+      expenses.filter { it.userId == SessionManager.getCurrentUser()?.userId }.sumOf { it.amount }
   Row(
       modifier =
           Modifier.fillMaxWidth()
@@ -46,7 +45,7 @@ fun FinanceBottomBar(expenses: List<Expense>, currencySymbol: String) {
                   color = MaterialTheme.colorScheme.onPrimary,
                   modifier = Modifier.align(Alignment.Start))
               Text(
-                  text ="%.2f %s".format(totalAmount,currencySymbol) ,
+                  text = "%.2f %s".format(totalAmount, currencySymbol),
                   color = MaterialTheme.colorScheme.onPrimary,
                   modifier = Modifier.align(Alignment.Start),
               )
@@ -60,7 +59,7 @@ fun FinanceBottomBar(expenses: List<Expense>, currencySymbol: String) {
                   color = MaterialTheme.colorScheme.onPrimary,
                   modifier = Modifier.align(Alignment.End))
               Text(
-                  text = "%.2f %s".format(expenses.sumOf { it.amount },currencySymbol),
+                  text = "%.2f %s".format(expenses.sumOf { it.amount }, currencySymbol),
                   color = MaterialTheme.colorScheme.onPrimary,
                   modifier = Modifier.align(Alignment.End))
             }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/FinanceBottomBar.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/FinanceBottomBar.kt
@@ -26,6 +26,9 @@ import com.github.se.wanderpals.service.SessionManager
  */
 @Composable
 fun FinanceBottomBar(expenses: List<Expense>, currencySymbol: String) {
+  val totalAmount = expenses
+    .filter { it.userId == SessionManager.getCurrentUser()?.userId }
+    .sumOf { it.amount }
   Row(
       modifier =
           Modifier.fillMaxWidth()
@@ -43,10 +46,7 @@ fun FinanceBottomBar(expenses: List<Expense>, currencySymbol: String) {
                   color = MaterialTheme.colorScheme.onPrimary,
                   modifier = Modifier.align(Alignment.Start))
               Text(
-                  text =
-                      "${expenses
-                          .filter { it.userId == SessionManager.getCurrentUser()?.userId }
-                          .sumOf { it.amount }} $currencySymbol",
+                  text ="%.2f %s".format(totalAmount,currencySymbol) ,
                   color = MaterialTheme.colorScheme.onPrimary,
                   modifier = Modifier.align(Alignment.Start),
               )
@@ -60,7 +60,7 @@ fun FinanceBottomBar(expenses: List<Expense>, currencySymbol: String) {
                   color = MaterialTheme.colorScheme.onPrimary,
                   modifier = Modifier.align(Alignment.End))
               Text(
-                  text = "${expenses.sumOf { it.amount }} $currencySymbol",
+                  text = "%.2f %s".format(expenses.sumOf { it.amount },currencySymbol),
                   color = MaterialTheme.colorScheme.onPrimary,
                   modifier = Modifier.align(Alignment.End))
             }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/FinancePieChart.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/FinancePieChart.kt
@@ -71,7 +71,7 @@ fun FinancePieChart(
                     color = MaterialTheme.colorScheme.primary,
                 )
                 Text(
-                    text = "$totalExpense $currencySymbol",
+                    text = "%.2f %s".format(totalExpense, currencySymbol),
                     style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
                     color = MaterialTheme.colorScheme.primary,
                 )

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/FinanceViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/FinanceViewModelTest.kt
@@ -35,9 +35,6 @@ class FinanceViewModelTest {
   private val testDispatcher = StandardTestDispatcher()
   private val tripId = "tripId"
 
-
-
-
   @OptIn(ExperimentalCoroutinesApi::class)
   @Before
   fun setup() {
@@ -58,17 +55,32 @@ class FinanceViewModelTest {
     coEvery { mockTripsRepository.getAllExpensesFromTrip(tripId) } returns
         listOf(
             Expense(
-                "", "Lunch", 10.0, Category.FOOD, "", "", emptyList(), emptyList(), LocalDate.now()))
+                "",
+                "Lunch",
+                10.0,
+                Category.FOOD,
+                "",
+                "",
+                emptyList(),
+                emptyList(),
+                LocalDate.now()))
     coEvery { mockTripsRepository.getAllUsersFromTrip(tripId) } returns
         listOf(User(userId = "1", name = "Alice"))
     coEvery { mockTripsRepository.addExpenseToTrip(tripId, any()) } returns "true"
     coEvery { mockTripsRepository.getTrip(any()) } returns
         Trip("-1", "", LocalDate.now(), LocalDate.now(), 0.0, "")
-    coEvery { mockTripsRepository.getAllExpensesFromTrip(any()) } returns  listOf(
-      Expense(
-        "", "Lunch", 10.0, Category.FOOD, "", "", emptyList(), emptyList(), LocalDate.now()))
-
-
+    coEvery { mockTripsRepository.getAllExpensesFromTrip(any()) } returns
+        listOf(
+            Expense(
+                "",
+                "Lunch",
+                10.0,
+                Category.FOOD,
+                "",
+                "",
+                emptyList(),
+                emptyList(),
+                LocalDate.now()))
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
@@ -111,36 +123,35 @@ class FinanceViewModelTest {
         coVerify { mockTripsRepository.addExpenseToTrip(tripId, expense) }
         assert(viewModel.expenseStateList.value.contains(expense))
       }
+
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
-  fun `updateCurrency updates trip currency and expenses correctly`() = runBlockingTest(testDispatcher) {
-    // Arrange
-    val newCurrency = "EUR"
-    val exchangeRate = 0.85
+  fun `updateCurrency updates trip currency and expenses correctly`() =
+      runBlockingTest(testDispatcher) {
+        // Arrange
+        val newCurrency = "EUR"
+        val exchangeRate = 0.85
 
-    // Mocking the _exchangeRate LiveData
-    val exchangeRateLiveData = MutableStateFlow<Double?>(exchangeRate)
-    viewModel.exchangeRate.value= exchangeRateLiveData.value
+        // Mocking the _exchangeRate LiveData
+        val exchangeRateLiveData = MutableStateFlow<Double?>(exchangeRate)
+        viewModel.exchangeRate.value = exchangeRateLiveData.value
 
-    val viewModelSpy = spyk(viewModel, recordPrivateCalls = true)
-    viewModelSpy
-    coEvery { viewModelSpy["updateExchangeRate"]("CHF",newCurrency) } coAnswers {}
+        val viewModelSpy = spyk(viewModel, recordPrivateCalls = true)
+        viewModelSpy
+        coEvery { viewModelSpy["updateExchangeRate"]("CHF", newCurrency) } coAnswers {}
 
-    // Act
-    viewModelSpy.updateCurrency(newCurrency)
+        // Act
+        viewModelSpy.updateCurrency(newCurrency)
 
-    advanceUntilIdle()
+        advanceUntilIdle()
 
+        coVerify { mockTripsRepository.getTrip(tripId) }
+        coVerify { mockTripsRepository.getAllExpensesFromTrip(tripId) }
 
-    coVerify { mockTripsRepository.getTrip(tripId) }
-    coVerify { mockTripsRepository.getAllExpensesFromTrip(tripId) }
-
-    coVerify {
-      mockTripsRepository.updateExpenseInTrip(
-        tripId,
-        match { it.amount == 10.0 * exchangeRate }
-      )
-    }
-    coVerify {(mockTripsRepository.updateTrip(any()))}
-  }
+        coVerify {
+          mockTripsRepository.updateExpenseInTrip(
+              tripId, match { it.amount == 10.0 * exchangeRate })
+        }
+        coVerify { (mockTripsRepository.updateTrip(any())) }
+      }
 }

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/FinanceViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/FinanceViewModelTest.kt
@@ -137,7 +137,6 @@ class FinanceViewModelTest {
         viewModel.exchangeRate.value = exchangeRateLiveData.value
 
         val viewModelSpy = spyk(viewModel, recordPrivateCalls = true)
-        viewModelSpy
         coEvery { viewModelSpy["updateExchangeRate"]("CHF", newCurrency) } coAnswers {}
 
         // Act

--- a/app/src/test/java/com/github/se/wanderpals/viewmodel/FinanceViewModelTest.kt
+++ b/app/src/test/java/com/github/se/wanderpals/viewmodel/FinanceViewModelTest.kt
@@ -137,7 +137,7 @@ class FinanceViewModelTest {
         viewModel.exchangeRate.value = exchangeRateLiveData.value
 
         val viewModelSpy = spyk(viewModel, recordPrivateCalls = true)
-        coEvery { viewModelSpy["updateExchangeRate"]("CHF", newCurrency) } coAnswers {}
+        coEvery { viewModelSpy["setExchangeRate"]("CHF", newCurrency) } coAnswers {}
 
         // Act
         viewModelSpy.updateCurrency(newCurrency)


### PR DESCRIPTION
This PR aimed to perform real time currency when the user changes the currency of the trip (this PR follows the work did on PR #386).
-  Now when changing the currency, the FinanceViewModel will perform an http get request using `OkHttp` on the currency converter coming from this website : [](https://www.oanda.com/rw-en/trading/) and use the old currency and new currency in the queries parameters
-  The response is parsed as a json answer response from their currency converter. After extracting the json answer containing the exchange rate between both currencies, the financeViewModel performs the expense amount transformation accordingly.