### PR TITLE
Fix Expense Duplication and Screen Flicker in FinanceViewModel and CreateExpense Screen

### DIFF
--- a/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
+++ b/app/src/main/java/com/github/se/wanderpals/model/viewmodel/FinanceViewModel.kt
@@ -34,7 +34,7 @@ import org.json.JSONObject
  * @param tripId The ID of the trip this ViewModel is associated with.
  */
 open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: String) :
-  ViewModel() {
+    ViewModel() {
 
   private val _users = MutableStateFlow(emptyList<User>())
   open val users: StateFlow<List<User>> = _users.asStateFlow()
@@ -59,8 +59,7 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
 
   // signal that the Expense was added successfully
   private val _createExpenseFinished = MutableStateFlow(false)
-  open val createExpenseFinished: StateFlow<Boolean> =
-    _createExpenseFinished.asStateFlow()
+  open val createExpenseFinished: StateFlow<Boolean> = _createExpenseFinished.asStateFlow()
 
   // don't add an Expense twice
   private val _isAddingExpense = MutableStateFlow(false)
@@ -98,10 +97,10 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
         _isAddingExpense.value = true
         tripsRepository.addExpenseToTrip(tripId, expense)
         val expenseList = tripsRepository.getAllExpensesFromTrip(tripId)
-        if(expenseList.isEmpty()){
-          //error
-          Log.e("FinanceViewModel","Error reading expense after addition (should not happen)")
-        }else{
+        if (expenseList.isEmpty()) {
+          // error
+          Log.e("FinanceViewModel", "Error reading expense after addition (should not happen)")
+        } else {
           val newExpense = expenseList.last()
           NotificationsManager.addExpenseNotification(tripId, newExpense)
         }
@@ -148,7 +147,7 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
         val expenses = tripsRepository.getAllExpensesFromTrip(tripId)
         expenses.forEach {
           tripsRepository.updateExpenseInTrip(
-            tripId, it.copy(amount = it.amount * exchangeRate.value!!))
+              tripId, it.copy(amount = it.amount * exchangeRate.value!!))
         }
         tripsRepository.updateTrip(currentTrip.copy(currencyCode = newCurrencyCode))
         updateStateLists()
@@ -179,13 +178,13 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
         if (response.isSuccessful) {
           val responseBody = response.body()?.string()
           val exchangeRateResponse =
-            responseBody?.let {
-              JSONObject(it)
-                .getJSONArray("response")
-                .getJSONObject(0)
-                .getString("average_bid")
-                .toDouble()
-            }
+              responseBody?.let {
+                JSONObject(it)
+                    .getJSONArray("response")
+                    .getJSONObject(0)
+                    .getString("average_bid")
+                    .toDouble()
+              }
           exchangeRate.value = exchangeRateResponse
           Log.d("UpdateExchangeRate", "Exchange rate updated successfully: $exchangeRate")
         } else {
@@ -216,17 +215,17 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
     val endDate = currentDate.toString() // Today's date
 
     return HttpUrl.Builder()
-      .scheme("https")
-      .host("fxds-public-exchange-rates-api.oanda.com")
-      .addPathSegment("cc-api")
-      .addPathSegment("currencies")
-      .addQueryParameter("base", fromCurrency)
-      .addQueryParameter("quote", toCurrency)
-      .addQueryParameter("data_type", "general_currency_pair")
-      .addQueryParameter("start_date", startDate)
-      .addQueryParameter("end_date", endDate)
-      .build()
-      .toString()
+        .scheme("https")
+        .host("fxds-public-exchange-rates-api.oanda.com")
+        .addPathSegment("cc-api")
+        .addPathSegment("currencies")
+        .addQueryParameter("base", fromCurrency)
+        .addQueryParameter("quote", toCurrency)
+        .addQueryParameter("data_type", "general_currency_pair")
+        .addQueryParameter("start_date", startDate)
+        .addQueryParameter("end_date", endDate)
+        .build()
+        .toString()
   }
 
   /** Setter functions */
@@ -243,8 +242,8 @@ open class FinanceViewModel(val tripsRepository: TripsRepository, val tripId: St
   }
 
   class FinanceViewModelFactory(
-    private val tripsRepository: TripsRepository,
-    private val tripId: String
+      private val tripsRepository: TripsRepository,
+      private val tripId: String
   ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
       if (modelClass.isAssignableFrom(FinanceViewModel::class.java)) {

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CreateExpense.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CreateExpense.kt
@@ -76,64 +76,74 @@ fun CreateExpense(
     onDone: () -> Unit = {}
 ) {
 
-  LaunchedEffect(key1 = Unit) { viewModel.loadMembers(tripId) }
+    val createExpenseFinished by viewModel.createExpenseFinished.collectAsState()
+    // Effect to react to the createAnnouncementFinished state change
+    LaunchedEffect(createExpenseFinished) {
+        if (createExpenseFinished) {
+            onDone()
+            navActions.goBack()
+            viewModel.setCreateExpenseFinished(false) // Reset the flag after handling it
+        }
+    }
 
-  var expandedMenu1 by remember { mutableStateOf(false) }
-  var expandedMenu2 by remember { mutableStateOf(false) }
-  var selectedMenu1: User? by remember { mutableStateOf(null) }
-  var selectedMenu2 by remember { mutableStateOf("") }
-  var expenseTitle by remember { mutableStateOf("") }
-  var expenseAmount by remember { mutableStateOf("") }
-  var expenseDate by remember { mutableStateOf("") }
-  var showDatePicker: Boolean by remember { mutableStateOf(false) }
+    LaunchedEffect(key1 = Unit) { viewModel.loadMembers(tripId) }
 
-  var errorText by remember { mutableStateOf("") }
+    var expandedMenu1 by remember { mutableStateOf(false) }
+    var expandedMenu2 by remember { mutableStateOf(false) }
+    var selectedMenu1: User? by remember { mutableStateOf(null) }
+    var selectedMenu2 by remember { mutableStateOf("") }
+    var expenseTitle by remember { mutableStateOf("") }
+    var expenseAmount by remember { mutableStateOf("") }
+    var expenseDate by remember { mutableStateOf("") }
+    var showDatePicker: Boolean by remember { mutableStateOf(false) }
 
-  val users by viewModel.users.collectAsState()
+    var errorText by remember { mutableStateOf("") }
 
-  var checkboxes = remember { mutableStateListOf<Boolean>() }
+    val users by viewModel.users.collectAsState()
 
-  if (checkboxes.size != users.size) {
-    checkboxes = users.map { false }.toMutableStateList()
-  }
+    var checkboxes = remember { mutableStateListOf<Boolean>() }
 
-  WanderPalsTheme {
-    Scaffold(
-        topBar = {
-          TopAppBar(
-              title = {
-                Text(
-                    text = "Add an expense",
-                    style = MaterialTheme.typography.titleLarge,
-                    modifier = Modifier.testTag("createExpenseTitle"),
-                    color = MaterialTheme.colorScheme.onPrimary)
-              },
-              navigationIcon = {
-                IconButton(
-                    onClick = { navActions.goBack() }, modifier = Modifier.testTag("BackButton")) {
-                      Icon(
-                          imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                          contentDescription = "Go back",
-                          tint = MaterialTheme.colorScheme.onPrimary,
-                      )
-                    }
-              },
-              colors =
-                  TopAppBarDefaults.topAppBarColors(
-                      containerColor = MaterialTheme.colorScheme.primary,
-                  ),
-          )
-        }) { paddingValues ->
-          Box(
-              modifier =
-                  Modifier.padding(paddingValues)
-                      .fillMaxSize()
-                      .background(MaterialTheme.colorScheme.background)) {
+    if (checkboxes.size != users.size) {
+        checkboxes = users.map { false }.toMutableStateList()
+    }
+
+    WanderPalsTheme {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = "Add an expense",
+                            style = MaterialTheme.typography.titleLarge,
+                            modifier = Modifier.testTag("createExpenseTitle"),
+                            color = MaterialTheme.colorScheme.onPrimary)
+                    },
+                    navigationIcon = {
+                        IconButton(
+                            onClick = { navActions.goBack() }, modifier = Modifier.testTag("BackButton")) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Go back",
+                                tint = MaterialTheme.colorScheme.onPrimary,
+                            )
+                        }
+                    },
+                    colors =
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                    ),
+                )
+            }) { paddingValues ->
+            Box(
+                modifier =
+                Modifier.padding(paddingValues)
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)) {
                 Box(modifier = Modifier.verticalScroll(rememberScrollState(), true)) {
-                  Column(
-                      modifier =
-                          Modifier.testTag("createExpenseContent")
-                              .background(MaterialTheme.colorScheme.background)) {
+                    Column(
+                        modifier =
+                        Modifier.testTag("createExpenseContent")
+                            .background(MaterialTheme.colorScheme.background)) {
                         HorizontalDivider(color = MaterialTheme.colorScheme.outline)
 
                         Spacer(modifier = Modifier.padding(4.dp))
@@ -145,14 +155,14 @@ fun CreateExpense(
                             label = { Text("Expense title") },
                             placeholder = { Text("Give a name to your expense") },
                             modifier =
-                                Modifier.testTag("expenseTitle")
-                                    .padding(horizontal = 24.dp, vertical = 8.dp)
-                                    .fillMaxWidth(),
+                            Modifier.testTag("expenseTitle")
+                                .padding(horizontal = 24.dp, vertical = 8.dp)
+                                .fillMaxWidth(),
                             singleLine = true,
                             suffix = {
-                              Text(
-                                  text = "${expenseTitle.length}/50",
-                                  style = MaterialTheme.typography.bodyMedium)
+                                Text(
+                                    text = "${expenseTitle.length}/50",
+                                    style = MaterialTheme.typography.bodyMedium)
                             },
                             isError = errorText.isNotEmpty(),
                         )
@@ -163,14 +173,14 @@ fun CreateExpense(
                             label = { Text("Amount") },
                             placeholder = { Text("") },
                             modifier =
-                                Modifier.testTag("Budget")
-                                    .padding(horizontal = 24.dp, vertical = 8.dp)
-                                    .fillMaxWidth(),
+                            Modifier.testTag("Budget")
+                                .padding(horizontal = 24.dp, vertical = 8.dp)
+                                .fillMaxWidth(),
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                             suffix = {
-                              Text(
-                                  text = "CHF | ${expenseAmount.length}/20",
-                                  style = MaterialTheme.typography.bodyMedium)
+                                Text(
+                                    text = "CHF | ${expenseAmount.length}/20",
+                                    style = MaterialTheme.typography.bodyMedium)
                             },
                             singleLine = true, // add the currency
                             isError = errorText.isNotEmpty())
@@ -182,171 +192,171 @@ fun CreateExpense(
                             label = { Text("Date") },
                             placeholder = { Text(" -- / -- / ---- ") },
                             modifier =
-                                Modifier.testTag("expenseDate")
-                                    .padding(horizontal = 24.dp, vertical = 8.dp)
-                                    .fillMaxWidth()
-                                    .clickable { showDatePicker = true },
+                            Modifier.testTag("expenseDate")
+                                .padding(horizontal = 24.dp, vertical = 8.dp)
+                                .fillMaxWidth()
+                                .clickable { showDatePicker = true },
                             singleLine = true,
                             interactionSource = DateInteractionSource { showDatePicker = true },
                             isError = errorText.isNotEmpty())
 
                         if (showDatePicker) {
-                          MyDatePickerDialog(
-                              onDateSelected = { expenseDate = it },
-                              onDismiss = { showDatePicker = false })
+                            MyDatePickerDialog(
+                                onDateSelected = { expenseDate = it },
+                                onDismiss = { showDatePicker = false })
                         }
                         // Dropdown menu for the user who paid
                         ExposedDropdownMenuBox(
                             expanded = expandedMenu1,
                             onExpandedChange = { expandedMenu1 = !expandedMenu1 },
                             modifier =
-                                Modifier.testTag("dropdownMenuPaid")
-                                    .padding(24.dp, 8.dp)
-                                    .fillMaxWidth()) {
-                              // Text field for the user who paid
-                              OutlinedTextField(
-                                  value = selectedMenu1?.name ?: "",
-                                  onValueChange = {},
-                                  label = { Text("Paid by") },
-                                  modifier = Modifier.testTag("paidBy").fillMaxWidth().menuAnchor(),
-                                  readOnly = true,
-                                  isError = errorText.isNotEmpty())
-                              // Dropdown menu for the user who paid
-                              ExposedDropdownMenu(
-                                  expanded = expandedMenu1,
-                                  onDismissRequest = { expandedMenu1 = false },
-                              ) {
+                            Modifier.testTag("dropdownMenuPaid")
+                                .padding(24.dp, 8.dp)
+                                .fillMaxWidth()) {
+                            // Text field for the user who paid
+                            OutlinedTextField(
+                                value = selectedMenu1?.name ?: "",
+                                onValueChange = {},
+                                label = { Text("Paid by") },
+                                modifier = Modifier.testTag("paidBy").fillMaxWidth().menuAnchor(),
+                                readOnly = true,
+                                isError = errorText.isNotEmpty())
+                            // Dropdown menu for the user who paid
+                            ExposedDropdownMenu(
+                                expanded = expandedMenu1,
+                                onDismissRequest = { expandedMenu1 = false },
+                            ) {
                                 users.forEach { item ->
-                                  // Dropdown menu item for each user
-                                  DropdownMenuItem(
-                                      text = { Text(text = item.name) },
-                                      onClick = {
-                                        selectedMenu1 = item
-                                        expandedMenu1 = false
-                                      },
-                                      modifier =
-                                          Modifier.padding(horizontal = 24.dp)
-                                              .fillMaxWidth()
-                                              .testTag(item.userId))
+                                    // Dropdown menu item for each user
+                                    DropdownMenuItem(
+                                        text = { Text(text = item.name) },
+                                        onClick = {
+                                            selectedMenu1 = item
+                                            expandedMenu1 = false
+                                        },
+                                        modifier =
+                                        Modifier.padding(horizontal = 24.dp)
+                                            .fillMaxWidth()
+                                            .testTag(item.userId))
                                 }
-                              }
                             }
+                        }
                         // Category dropdown
                         ExposedDropdownMenuBox(
                             expanded = expandedMenu2,
                             onExpandedChange = { expandedMenu2 = !expandedMenu2 },
                             modifier =
-                                Modifier.testTag("dropdownMenuCategory")
-                                    .padding(24.dp, top = 8.dp, bottom = 16.dp, end = 24.dp)
-                                    .fillMaxWidth()) {
-                              // Text field for the category
-                              OutlinedTextField(
-                                  value = selectedMenu2,
-                                  onValueChange = {},
-                                  label = { Text("Category") },
-                                  modifier =
-                                      Modifier.fillMaxWidth().menuAnchor().testTag("category"),
-                                  readOnly = true,
-                                  isError = errorText.isNotEmpty())
-                              // Dropdown menu for the category
-                              ExposedDropdownMenu(
-                                  expanded = expandedMenu2,
-                                  onDismissRequest = { expandedMenu2 = false },
-                              ) {
+                            Modifier.testTag("dropdownMenuCategory")
+                                .padding(24.dp, top = 8.dp, bottom = 16.dp, end = 24.dp)
+                                .fillMaxWidth()) {
+                            // Text field for the category
+                            OutlinedTextField(
+                                value = selectedMenu2,
+                                onValueChange = {},
+                                label = { Text("Category") },
+                                modifier =
+                                Modifier.fillMaxWidth().menuAnchor().testTag("category"),
+                                readOnly = true,
+                                isError = errorText.isNotEmpty())
+                            // Dropdown menu for the category
+                            ExposedDropdownMenu(
+                                expanded = expandedMenu2,
+                                onDismissRequest = { expandedMenu2 = false },
+                            ) {
                                 Category.values().forEach { item ->
-                                  // Dropdown menu item for each category
-                                  DropdownMenuItem(
-                                      text = { Text(text = item.name) },
-                                      onClick = {
-                                        selectedMenu2 = item.name
-                                        expandedMenu2 = false
-                                      },
-                                      modifier =
-                                          Modifier.padding(horizontal = 24.dp)
-                                              .fillMaxWidth()
-                                              .testTag(item.name))
+                                    // Dropdown menu item for each category
+                                    DropdownMenuItem(
+                                        text = { Text(text = item.name) },
+                                        onClick = {
+                                            selectedMenu2 = item.name
+                                            expandedMenu2 = false
+                                        },
+                                        modifier =
+                                        Modifier.padding(horizontal = 24.dp)
+                                            .fillMaxWidth()
+                                            .testTag(item.name))
                                 }
-                              }
                             }
+                        }
 
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier.padding(16.dp, bottom = 16.dp)) {
-                              Checkbox(
-                                  checked = checkboxes.all { it },
-                                  onCheckedChange = {
+                            Checkbox(
+                                checked = checkboxes.all { it },
+                                onCheckedChange = {
                                     if (checkboxes.all { it }) checkboxes.replaceAll { false }
                                     else checkboxes.replaceAll { true }
-                                  },
-                                  modifier = Modifier.testTag("checkboxAll"))
-                              Text(
-                                  text = "FOR WHOM",
-                                  color = MaterialTheme.colorScheme.onSurface,
-                                  style = MaterialTheme.typography.labelMedium,
-                              )
-                            }
+                                },
+                                modifier = Modifier.testTag("checkboxAll"))
+                            Text(
+                                text = "FOR WHOM",
+                                color = MaterialTheme.colorScheme.onSurface,
+                                style = MaterialTheme.typography.labelMedium,
+                            )
+                        }
                         // List of checkboxes and username to select participants
                         Surface(
                             modifier = Modifier.fillMaxWidth(),
                             color = MaterialTheme.colorScheme.background) {
-                              LazyColumn(modifier = Modifier.fillMaxWidth().height(200.dp)) {
+                            LazyColumn(modifier = Modifier.fillMaxWidth().height(200.dp)) {
                                 if (users.isEmpty()) {
-                                  item {
-                                    // edge case: no users found
-                                    Text(
-                                        text = "No users found, this should not happen.",
-                                        color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                        modifier = Modifier.padding(16.dp).testTag("noUsersFound"))
-                                  }
+                                    item {
+                                        // edge case: no users found
+                                        Text(
+                                            text = "No users found, this should not happen.",
+                                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                            modifier = Modifier.padding(16.dp).testTag("noUsersFound"))
+                                    }
                                 } else {
-                                  items(users.size) { index ->
-                                    // Simple row with a checkbox and the username
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        modifier =
+                                    items(users.size) { index ->
+                                        // Simple row with a checkbox and the username
+                                        Row(
+                                            verticalAlignment = Alignment.CenterVertically,
+                                            modifier =
                                             Modifier.background(
-                                                    if (checkboxes[index])
-                                                        MaterialTheme.colorScheme.primaryContainer
-                                                    else MaterialTheme.colorScheme.background)
+                                                if (checkboxes[index])
+                                                    MaterialTheme.colorScheme.primaryContainer
+                                                else MaterialTheme.colorScheme.background)
                                                 .fillMaxWidth()
                                                 .padding(16.dp, 8.dp)
                                                 .testTag("userRow$index")) {
-                                          Checkbox(
-                                              checked = checkboxes[index],
-                                              onCheckedChange = {
-                                                checkboxes[index] = !checkboxes[index]
-                                              },
-                                              modifier = Modifier.testTag("checkbox$index"))
-                                          Text(
-                                              text = users[index].name,
-                                              color = MaterialTheme.colorScheme.onPrimaryContainer)
+                                            Checkbox(
+                                                checked = checkboxes[index],
+                                                onCheckedChange = {
+                                                    checkboxes[index] = !checkboxes[index]
+                                                },
+                                                modifier = Modifier.testTag("checkbox$index"))
+                                            Text(
+                                                text = users[index].name,
+                                                color = MaterialTheme.colorScheme.onPrimaryContainer)
                                         }
-                                  }
+                                    }
                                 }
-                              }
                             }
-                      }
+                        }
+                    }
                 }
                 // Save button
                 Box(
                     contentAlignment = Alignment.BottomCenter,
                     modifier = Modifier.padding().fillMaxSize()) {
-                      Column(
-                          modifier = Modifier.fillMaxWidth(),
-                          horizontalAlignment = Alignment.CenterHorizontally) {
-                            ExtendedFloatingActionButton(
-                                onClick = {
-                                  // Check if all fields are filled and at least one participant is
-                                  // selected before saving
-                                  if (selectedMenu1 == null ||
-                                      selectedMenu2.isEmpty() ||
-                                      expenseTitle.isEmpty() ||
-                                      expenseAmount.toDoubleOrNull() == null ||
-                                      expenseDate.isEmpty() ||
-                                      checkboxes.all { !it }) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally) {
+                        ExtendedFloatingActionButton(
+                            onClick = {
+                                // Check if all fields are filled and at least one participant is
+                                // selected before saving
+                                if (selectedMenu1 == null ||
+                                    selectedMenu2.isEmpty() ||
+                                    expenseTitle.isEmpty() ||
+                                    expenseAmount.toDoubleOrNull() == null ||
+                                    expenseDate.isEmpty() ||
+                                    checkboxes.all { !it }) {
                                     errorText =
                                         "Please fill in all fields and select at least one participant."
-                                  } else {
+                                } else {
                                     val selectedUsers =
                                         users.filterIndexed { index, _ -> checkboxes[index] }
                                     val expense =
@@ -355,9 +365,9 @@ fun CreateExpense(
                                             title = expenseTitle,
                                             amount = expenseAmount.toDouble(),
                                             localDate =
-                                                LocalDate.parse(
-                                                    expenseDate,
-                                                    DateTimeFormatter.ofPattern("dd/MM/yyyy")),
+                                            LocalDate.parse(
+                                                expenseDate,
+                                                DateTimeFormatter.ofPattern("dd/MM/yyyy")),
                                             category = Category.valueOf(selectedMenu2),
                                             userName = selectedMenu1!!.name,
                                             userId = selectedMenu1!!.userId,
@@ -365,32 +375,30 @@ fun CreateExpense(
                                             names = selectedUsers.map { it.name })
                                     errorText = ""
                                     viewModel.addExpense(tripId, expense)
-                                    onDone()
-                                    navActions.goBack()
-                                  }
-                                },
-                                modifier =
-                                    Modifier.fillMaxWidth(0.5f)
-                                        .padding(
-                                            bottom = if (errorText.isNotEmpty()) 4.dp else 10.dp)
-                                        .testTag("saveButton"),
-                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                elevation = FloatingActionButtonDefaults.elevation(2.dp, 1.dp)) {
-                                  Text(
-                                      text = "Save",
-                                      color = MaterialTheme.colorScheme.onSecondaryContainer)
                                 }
-                            // Error text
-                            if (errorText.isNotEmpty()) {
-                              Text(
-                                  text = errorText,
-                                  color = MaterialTheme.colorScheme.error,
-                                  style = MaterialTheme.typography.bodyMedium,
-                                  modifier = Modifier.padding(bottom = 10.dp).testTag("errorText"))
-                            }
-                          }
+                            },
+                            modifier =
+                            Modifier.fillMaxWidth(0.5f)
+                                .padding(
+                                    bottom = if (errorText.isNotEmpty()) 4.dp else 10.dp)
+                                .testTag("saveButton"),
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            elevation = FloatingActionButtonDefaults.elevation(2.dp, 1.dp)) {
+                            Text(
+                                text = "Save",
+                                color = MaterialTheme.colorScheme.onSecondaryContainer)
+                        }
+                        // Error text
+                        if (errorText.isNotEmpty()) {
+                            Text(
+                                text = errorText,
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodyMedium,
+                                modifier = Modifier.padding(bottom = 10.dp).testTag("errorText"))
+                        }
                     }
-              }
+                }
+            }
         }
-  }
+    }
 }

--- a/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CreateExpense.kt
+++ b/app/src/main/java/com/github/se/wanderpals/ui/screens/trip/finance/CreateExpense.kt
@@ -76,74 +76,74 @@ fun CreateExpense(
     onDone: () -> Unit = {}
 ) {
 
-    val createExpenseFinished by viewModel.createExpenseFinished.collectAsState()
-    // Effect to react to the createAnnouncementFinished state change
-    LaunchedEffect(createExpenseFinished) {
-        if (createExpenseFinished) {
-            onDone()
-            navActions.goBack()
-            viewModel.setCreateExpenseFinished(false) // Reset the flag after handling it
-        }
+  val createExpenseFinished by viewModel.createExpenseFinished.collectAsState()
+  // Effect to react to the createAnnouncementFinished state change
+  LaunchedEffect(createExpenseFinished) {
+    if (createExpenseFinished) {
+      onDone()
+      navActions.goBack()
+      viewModel.setCreateExpenseFinished(false) // Reset the flag after handling it
     }
+  }
 
-    LaunchedEffect(key1 = Unit) { viewModel.loadMembers(tripId) }
+  LaunchedEffect(key1 = Unit) { viewModel.loadMembers(tripId) }
 
-    var expandedMenu1 by remember { mutableStateOf(false) }
-    var expandedMenu2 by remember { mutableStateOf(false) }
-    var selectedMenu1: User? by remember { mutableStateOf(null) }
-    var selectedMenu2 by remember { mutableStateOf("") }
-    var expenseTitle by remember { mutableStateOf("") }
-    var expenseAmount by remember { mutableStateOf("") }
-    var expenseDate by remember { mutableStateOf("") }
-    var showDatePicker: Boolean by remember { mutableStateOf(false) }
+  var expandedMenu1 by remember { mutableStateOf(false) }
+  var expandedMenu2 by remember { mutableStateOf(false) }
+  var selectedMenu1: User? by remember { mutableStateOf(null) }
+  var selectedMenu2 by remember { mutableStateOf("") }
+  var expenseTitle by remember { mutableStateOf("") }
+  var expenseAmount by remember { mutableStateOf("") }
+  var expenseDate by remember { mutableStateOf("") }
+  var showDatePicker: Boolean by remember { mutableStateOf(false) }
 
-    var errorText by remember { mutableStateOf("") }
+  var errorText by remember { mutableStateOf("") }
 
-    val users by viewModel.users.collectAsState()
+  val users by viewModel.users.collectAsState()
 
-    var checkboxes = remember { mutableStateListOf<Boolean>() }
+  var checkboxes = remember { mutableStateListOf<Boolean>() }
 
-    if (checkboxes.size != users.size) {
-        checkboxes = users.map { false }.toMutableStateList()
-    }
+  if (checkboxes.size != users.size) {
+    checkboxes = users.map { false }.toMutableStateList()
+  }
 
-    WanderPalsTheme {
-        Scaffold(
-            topBar = {
-                TopAppBar(
-                    title = {
-                        Text(
-                            text = "Add an expense",
-                            style = MaterialTheme.typography.titleLarge,
-                            modifier = Modifier.testTag("createExpenseTitle"),
-                            color = MaterialTheme.colorScheme.onPrimary)
-                    },
-                    navigationIcon = {
-                        IconButton(
-                            onClick = { navActions.goBack() }, modifier = Modifier.testTag("BackButton")) {
-                            Icon(
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                contentDescription = "Go back",
-                                tint = MaterialTheme.colorScheme.onPrimary,
-                            )
-                        }
-                    },
-                    colors =
-                    TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                    ),
-                )
-            }) { paddingValues ->
-            Box(
-                modifier =
-                Modifier.padding(paddingValues)
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background)) {
+  WanderPalsTheme {
+    Scaffold(
+        topBar = {
+          TopAppBar(
+              title = {
+                Text(
+                    text = "Add an expense",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.testTag("createExpenseTitle"),
+                    color = MaterialTheme.colorScheme.onPrimary)
+              },
+              navigationIcon = {
+                IconButton(
+                    onClick = { navActions.goBack() }, modifier = Modifier.testTag("BackButton")) {
+                      Icon(
+                          imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                          contentDescription = "Go back",
+                          tint = MaterialTheme.colorScheme.onPrimary,
+                      )
+                    }
+              },
+              colors =
+                  TopAppBarDefaults.topAppBarColors(
+                      containerColor = MaterialTheme.colorScheme.primary,
+                  ),
+          )
+        }) { paddingValues ->
+          Box(
+              modifier =
+                  Modifier.padding(paddingValues)
+                      .fillMaxSize()
+                      .background(MaterialTheme.colorScheme.background)) {
                 Box(modifier = Modifier.verticalScroll(rememberScrollState(), true)) {
-                    Column(
-                        modifier =
-                        Modifier.testTag("createExpenseContent")
-                            .background(MaterialTheme.colorScheme.background)) {
+                  Column(
+                      modifier =
+                          Modifier.testTag("createExpenseContent")
+                              .background(MaterialTheme.colorScheme.background)) {
                         HorizontalDivider(color = MaterialTheme.colorScheme.outline)
 
                         Spacer(modifier = Modifier.padding(4.dp))
@@ -155,14 +155,14 @@ fun CreateExpense(
                             label = { Text("Expense title") },
                             placeholder = { Text("Give a name to your expense") },
                             modifier =
-                            Modifier.testTag("expenseTitle")
-                                .padding(horizontal = 24.dp, vertical = 8.dp)
-                                .fillMaxWidth(),
+                                Modifier.testTag("expenseTitle")
+                                    .padding(horizontal = 24.dp, vertical = 8.dp)
+                                    .fillMaxWidth(),
                             singleLine = true,
                             suffix = {
-                                Text(
-                                    text = "${expenseTitle.length}/50",
-                                    style = MaterialTheme.typography.bodyMedium)
+                              Text(
+                                  text = "${expenseTitle.length}/50",
+                                  style = MaterialTheme.typography.bodyMedium)
                             },
                             isError = errorText.isNotEmpty(),
                         )
@@ -173,14 +173,14 @@ fun CreateExpense(
                             label = { Text("Amount") },
                             placeholder = { Text("") },
                             modifier =
-                            Modifier.testTag("Budget")
-                                .padding(horizontal = 24.dp, vertical = 8.dp)
-                                .fillMaxWidth(),
+                                Modifier.testTag("Budget")
+                                    .padding(horizontal = 24.dp, vertical = 8.dp)
+                                    .fillMaxWidth(),
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                             suffix = {
-                                Text(
-                                    text = "CHF | ${expenseAmount.length}/20",
-                                    style = MaterialTheme.typography.bodyMedium)
+                              Text(
+                                  text = "CHF | ${expenseAmount.length}/20",
+                                  style = MaterialTheme.typography.bodyMedium)
                             },
                             singleLine = true, // add the currency
                             isError = errorText.isNotEmpty())
@@ -192,171 +192,171 @@ fun CreateExpense(
                             label = { Text("Date") },
                             placeholder = { Text(" -- / -- / ---- ") },
                             modifier =
-                            Modifier.testTag("expenseDate")
-                                .padding(horizontal = 24.dp, vertical = 8.dp)
-                                .fillMaxWidth()
-                                .clickable { showDatePicker = true },
+                                Modifier.testTag("expenseDate")
+                                    .padding(horizontal = 24.dp, vertical = 8.dp)
+                                    .fillMaxWidth()
+                                    .clickable { showDatePicker = true },
                             singleLine = true,
                             interactionSource = DateInteractionSource { showDatePicker = true },
                             isError = errorText.isNotEmpty())
 
                         if (showDatePicker) {
-                            MyDatePickerDialog(
-                                onDateSelected = { expenseDate = it },
-                                onDismiss = { showDatePicker = false })
+                          MyDatePickerDialog(
+                              onDateSelected = { expenseDate = it },
+                              onDismiss = { showDatePicker = false })
                         }
                         // Dropdown menu for the user who paid
                         ExposedDropdownMenuBox(
                             expanded = expandedMenu1,
                             onExpandedChange = { expandedMenu1 = !expandedMenu1 },
                             modifier =
-                            Modifier.testTag("dropdownMenuPaid")
-                                .padding(24.dp, 8.dp)
-                                .fillMaxWidth()) {
-                            // Text field for the user who paid
-                            OutlinedTextField(
-                                value = selectedMenu1?.name ?: "",
-                                onValueChange = {},
-                                label = { Text("Paid by") },
-                                modifier = Modifier.testTag("paidBy").fillMaxWidth().menuAnchor(),
-                                readOnly = true,
-                                isError = errorText.isNotEmpty())
-                            // Dropdown menu for the user who paid
-                            ExposedDropdownMenu(
-                                expanded = expandedMenu1,
-                                onDismissRequest = { expandedMenu1 = false },
-                            ) {
+                                Modifier.testTag("dropdownMenuPaid")
+                                    .padding(24.dp, 8.dp)
+                                    .fillMaxWidth()) {
+                              // Text field for the user who paid
+                              OutlinedTextField(
+                                  value = selectedMenu1?.name ?: "",
+                                  onValueChange = {},
+                                  label = { Text("Paid by") },
+                                  modifier = Modifier.testTag("paidBy").fillMaxWidth().menuAnchor(),
+                                  readOnly = true,
+                                  isError = errorText.isNotEmpty())
+                              // Dropdown menu for the user who paid
+                              ExposedDropdownMenu(
+                                  expanded = expandedMenu1,
+                                  onDismissRequest = { expandedMenu1 = false },
+                              ) {
                                 users.forEach { item ->
-                                    // Dropdown menu item for each user
-                                    DropdownMenuItem(
-                                        text = { Text(text = item.name) },
-                                        onClick = {
-                                            selectedMenu1 = item
-                                            expandedMenu1 = false
-                                        },
-                                        modifier =
-                                        Modifier.padding(horizontal = 24.dp)
-                                            .fillMaxWidth()
-                                            .testTag(item.userId))
+                                  // Dropdown menu item for each user
+                                  DropdownMenuItem(
+                                      text = { Text(text = item.name) },
+                                      onClick = {
+                                        selectedMenu1 = item
+                                        expandedMenu1 = false
+                                      },
+                                      modifier =
+                                          Modifier.padding(horizontal = 24.dp)
+                                              .fillMaxWidth()
+                                              .testTag(item.userId))
                                 }
+                              }
                             }
-                        }
                         // Category dropdown
                         ExposedDropdownMenuBox(
                             expanded = expandedMenu2,
                             onExpandedChange = { expandedMenu2 = !expandedMenu2 },
                             modifier =
-                            Modifier.testTag("dropdownMenuCategory")
-                                .padding(24.dp, top = 8.dp, bottom = 16.dp, end = 24.dp)
-                                .fillMaxWidth()) {
-                            // Text field for the category
-                            OutlinedTextField(
-                                value = selectedMenu2,
-                                onValueChange = {},
-                                label = { Text("Category") },
-                                modifier =
-                                Modifier.fillMaxWidth().menuAnchor().testTag("category"),
-                                readOnly = true,
-                                isError = errorText.isNotEmpty())
-                            // Dropdown menu for the category
-                            ExposedDropdownMenu(
-                                expanded = expandedMenu2,
-                                onDismissRequest = { expandedMenu2 = false },
-                            ) {
+                                Modifier.testTag("dropdownMenuCategory")
+                                    .padding(24.dp, top = 8.dp, bottom = 16.dp, end = 24.dp)
+                                    .fillMaxWidth()) {
+                              // Text field for the category
+                              OutlinedTextField(
+                                  value = selectedMenu2,
+                                  onValueChange = {},
+                                  label = { Text("Category") },
+                                  modifier =
+                                      Modifier.fillMaxWidth().menuAnchor().testTag("category"),
+                                  readOnly = true,
+                                  isError = errorText.isNotEmpty())
+                              // Dropdown menu for the category
+                              ExposedDropdownMenu(
+                                  expanded = expandedMenu2,
+                                  onDismissRequest = { expandedMenu2 = false },
+                              ) {
                                 Category.values().forEach { item ->
-                                    // Dropdown menu item for each category
-                                    DropdownMenuItem(
-                                        text = { Text(text = item.name) },
-                                        onClick = {
-                                            selectedMenu2 = item.name
-                                            expandedMenu2 = false
-                                        },
-                                        modifier =
-                                        Modifier.padding(horizontal = 24.dp)
-                                            .fillMaxWidth()
-                                            .testTag(item.name))
+                                  // Dropdown menu item for each category
+                                  DropdownMenuItem(
+                                      text = { Text(text = item.name) },
+                                      onClick = {
+                                        selectedMenu2 = item.name
+                                        expandedMenu2 = false
+                                      },
+                                      modifier =
+                                          Modifier.padding(horizontal = 24.dp)
+                                              .fillMaxWidth()
+                                              .testTag(item.name))
                                 }
+                              }
                             }
-                        }
 
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier.padding(16.dp, bottom = 16.dp)) {
-                            Checkbox(
-                                checked = checkboxes.all { it },
-                                onCheckedChange = {
+                              Checkbox(
+                                  checked = checkboxes.all { it },
+                                  onCheckedChange = {
                                     if (checkboxes.all { it }) checkboxes.replaceAll { false }
                                     else checkboxes.replaceAll { true }
-                                },
-                                modifier = Modifier.testTag("checkboxAll"))
-                            Text(
-                                text = "FOR WHOM",
-                                color = MaterialTheme.colorScheme.onSurface,
-                                style = MaterialTheme.typography.labelMedium,
-                            )
-                        }
+                                  },
+                                  modifier = Modifier.testTag("checkboxAll"))
+                              Text(
+                                  text = "FOR WHOM",
+                                  color = MaterialTheme.colorScheme.onSurface,
+                                  style = MaterialTheme.typography.labelMedium,
+                              )
+                            }
                         // List of checkboxes and username to select participants
                         Surface(
                             modifier = Modifier.fillMaxWidth(),
                             color = MaterialTheme.colorScheme.background) {
-                            LazyColumn(modifier = Modifier.fillMaxWidth().height(200.dp)) {
+                              LazyColumn(modifier = Modifier.fillMaxWidth().height(200.dp)) {
                                 if (users.isEmpty()) {
-                                    item {
-                                        // edge case: no users found
-                                        Text(
-                                            text = "No users found, this should not happen.",
-                                            color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                            modifier = Modifier.padding(16.dp).testTag("noUsersFound"))
-                                    }
+                                  item {
+                                    // edge case: no users found
+                                    Text(
+                                        text = "No users found, this should not happen.",
+                                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                        modifier = Modifier.padding(16.dp).testTag("noUsersFound"))
+                                  }
                                 } else {
-                                    items(users.size) { index ->
-                                        // Simple row with a checkbox and the username
-                                        Row(
-                                            verticalAlignment = Alignment.CenterVertically,
-                                            modifier =
+                                  items(users.size) { index ->
+                                    // Simple row with a checkbox and the username
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        modifier =
                                             Modifier.background(
-                                                if (checkboxes[index])
-                                                    MaterialTheme.colorScheme.primaryContainer
-                                                else MaterialTheme.colorScheme.background)
+                                                    if (checkboxes[index])
+                                                        MaterialTheme.colorScheme.primaryContainer
+                                                    else MaterialTheme.colorScheme.background)
                                                 .fillMaxWidth()
                                                 .padding(16.dp, 8.dp)
                                                 .testTag("userRow$index")) {
-                                            Checkbox(
-                                                checked = checkboxes[index],
-                                                onCheckedChange = {
-                                                    checkboxes[index] = !checkboxes[index]
-                                                },
-                                                modifier = Modifier.testTag("checkbox$index"))
-                                            Text(
-                                                text = users[index].name,
-                                                color = MaterialTheme.colorScheme.onPrimaryContainer)
+                                          Checkbox(
+                                              checked = checkboxes[index],
+                                              onCheckedChange = {
+                                                checkboxes[index] = !checkboxes[index]
+                                              },
+                                              modifier = Modifier.testTag("checkbox$index"))
+                                          Text(
+                                              text = users[index].name,
+                                              color = MaterialTheme.colorScheme.onPrimaryContainer)
                                         }
-                                    }
+                                  }
                                 }
+                              }
                             }
-                        }
-                    }
+                      }
                 }
                 // Save button
                 Box(
                     contentAlignment = Alignment.BottomCenter,
                     modifier = Modifier.padding().fillMaxSize()) {
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalAlignment = Alignment.CenterHorizontally) {
-                        ExtendedFloatingActionButton(
-                            onClick = {
-                                // Check if all fields are filled and at least one participant is
-                                // selected before saving
-                                if (selectedMenu1 == null ||
-                                    selectedMenu2.isEmpty() ||
-                                    expenseTitle.isEmpty() ||
-                                    expenseAmount.toDoubleOrNull() == null ||
-                                    expenseDate.isEmpty() ||
-                                    checkboxes.all { !it }) {
+                      Column(
+                          modifier = Modifier.fillMaxWidth(),
+                          horizontalAlignment = Alignment.CenterHorizontally) {
+                            ExtendedFloatingActionButton(
+                                onClick = {
+                                  // Check if all fields are filled and at least one participant is
+                                  // selected before saving
+                                  if (selectedMenu1 == null ||
+                                      selectedMenu2.isEmpty() ||
+                                      expenseTitle.isEmpty() ||
+                                      expenseAmount.toDoubleOrNull() == null ||
+                                      expenseDate.isEmpty() ||
+                                      checkboxes.all { !it }) {
                                     errorText =
                                         "Please fill in all fields and select at least one participant."
-                                } else {
+                                  } else {
                                     val selectedUsers =
                                         users.filterIndexed { index, _ -> checkboxes[index] }
                                     val expense =
@@ -365,9 +365,9 @@ fun CreateExpense(
                                             title = expenseTitle,
                                             amount = expenseAmount.toDouble(),
                                             localDate =
-                                            LocalDate.parse(
-                                                expenseDate,
-                                                DateTimeFormatter.ofPattern("dd/MM/yyyy")),
+                                                LocalDate.parse(
+                                                    expenseDate,
+                                                    DateTimeFormatter.ofPattern("dd/MM/yyyy")),
                                             category = Category.valueOf(selectedMenu2),
                                             userName = selectedMenu1!!.name,
                                             userId = selectedMenu1!!.userId,
@@ -375,30 +375,30 @@ fun CreateExpense(
                                             names = selectedUsers.map { it.name })
                                     errorText = ""
                                     viewModel.addExpense(tripId, expense)
+                                  }
+                                },
+                                modifier =
+                                    Modifier.fillMaxWidth(0.5f)
+                                        .padding(
+                                            bottom = if (errorText.isNotEmpty()) 4.dp else 10.dp)
+                                        .testTag("saveButton"),
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                elevation = FloatingActionButtonDefaults.elevation(2.dp, 1.dp)) {
+                                  Text(
+                                      text = "Save",
+                                      color = MaterialTheme.colorScheme.onSecondaryContainer)
                                 }
-                            },
-                            modifier =
-                            Modifier.fillMaxWidth(0.5f)
-                                .padding(
-                                    bottom = if (errorText.isNotEmpty()) 4.dp else 10.dp)
-                                .testTag("saveButton"),
-                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                            elevation = FloatingActionButtonDefaults.elevation(2.dp, 1.dp)) {
-                            Text(
-                                text = "Save",
-                                color = MaterialTheme.colorScheme.onSecondaryContainer)
-                        }
-                        // Error text
-                        if (errorText.isNotEmpty()) {
-                            Text(
-                                text = errorText,
-                                color = MaterialTheme.colorScheme.error,
-                                style = MaterialTheme.typography.bodyMedium,
-                                modifier = Modifier.padding(bottom = 10.dp).testTag("errorText"))
-                        }
+                            // Error text
+                            if (errorText.isNotEmpty()) {
+                              Text(
+                                  text = errorText,
+                                  color = MaterialTheme.colorScheme.error,
+                                  style = MaterialTheme.typography.bodyMedium,
+                                  modifier = Modifier.padding(bottom = 10.dp).testTag("errorText"))
+                            }
+                          }
                     }
-                }
-            }
+              }
         }
-    }
+  }
 }


### PR DESCRIPTION
This PR addresses two critical issues in the FinanceViewModel and CreateExpense screen. Firstly, it resolves the expense duplication bug by ensuring addExpense is not called multiple times when invoked rapidly. Secondly, it fixes the screen flicker issue by properly loading data before displaying the expense list, preventing the initial empty state. Unit tests have been added to verify the bug.